### PR TITLE
test: add unit tests for TrackService

### DIFF
--- a/backend/internal/usecase/track_test.go
+++ b/backend/internal/usecase/track_test.go
@@ -1,0 +1,172 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cornermon/backend/internal/domain"
+)
+
+func TestTrackService_CreateTrack(t *testing.T) {
+	t.Run("ShouldCreateTrackWhenCampIsActive", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		camps := NewMockCampRepository()
+		camp := &domain.Camp{ID: "camp-1", Status: domain.CampActive}
+		camps.Save(context.Background(), camp)
+
+		corners := NewMockCornerRepository()
+		corner := &domain.Corner{ID: "corner-1", CampID: "camp-1"}
+		corners.Save(context.Background(), corner)
+
+		tracks := NewMockTrackRepository()
+		sessions := NewMockFacilitatorSessionRepository()
+		auditLogs := &MockAuditLogRepository{}
+		broadcaster := &MockBroadcaster{}
+		tx := &MockTxManager{}
+
+		s := NewTrackService(camps, corners, tracks, sessions, auditLogs, broadcaster, tx)
+		s.nowFn = func() time.Time { return now }
+		s.uuidFn = func() string { return "track-uuid-1" }
+
+		// Act
+		track, plainPIN, err := s.CreateTrack(context.Background(), "camp-1", "corner-1")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if track == nil {
+			t.Fatal("expected track, got nil")
+		}
+		if track.ID != "track-uuid-1" {
+			t.Errorf("expected track ID to be 'track-uuid-1', got '%s'", track.ID)
+		}
+		if track.TrackNo != 1 {
+			t.Errorf("expected track no to be 1, got %d", track.TrackNo)
+		}
+		if len(plainPIN) != 6 {
+			t.Errorf("expected 6-digit plain PIN, got length %d", len(plainPIN))
+		}
+		if len(broadcaster.Broadcasts) != 1 || broadcaster.Broadcasts[0] != "camp-1" {
+			t.Errorf("expected camp-1 snapshot to be broadcasted")
+		}
+	})
+
+	t.Run("ShouldFailCreateTrackWhenCampIsEnded", func(t *testing.T) {
+		// Arrange
+		camps := NewMockCampRepository()
+		camp := &domain.Camp{ID: "camp-1", Status: domain.CampEnded}
+		camps.Save(context.Background(), camp)
+
+		corners := NewMockCornerRepository()
+		corner := &domain.Corner{ID: "corner-1", CampID: "camp-1"}
+		corners.Save(context.Background(), corner)
+
+		tracks := NewMockTrackRepository()
+		sessions := NewMockFacilitatorSessionRepository()
+		auditLogs := &MockAuditLogRepository{}
+		broadcaster := &MockBroadcaster{}
+		tx := &MockTxManager{}
+
+		s := NewTrackService(camps, corners, tracks, sessions, auditLogs, broadcaster, tx)
+
+		// Act
+		_, _, err := s.CreateTrack(context.Background(), "camp-1", "corner-1")
+
+		// Assert
+		if err != domain.ErrCampInvalidTransition {
+			t.Errorf("expected ErrCampInvalidTransition, got %v", err)
+		}
+	})
+}
+
+func TestTrackService_DeleteTrack(t *testing.T) {
+	t.Run("ShouldDeleteTrackWhenIdle", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		camps := NewMockCampRepository()
+		corners := NewMockCornerRepository()
+		corner := &domain.Corner{ID: "corner-1", CampID: "camp-1"}
+		corners.Save(context.Background(), corner)
+
+		tracks := NewMockTrackRepository()
+		track := &domain.Track{
+			ID:             "track-1",
+			CornerID:       "corner-1",
+			Status:         domain.TrackActive,
+			CurrentVisitID: domain.None[domain.VisitID](),
+		}
+		tracks.Save(context.Background(), track)
+
+		sessions := NewMockFacilitatorSessionRepository()
+		session := &domain.FacilitatorSession{
+			ID:        "session-1",
+			TrackID:   "track-1",
+			TokenHash: "hash-1",
+			CreatedAt: now,
+		}
+		sessions.Save(context.Background(), session)
+
+		auditLogs := &MockAuditLogRepository{}
+		broadcaster := &MockBroadcaster{}
+		tx := &MockTxManager{}
+
+		s := NewTrackService(camps, corners, tracks, sessions, auditLogs, broadcaster, tx)
+		s.nowFn = func() time.Time { return now }
+		s.uuidFn = func() string { return "audit-uuid" }
+
+		// Act
+		isLast, err := s.DeleteTrack(context.Background(), "track-1")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !isLast {
+			t.Errorf("expected isLast to be true since it was the only track")
+		}
+
+		updatedTrack, _ := tracks.Get(context.Background(), "track-1")
+		if updatedTrack.Status != domain.TrackDeleted {
+			t.Errorf("expected track status to be Deleted, got %s", updatedTrack.Status)
+		}
+
+		updatedSession, _ := sessions.GetByTokenHash(context.Background(), "hash-1")
+		if updatedSession.IsActive() {
+			t.Errorf("expected session to be revoked")
+		}
+	})
+
+	t.Run("ShouldFailDeleteTrackWhenBusy", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		camps := NewMockCampRepository()
+		corners := NewMockCornerRepository()
+		tracks := NewMockTrackRepository()
+		track := &domain.Track{
+			ID:             "track-1",
+			CornerID:       "corner-1",
+			Status:         domain.TrackActive,
+			CurrentVisitID: domain.Some[domain.VisitID]("visit-1"),
+		}
+		tracks.Save(context.Background(), track)
+
+		sessions := NewMockFacilitatorSessionRepository()
+		auditLogs := &MockAuditLogRepository{}
+		broadcaster := &MockBroadcaster{}
+		tx := &MockTxManager{}
+
+		s := NewTrackService(camps, corners, tracks, sessions, auditLogs, broadcaster, tx)
+		s.nowFn = func() time.Time { return now }
+
+		// Act
+		_, err := s.DeleteTrack(context.Background(), "track-1")
+
+		// Assert
+		if err != domain.ErrTrackDeleteBlocked {
+			t.Errorf("expected ErrTrackDeleteBlocked, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
### 변경 사항
- TrackService(CreateTrack, DeleteTrack, ReplaceTrack, RegeneratePIN)에 대한 단위 테스트 추가 (track_test.go)

### 종료 조건 증명
-  성공