### PR TITLE
feat: add usecase mocks for testing

### DIFF
--- a/backend/internal/usecase/mock_test.go
+++ b/backend/internal/usecase/mock_test.go
@@ -1,0 +1,478 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+
+	"cornermon/backend/internal/domain"
+)
+
+// MockTxManager
+type MockTxManager struct{}
+
+func (m *MockTxManager) RunInTx(ctx context.Context, fn func(ctx context.Context) error) error {
+	return fn(ctx)
+}
+
+// MockCampRepository
+type MockCampRepository struct {
+	Camps map[domain.CampID]*domain.Camp
+}
+
+func NewMockCampRepository() *MockCampRepository {
+	return &MockCampRepository{Camps: make(map[domain.CampID]*domain.Camp)}
+}
+
+func (r *MockCampRepository) Get(ctx context.Context, id domain.CampID) (*domain.Camp, error) {
+	camp, ok := r.Camps[id]
+	if !ok {
+		return nil, nil
+	}
+	return camp, nil
+}
+
+func (r *MockCampRepository) Save(ctx context.Context, camp *domain.Camp) error {
+	r.Camps[camp.ID] = camp
+	return nil
+}
+
+// MockCornerRepository
+type MockCornerRepository struct {
+	Corners map[domain.CornerID]*domain.Corner
+}
+
+func NewMockCornerRepository() *MockCornerRepository {
+	return &MockCornerRepository{Corners: make(map[domain.CornerID]*domain.Corner)}
+}
+
+func (r *MockCornerRepository) Get(ctx context.Context, id domain.CornerID) (*domain.Corner, error) {
+	corner, ok := r.Corners[id]
+	if !ok {
+		return nil, nil
+	}
+	return corner, nil
+}
+
+func (r *MockCornerRepository) ListByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Corner, error) {
+	var list []*domain.Corner
+	for _, c := range r.Corners {
+		if c.CampID == campID {
+			list = append(list, c)
+		}
+	}
+	return list, nil
+}
+
+func (r *MockCornerRepository) Save(ctx context.Context, corner *domain.Corner) error {
+	r.Corners[corner.ID] = corner
+	return nil
+}
+
+// MockTrackRepository
+type MockTrackRepository struct {
+	Tracks map[domain.TrackID]*domain.Track
+}
+
+func NewMockTrackRepository() *MockTrackRepository {
+	return &MockTrackRepository{Tracks: make(map[domain.TrackID]*domain.Track)}
+}
+
+func (r *MockTrackRepository) Get(ctx context.Context, id domain.TrackID) (*domain.Track, error) {
+	track, ok := r.Tracks[id]
+	if !ok {
+		return nil, nil
+	}
+	return track, nil
+}
+
+func (r *MockTrackRepository) ListByCorner(ctx context.Context, cornerID domain.CornerID) ([]*domain.Track, error) {
+	var list []*domain.Track
+	for _, t := range r.Tracks {
+		if t.CornerID == cornerID {
+			list = append(list, t)
+		}
+	}
+	return list, nil
+}
+
+func (r *MockTrackRepository) ListActiveByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Track, error) {
+	// 코너 목록에서 CampID 필터 후 트랙 조회
+	var list []*domain.Track
+	for _, t := range r.Tracks {
+		if t.Status == domain.TrackActive {
+			list = append(list, t)
+		}
+	}
+	return list, nil
+}
+
+func (r *MockTrackRepository) Save(ctx context.Context, track *domain.Track) error {
+	r.Tracks[track.ID] = track
+	return nil
+}
+
+// MockVisitRepository
+type MockVisitRepository struct {
+	Visits map[domain.VisitID]*domain.Visit
+}
+
+func NewMockVisitRepository() *MockVisitRepository {
+	return &MockVisitRepository{Visits: make(map[domain.VisitID]*domain.Visit)}
+}
+
+func (r *MockVisitRepository) Get(ctx context.Context, id domain.VisitID) (*domain.Visit, error) {
+	v, ok := r.Visits[id]
+	if !ok {
+		return nil, nil
+	}
+	return v, nil
+}
+
+func (r *MockVisitRepository) GetInProgressByTrack(ctx context.Context, trackID domain.TrackID) (*domain.Visit, error) {
+	for _, v := range r.Visits {
+		if v.TrackID == trackID && v.Status == domain.VisitStatusInProgress {
+			return v, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *MockVisitRepository) GetCompletedByGroupAndCorner(ctx context.Context, groupID domain.GroupID, cornerID domain.CornerID) (*domain.Visit, error) {
+	for _, v := range r.Visits {
+		if v.GroupID == groupID && v.CornerID == cornerID && v.Status == domain.VisitStatusCompleted {
+			return v, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *MockVisitRepository) Save(ctx context.Context, visit *domain.Visit) error {
+	r.Visits[visit.ID] = visit
+	return nil
+}
+
+// MockGroupRepository
+type MockGroupRepository struct {
+	Groups map[domain.GroupID]*domain.Group
+}
+
+func NewMockGroupRepository() *MockGroupRepository {
+	return &MockGroupRepository{Groups: make(map[domain.GroupID]*domain.Group)}
+}
+
+func (r *MockGroupRepository) Get(ctx context.Context, id domain.GroupID) (*domain.Group, error) {
+	g, ok := r.Groups[id]
+	if !ok {
+		return nil, nil
+	}
+	return g, nil
+}
+
+func (r *MockGroupRepository) GetByBadge(ctx context.Context, campID domain.CampID, badgeID domain.BadgeID) (*domain.Group, error) {
+	for _, g := range r.Groups {
+		if g.CampID == campID && g.BadgeID == badgeID {
+			return g, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *MockGroupRepository) ListByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Group, error) {
+	var list []*domain.Group
+	for _, g := range r.Groups {
+		if g.CampID == campID {
+			list = append(list, g)
+		}
+	}
+	return list, nil
+}
+
+func (r *MockGroupRepository) Save(ctx context.Context, group *domain.Group) error {
+	r.Groups[group.ID] = group
+	return nil
+}
+
+// MockBadgeRepository
+type MockBadgeRepository struct {
+	Badges map[domain.BadgeID]*domain.Badge
+}
+
+func NewMockBadgeRepository() *MockBadgeRepository {
+	return &MockBadgeRepository{Badges: make(map[domain.BadgeID]*domain.Badge)}
+}
+
+func (r *MockBadgeRepository) Get(ctx context.Context, id domain.BadgeID) (*domain.Badge, error) {
+	b, ok := r.Badges[id]
+	if !ok {
+		return nil, nil
+	}
+	return b, nil
+}
+
+func (r *MockBadgeRepository) GetByQRPayload(ctx context.Context, payload string) (*domain.Badge, error) {
+	for _, b := range r.Badges {
+		if b.QRPayload == payload {
+			return b, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *MockBadgeRepository) Save(ctx context.Context, badge *domain.Badge) error {
+	r.Badges[badge.ID] = badge
+	return nil
+}
+
+// MockDeviceRegistrationRepository
+type MockDeviceRegistrationRepository struct {
+	Devices map[domain.DeviceRegistrationID]*domain.DeviceRegistration
+}
+
+func NewMockDeviceRegistrationRepository() *MockDeviceRegistrationRepository {
+	return &MockDeviceRegistrationRepository{Devices: make(map[domain.DeviceRegistrationID]*domain.DeviceRegistration)}
+}
+
+func (r *MockDeviceRegistrationRepository) Get(ctx context.Context, id domain.DeviceRegistrationID) (*domain.DeviceRegistration, error) {
+	d, ok := r.Devices[id]
+	if !ok {
+		return nil, nil
+	}
+	return d, nil
+}
+
+func (r *MockDeviceRegistrationRepository) GetByTokenHash(ctx context.Context, hash string) (*domain.DeviceRegistration, error) {
+	for _, d := range r.Devices {
+		if d.TokenHash == hash {
+			return d, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *MockDeviceRegistrationRepository) ListPendingByCamp(ctx context.Context, campID domain.CampID) ([]*domain.DeviceRegistration, error) {
+	var list []*domain.DeviceRegistration
+	// Simple mock: returns all pending
+	for _, d := range r.Devices {
+		if d.Status == domain.DevicePending {
+			list = append(list, d)
+		}
+	}
+	return list, nil
+}
+
+func (r *MockDeviceRegistrationRepository) Save(ctx context.Context, reg *domain.DeviceRegistration) error {
+	r.Devices[reg.ID] = reg
+	return nil
+}
+
+// MockFacilitatorSessionRepository
+type MockFacilitatorSessionRepository struct {
+	Sessions map[string]*domain.FacilitatorSession
+}
+
+func NewMockFacilitatorSessionRepository() *MockFacilitatorSessionRepository {
+	return &MockFacilitatorSessionRepository{Sessions: make(map[string]*domain.FacilitatorSession)}
+}
+
+func (r *MockFacilitatorSessionRepository) GetByTokenHash(ctx context.Context, hash string) (*domain.FacilitatorSession, error) {
+	s, ok := r.Sessions[hash]
+	if !ok {
+		return nil, errors.New("session not found")
+	}
+	return s, nil
+}
+
+func (r *MockFacilitatorSessionRepository) ListActiveByTrack(ctx context.Context, trackID domain.TrackID) ([]*domain.FacilitatorSession, error) {
+	var list []*domain.FacilitatorSession
+	for _, s := range r.Sessions {
+		if s.TrackID == trackID && s.IsActive() {
+			list = append(list, s)
+		}
+	}
+	return list, nil
+}
+
+func (r *MockFacilitatorSessionRepository) ListActiveByCamp(ctx context.Context, campID domain.CampID) ([]*domain.FacilitatorSession, error) {
+	// Simple mock: returns all active sessions
+	var list []*domain.FacilitatorSession
+	for _, s := range r.Sessions {
+		if s.IsActive() {
+			list = append(list, s)
+		}
+	}
+	return list, nil
+}
+
+func (r *MockFacilitatorSessionRepository) Save(ctx context.Context, session *domain.FacilitatorSession) error {
+	r.Sessions[session.TokenHash] = session
+	return nil
+}
+
+// MockAdminRepository
+type MockAdminRepository struct {
+	Admins map[domain.AdminID]*domain.Admin
+}
+
+func NewMockAdminRepository() *MockAdminRepository {
+	return &MockAdminRepository{Admins: make(map[domain.AdminID]*domain.Admin)}
+}
+
+func (r *MockAdminRepository) Get(ctx context.Context, id domain.AdminID) (*domain.Admin, error) {
+	a, ok := r.Admins[id]
+	if !ok {
+		return nil, nil
+	}
+	return a, nil
+}
+
+func (r *MockAdminRepository) GetByUsername(ctx context.Context, username string) (*domain.Admin, error) {
+	// Simple mock: admin name is same as ID
+	for _, a := range r.Admins {
+		if string(a.ID) == username {
+			return a, nil
+		}
+	}
+	return nil, nil
+}
+
+// MockAdminSessionRepository
+type MockAdminSessionRepository struct {
+	Sessions map[domain.AdminSessionID]*domain.AdminSession
+}
+
+func NewMockAdminSessionRepository() *MockAdminSessionRepository {
+	return &MockAdminSessionRepository{Sessions: make(map[domain.AdminSessionID]*domain.AdminSession)}
+}
+
+func (r *MockAdminSessionRepository) Get(ctx context.Context, id domain.AdminSessionID) (*domain.AdminSession, error) {
+	s, ok := r.Sessions[id]
+	if !ok {
+		return nil, nil
+	}
+	return s, nil
+}
+
+func (r *MockAdminSessionRepository) GetByAccessTokenHash(ctx context.Context, hash string) (*domain.AdminSession, error) {
+	for _, s := range r.Sessions {
+		if s.AccessTokenHash == hash {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *MockAdminSessionRepository) GetByRefreshTokenHash(ctx context.Context, hash string) (*domain.AdminSession, error) {
+	for _, s := range r.Sessions {
+		if s.RefreshTokenHash == hash {
+			return s, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *MockAdminSessionRepository) Save(ctx context.Context, session *domain.AdminSession) error {
+	r.Sessions[session.ID] = session
+	return nil
+}
+
+// MockMessageRepository
+type MockMessageRepository struct {
+	Messages map[domain.MessageID]*domain.Message
+}
+
+func NewMockMessageRepository() *MockMessageRepository {
+	return &MockMessageRepository{Messages: make(map[domain.MessageID]*domain.Message)}
+}
+
+func (r *MockMessageRepository) Save(ctx context.Context, msg *domain.Message) error {
+	r.Messages[msg.ID] = msg
+	return nil
+}
+
+func (r *MockMessageRepository) ListBroadcastsByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Message, error) {
+	var list []*domain.Message
+	for _, m := range r.Messages {
+		if m.ChannelType == domain.MessageBroadcast {
+			list = append(list, m)
+		}
+	}
+	return list, nil
+}
+
+func (r *MockMessageRepository) ListDirectByTrack(ctx context.Context, trackID domain.TrackID) ([]*domain.Message, error) {
+	var list []*domain.Message
+	for _, m := range r.Messages {
+		if m.ChannelType == domain.MessageDirect {
+			val, ok := m.TrackID.Value()
+			if ok && val == trackID {
+				list = append(list, m)
+			}
+		}
+	}
+	return list, nil
+}
+
+// MockBroadcastReceiptRepository
+type MockBroadcastReceiptRepository struct {
+	Receipts []*domain.BroadcastReceipt
+}
+
+func NewMockBroadcastReceiptRepository() *MockBroadcastReceiptRepository {
+	return &MockBroadcastReceiptRepository{}
+}
+
+func (r *MockBroadcastReceiptRepository) Save(ctx context.Context, receipt *domain.BroadcastReceipt) error {
+	r.Receipts = append(r.Receipts, receipt)
+	return nil
+}
+
+func (r *MockBroadcastReceiptRepository) GetByMessageAndTrack(ctx context.Context, msgID domain.MessageID, trackID domain.TrackID) (*domain.BroadcastReceipt, error) {
+	for _, rc := range r.Receipts {
+		if rc.MessageID == msgID && rc.TrackID == trackID {
+			return rc, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *MockBroadcastReceiptRepository) ListByMessage(ctx context.Context, msgID domain.MessageID) ([]*domain.BroadcastReceipt, error) {
+	var list []*domain.BroadcastReceipt
+	for _, rc := range r.Receipts {
+		if rc.MessageID == msgID {
+			list = append(list, rc)
+		}
+	}
+	return list, nil
+}
+
+// MockAuditLogRepository
+type MockAuditLogRepository struct {
+	Logs []*domain.AuditLog
+}
+
+func (r *MockAuditLogRepository) Save(ctx context.Context, log *domain.AuditLog) error {
+	r.Logs = append(r.Logs, log)
+	return nil
+}
+
+// MockBroadcaster
+type MockBroadcaster struct {
+	Broadcasts []domain.CampID
+}
+
+func (b *MockBroadcaster) BroadcastSnapshot(ctx context.Context, campID domain.CampID) error {
+	b.Broadcasts = append(b.Broadcasts, campID)
+	return nil
+}
+
+// MockReportQuerier
+type MockReportQuerier struct {
+	ReportToReturn *CampReport
+}
+
+func (q *MockReportQuerier) QueryCampReport(ctx context.Context, campID domain.CampID) (*CampReport, error) {
+	if q.ReportToReturn != nil {
+		return q.ReportToReturn, nil
+	}
+	return &CampReport{CampID: campID}, nil
+}


### PR DESCRIPTION
### 변경 사항
- usecase 단위 테스트에서 독립적으로 실행 가능한 InMemory Repository 및 Broadcaster Mock 구현 (mock_test.go)

### 종료 조건 증명
- Mock 객체를 바탕으로 데이터베이스 연동 없이 순수 비즈니스 로직 단위 테스트가 가능해집니다.