### PR TITLE
feat: implement AdminAuthService and its tests

### DIFF
--- a/backend/internal/usecase/auth_admin.go
+++ b/backend/internal/usecase/auth_admin.go
@@ -1,0 +1,206 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"cornermon/backend/internal/domain"
+
+	"github.com/google/uuid"
+)
+
+const AdminAccessTokenTTL = 30 * time.Minute
+const AdminRefreshTokenIdleTTL = 12 * time.Hour
+
+type AdminAuthService struct {
+	admins    AdminRepository
+	sessions  AdminSessionRepository
+	auditLogs AuditLogRepository
+	tx        TxManager
+
+	nowFn  func() time.Time
+	uuidFn func() string
+}
+
+func NewAdminAuthService(
+	admins AdminRepository,
+	sessions AdminSessionRepository,
+	auditLogs AuditLogRepository,
+	tx TxManager,
+) *AdminAuthService {
+	return &AdminAuthService{
+		admins:    admins,
+		sessions:  sessions,
+		auditLogs: auditLogs,
+		tx:        tx,
+		nowFn:     time.Now,
+		uuidFn:    uuid.NewString,
+	}
+}
+
+// Login - UC-11
+func (s *AdminAuthService) Login(
+	ctx context.Context,
+	username string,
+	password string,
+	deviceInfo string,
+) (string, string, *domain.AdminSession, error) {
+	now := s.nowFn()
+
+	admin, err := s.admins.GetByUsername(ctx, username)
+	if err != nil {
+		return "", "", nil, err
+	}
+	if admin == nil {
+		s.recordAuditLog(ctx, "anonymous", "ADMIN_LOGIN", username, false, map[string]any{"error": "admin not found"})
+		return "", "", nil, errors.New("invalid username or password")
+	}
+
+	if err := verifyPassword(admin.PasswordHash, password); err != nil {
+		s.recordAuditLog(ctx, "anonymous", "ADMIN_LOGIN", username, false, map[string]any{"error": "invalid password"})
+		return "", "", nil, errors.New("invalid username or password")
+	}
+
+	plainAccess, accessHash, err := generateOpaqueToken()
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	plainRefresh, refreshHash, err := generateOpaqueToken()
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	sessionID := domain.AdminSessionID(s.uuidFn())
+	session := &domain.AdminSession{
+		ID:               sessionID,
+		AdminID:          admin.ID,
+		AccessTokenHash:  accessHash,
+		RefreshTokenHash: refreshHash,
+		DeviceInfo:       deviceInfo,
+		CreatedAt:        now,
+		LastUsedAt:       now,
+		RevokedAt:        domain.None[time.Time](),
+	}
+
+	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		return s.sessions.Save(ctx, session)
+	})
+
+	if err != nil {
+		s.recordAuditLog(ctx, "anonymous", "ADMIN_LOGIN", username, false, map[string]any{"error": err.Error()})
+		return "", "", nil, err
+	}
+
+	s.recordAuditLog(ctx, string(admin.ID), "ADMIN_LOGIN", string(session.ID), true, nil)
+	return plainAccess, plainRefresh, session, nil
+}
+
+// RefreshToken - UC-12
+func (s *AdminAuthService) RefreshToken(
+	ctx context.Context,
+	refreshToken string,
+) (string, error) {
+	now := s.nowFn()
+	refreshHash := hashSHA256(refreshToken)
+
+	session, err := s.sessions.GetByRefreshTokenHash(ctx, refreshHash)
+	if err != nil {
+		return "", err
+	}
+	if session == nil || session.IsRefreshExpired(now, AdminRefreshTokenIdleTTL) {
+		return "", errors.New("refresh token expired or revoked")
+	}
+
+	plainAccess, accessHash, err := generateOpaqueToken()
+	if err != nil {
+		return "", err
+	}
+
+	session.AccessTokenHash = accessHash
+	session.TouchRefresh(now)
+
+	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		return s.sessions.Save(ctx, session)
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return plainAccess, nil
+}
+
+// ValidateAccessToken - UC-13
+func (s *AdminAuthService) ValidateAccessToken(
+	ctx context.Context,
+	accessToken string,
+) (*domain.AdminSession, error) {
+	now := s.nowFn()
+	accessHash := hashSHA256(accessToken)
+
+	session, err := s.sessions.GetByAccessTokenHash(ctx, accessHash)
+	if err != nil {
+		return nil, err
+	}
+	if session == nil {
+		return nil, errors.New("session not found")
+	}
+
+	if session.RevokedAt.IsSet() {
+		return nil, domain.ErrSessionRevoked
+	}
+
+	if now.After(session.LastUsedAt.Add(AdminAccessTokenTTL)) {
+		return nil, errors.New("access token expired")
+	}
+
+	return session, nil
+}
+
+// RevokeSession - UC-17
+func (s *AdminAuthService) RevokeSession(
+	ctx context.Context,
+	sessionID domain.AdminSessionID,
+	actorAdminID domain.AdminID,
+) error {
+	now := s.nowFn()
+
+	session, err := s.sessions.Get(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	if session == nil {
+		return errors.New("session not found")
+	}
+
+	if err := session.Revoke(now); err != nil {
+		return err
+	}
+
+	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		return s.sessions.Save(ctx, session)
+	})
+
+	if err != nil {
+		s.recordAuditLog(ctx, string(actorAdminID), "ADMIN_SESSION_REVOKE", string(sessionID), false, map[string]any{"error": err.Error()})
+		return err
+	}
+
+	s.recordAuditLog(ctx, string(actorAdminID), "ADMIN_SESSION_REVOKE", string(sessionID), true, nil)
+	return nil
+}
+
+func (s *AdminAuthService) recordAuditLog(ctx context.Context, actor, action, target string, success bool, metadata map[string]any) {
+	log := domain.NewAuditLog(
+		domain.AuditLogID(s.uuidFn()),
+		actor,
+		action,
+		target,
+		success,
+		s.nowFn(),
+		metadata,
+	)
+	_ = s.auditLogs.Save(ctx, log)
+}

--- a/backend/internal/usecase/auth_admin_test.go
+++ b/backend/internal/usecase/auth_admin_test.go
@@ -1,0 +1,95 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cornermon/backend/internal/domain"
+)
+
+func TestAdminAuthService_Login(t *testing.T) {
+	t.Run("ShouldLoginAdminSuccessfullyWhenCredentialsAreValid", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		admins := NewMockAdminRepository()
+		passwordHash, _ := hashPassword("admin-password")
+		admin := &domain.Admin{ID: "admin-1", PasswordHash: passwordHash}
+		admins.Admins["admin-1"] = admin
+
+		sessions := NewMockAdminSessionRepository()
+		auditLogs := &MockAuditLogRepository{}
+		tx := &MockTxManager{}
+
+		s := NewAdminAuthService(admins, sessions, auditLogs, tx)
+		s.nowFn = func() time.Time { return now }
+		s.uuidFn = func() string { return "session-uuid" }
+
+		// Act
+		access, refresh, session, err := s.Login(context.Background(), "admin-1", "admin-password", "PC")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if access == "" || refresh == "" {
+			t.Fatal("expected non-empty tokens")
+		}
+		if session.ID != "session-uuid" {
+			t.Errorf("expected session ID 'session-uuid', got '%s'", session.ID)
+		}
+	})
+
+	t.Run("ShouldFailLoginAdminWhenPasswordIsIncorrect", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		passwordHash, _ := hashPassword("admin-password")
+		admin := &domain.Admin{ID: "admin-1", PasswordHash: passwordHash}
+		admins.Admins["admin-1"] = admin
+
+		sessions := NewMockAdminSessionRepository()
+		auditLogs := &MockAuditLogRepository{}
+		tx := &MockTxManager{}
+
+		s := NewAdminAuthService(admins, sessions, auditLogs, tx)
+
+		// Act
+		_, _, _, err := s.Login(context.Background(), "admin-1", "wrong-password", "PC")
+
+		// Assert
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}
+
+func TestAdminAuthService_RefreshToken(t *testing.T) {
+	t.Run("ShouldRefreshTokenSuccessfullyWhenNotExpired", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		sessions := NewMockAdminSessionRepository()
+		session := &domain.AdminSession{
+			ID:               "session-1",
+			AdminID:          "admin-1",
+			AccessTokenHash:  "access-hash-1",
+			RefreshTokenHash: hashSHA256("refresh-token-1"),
+			CreatedAt:        now.Add(-1 * time.Hour),
+			LastUsedAt:       now.Add(-10 * time.Minute),
+		}
+		sessions.Sessions["session-1"] = session
+
+		s := NewAdminAuthService(nil, sessions, nil, &MockTxManager{})
+		s.nowFn = func() time.Time { return now }
+
+		// Act
+		newAccess, err := s.RefreshToken(context.Background(), "refresh-token-1")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if newAccess == "" {
+			t.Fatal("expected non-empty access token")
+		}
+	})
+}


### PR DESCRIPTION
### 변경 사항
- 관리자 로그인 기능 구현 (UC-11)
- 관리자 액세스 토큰 갱신 기능 구현 (UC-12)
- 관리자 액세스 토큰 검증 기능 구현 (UC-13)
- 관리자 세션 강제 회수 기능 구현 (UC-17)
- 관련 단위 테스트 추가

### 종료 조건 증명
-  성공