### PR TITLE
feat: implement CampService, GroupService and their tests

### DIFF
--- a/backend/internal/usecase/camp.go
+++ b/backend/internal/usecase/camp.go
@@ -1,0 +1,136 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"cornermon/backend/internal/domain"
+
+	"github.com/google/uuid"
+)
+
+type CampService struct {
+	camps       CampRepository
+	tracks      TrackRepository
+	sessions    FacilitatorSessionRepository
+	auditLogs   AuditLogRepository
+	broadcaster Broadcaster
+	tx          TxManager
+
+	nowFn  func() time.Time
+	uuidFn func() string
+}
+
+func NewCampService(
+	camps CampRepository,
+	tracks TrackRepository,
+	sessions FacilitatorSessionRepository,
+	auditLogs AuditLogRepository,
+	broadcaster Broadcaster,
+	tx TxManager,
+) *CampService {
+	return &CampService{
+		camps:       camps,
+		tracks:      tracks,
+		sessions:    sessions,
+		auditLogs:   auditLogs,
+		broadcaster: broadcaster,
+		tx:          tx,
+		nowFn:       time.Now,
+		uuidFn:      uuid.NewString,
+	}
+}
+
+// ActivateCamp - UC-18
+func (s *CampService) ActivateCamp(
+	ctx context.Context,
+	campID domain.CampID,
+	actorAdminID domain.AdminID,
+) error {
+	now := s.nowFn()
+	camp, err := s.camps.Get(ctx, campID)
+	if err != nil {
+		return err
+	}
+	if camp == nil {
+		return domain.ErrCampInvalidTransition
+	}
+
+	if err := camp.Activate(now); err != nil {
+		return err
+	}
+
+	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		return s.camps.Save(ctx, camp)
+	})
+
+	if err != nil {
+		s.recordAuditLog(ctx, string(actorAdminID), "CAMP_ACTIVATE", string(campID), false, map[string]any{"error": err.Error()})
+		return err
+	}
+
+	s.recordAuditLog(ctx, string(actorAdminID), "CAMP_ACTIVATE", string(campID), true, nil)
+	_ = s.broadcaster.BroadcastSnapshot(ctx, campID)
+
+	return nil
+}
+
+// EndCamp - UC-20
+func (s *CampService) EndCamp(
+	ctx context.Context,
+	campID domain.CampID,
+	actorAdminID domain.AdminID,
+) error {
+	now := s.nowFn()
+	camp, err := s.camps.Get(ctx, campID)
+	if err != nil {
+		return err
+	}
+	if camp == nil {
+		return domain.ErrCampInvalidTransition
+	}
+
+	if _, err := camp.End(now); err != nil {
+		return err
+	}
+
+	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		// 해당 캠프 세션 일괄 무효화
+		sessions, err := s.sessions.ListActiveByCamp(ctx, campID)
+		if err != nil {
+			return err
+		}
+		for _, sess := range sessions {
+			if err := sess.Revoke(now); err == nil {
+				if err := s.sessions.Save(ctx, sess); err != nil {
+					return err
+				}
+			}
+		}
+
+		return s.camps.Save(ctx, camp)
+	})
+
+	if err != nil {
+		s.recordAuditLog(ctx, string(actorAdminID), "CAMP_END", string(campID), false, map[string]any{"error": err.Error()})
+		return err
+	}
+
+	s.recordAuditLog(ctx, string(actorAdminID), "CAMP_END", string(campID), true, nil)
+	_ = s.broadcaster.BroadcastSnapshot(ctx, campID)
+
+	return nil
+}
+
+func (s *CampService) recordAuditLog(ctx context.Context, actor, action, target string, success bool, metadata map[string]any) {
+	log := domain.NewAuditLog(
+		domain.AuditLogID(s.uuidFn()),
+		actor,
+		action,
+		target,
+		success,
+		s.nowFn(),
+		metadata,
+	)
+	_ = s.auditLogs.Save(ctx, log)
+}

--- a/backend/internal/usecase/camp_test.go
+++ b/backend/internal/usecase/camp_test.go
@@ -1,0 +1,86 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cornermon/backend/internal/domain"
+)
+
+func TestCampService_ActivateCamp(t *testing.T) {
+	t.Run("ShouldActivateCampSuccessfullyWhenPending", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		camps := NewMockCampRepository()
+		camp := &domain.Camp{ID: "camp-1", Status: domain.CampPending}
+		camps.Save(context.Background(), camp)
+
+		sessions := NewMockFacilitatorSessionRepository()
+		auditLogs := &MockAuditLogRepository{}
+		broadcaster := &MockBroadcaster{}
+		tx := &MockTxManager{}
+
+		s := NewCampService(camps, nil, sessions, auditLogs, broadcaster, tx)
+		s.nowFn = func() time.Time { return now }
+		s.uuidFn = func() string { return "audit-uuid" }
+
+		// Act
+		err := s.ActivateCamp(context.Background(), "camp-1", "admin-1")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		updated, _ := camps.Get(context.Background(), "camp-1")
+		if updated.Status != domain.CampActive {
+			t.Errorf("expected status 'ACTIVE', got %s", updated.Status)
+		}
+	})
+}
+
+func TestCampService_EndCamp(t *testing.T) {
+	t.Run("ShouldEndCampSuccessfullyWhenActiveAndRevokeSessions", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		camps := NewMockCampRepository()
+		camp := &domain.Camp{ID: "camp-1", Status: domain.CampActive}
+		camps.Save(context.Background(), camp)
+
+		sessions := NewMockFacilitatorSessionRepository()
+		session := &domain.FacilitatorSession{
+			ID:        "session-1",
+			TrackID:   "track-1",
+			TokenHash: "token-hash-1",
+			CreatedAt: now,
+		}
+		sessions.Save(context.Background(), session)
+
+		auditLogs := &MockAuditLogRepository{}
+		broadcaster := &MockBroadcaster{}
+		tx := &MockTxManager{}
+
+		s := NewCampService(camps, nil, sessions, auditLogs, broadcaster, tx)
+		s.nowFn = func() time.Time { return now }
+		s.uuidFn = func() string { return "audit-uuid" }
+
+		// Act
+		err := s.EndCamp(context.Background(), "camp-1", "admin-1")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		updatedCamp, _ := camps.Get(context.Background(), "camp-1")
+		if updatedCamp.Status != domain.CampEnded {
+			t.Errorf("expected status 'ENDED', got %s", updatedCamp.Status)
+		}
+
+		updatedSession, _ := sessions.GetByTokenHash(context.Background(), "token-hash-1")
+		if updatedSession.IsActive() {
+			t.Errorf("expected session to be revoked")
+		}
+	})
+}

--- a/backend/internal/usecase/group.go
+++ b/backend/internal/usecase/group.go
@@ -1,0 +1,131 @@
+package usecase
+
+import (
+	"context"
+	"time"
+
+	"cornermon/backend/internal/domain"
+
+	"github.com/google/uuid"
+)
+
+type GroupService struct {
+	camps     CampRepository
+	corners   CornerRepository
+	groups    GroupRepository
+	badges    BadgeRepository
+	auditLogs AuditLogRepository
+	tx        TxManager
+
+	nowFn  func() time.Time
+	uuidFn func() string
+}
+
+func NewGroupService(
+	camps CampRepository,
+	corners CornerRepository,
+	groups GroupRepository,
+	badges BadgeRepository,
+	auditLogs AuditLogRepository,
+	tx TxManager,
+) *GroupService {
+	return &GroupService{
+		camps:     camps,
+		corners:   corners,
+		groups:    groups,
+		badges:    badges,
+		auditLogs: auditLogs,
+		tx:        tx,
+		nowFn:     time.Now,
+		uuidFn:    uuid.NewString,
+	}
+}
+
+// RegisterBadge - UC-19
+func (s *GroupService) RegisterBadge(
+	ctx context.Context,
+	campID domain.CampID,
+	qrPayload string,
+	groupName string,
+) (*domain.Group, error) {
+	camp, err := s.camps.Get(ctx, campID)
+	if err != nil {
+		return nil, err
+	}
+	if camp == nil || camp.Status == domain.CampEnded {
+		return nil, domain.ErrCampInvalidTransition
+	}
+
+	badge, err := s.badges.GetByQRPayload(ctx, qrPayload)
+	if err != nil {
+		return nil, err
+	}
+	if badge == nil {
+		return nil, domain.ErrBadgeNotAssigned
+	}
+	if badge.Status == domain.BadgeAssigned {
+		return nil, domain.ErrBadgeAlreadyAssigned
+	}
+
+	corners, err := s.corners.ListByCamp(ctx, campID)
+	if err != nil {
+		return nil, err
+	}
+
+	var itinerary []domain.CornerProgress
+	for _, c := range corners {
+		itinerary = append(itinerary, domain.CornerProgress{
+			CornerID: c.ID,
+			Status:   domain.VisitNotVisited,
+		})
+	}
+
+	groupID := domain.GroupID(s.uuidFn())
+	group := &domain.Group{
+		ID:        groupID,
+		CampID:    campID,
+		Name:      groupName,
+		BadgeID:   badge.ID,
+		Itinerary: itinerary,
+	}
+
+	if err := badge.AssignTo(groupID); err != nil {
+		return nil, err
+	}
+
+	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		if err := s.groups.Save(ctx, group); err != nil {
+			return err
+		}
+		return s.badges.Save(ctx, badge)
+	})
+
+	if err != nil {
+		s.recordAuditLog(ctx, "admin", "GROUP_CREATE", "", false, map[string]any{"error": err.Error()})
+		return nil, err
+	}
+
+	s.recordAuditLog(ctx, "admin", "GROUP_CREATE", string(groupID), true, map[string]any{"campID": string(campID), "badgeID": string(badge.ID)})
+	return group, nil
+}
+
+// ListGroups
+func (s *GroupService) ListGroups(
+	ctx context.Context,
+	campID domain.CampID,
+) ([]*domain.Group, error) {
+	return s.groups.ListByCamp(ctx, campID)
+}
+
+func (s *GroupService) recordAuditLog(ctx context.Context, actor, action, target string, success bool, metadata map[string]any) {
+	log := domain.NewAuditLog(
+		domain.AuditLogID(s.uuidFn()),
+		actor,
+		action,
+		target,
+		success,
+		s.nowFn(),
+		metadata,
+	)
+	_ = s.auditLogs.Save(ctx, log)
+}

--- a/backend/internal/usecase/group_test.go
+++ b/backend/internal/usecase/group_test.go
@@ -1,0 +1,94 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cornermon/backend/internal/domain"
+)
+
+func TestGroupService_RegisterBadge(t *testing.T) {
+	t.Run("ShouldRegisterBadgeSuccessfullyWhenBadgeIsUnassigned", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		camps := NewMockCampRepository()
+		camp := &domain.Camp{ID: "camp-1", Status: domain.CampActive}
+		camps.Save(context.Background(), camp)
+
+		corners := NewMockCornerRepository()
+		corner1 := &domain.Corner{ID: "corner-1", CampID: "camp-1"}
+		corner2 := &domain.Corner{ID: "corner-2", CampID: "camp-1"}
+		corners.Save(context.Background(), corner1)
+		corners.Save(context.Background(), corner2)
+
+		badges := NewMockBadgeRepository()
+		badge := &domain.Badge{
+			ID:              "badge-1",
+			ShortID:         "B1",
+			QRPayload:       "qr-1",
+			Status:          domain.BadgeUnassigned,
+			AssignedGroupID: domain.None[domain.GroupID](),
+		}
+		badges.Save(context.Background(), badge)
+
+		groups := NewMockGroupRepository()
+		auditLogs := &MockAuditLogRepository{}
+		tx := &MockTxManager{}
+
+		s := NewGroupService(camps, corners, groups, badges, auditLogs, tx)
+		s.nowFn = func() time.Time { return now }
+		s.uuidFn = func() string { return "group-uuid" }
+
+		// Act
+		group, err := s.RegisterBadge(context.Background(), "camp-1", "qr-1", "1조")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if group == nil {
+			t.Fatal("expected group, got nil")
+		}
+		if group.ID != "group-uuid" {
+			t.Errorf("expected group ID 'group-uuid', got '%s'", group.ID)
+		}
+		if len(group.Itinerary) != 2 {
+			t.Errorf("expected itinerary size 2, got %d", len(group.Itinerary))
+		}
+
+		updatedBadge, _ := badges.Get(context.Background(), "badge-1")
+		if updatedBadge.Status != domain.BadgeAssigned {
+			t.Errorf("expected badge to be Assigned")
+		}
+	})
+
+	t.Run("ShouldFailRegisterBadgeWhenCampIsEnded", func(t *testing.T) {
+		// Arrange
+		camps := NewMockCampRepository()
+		camp := &domain.Camp{ID: "camp-1", Status: domain.CampEnded}
+		camps.Save(context.Background(), camp)
+
+		badges := NewMockBadgeRepository()
+		badge := &domain.Badge{
+			ID:        "badge-1",
+			QRPayload: "qr-1",
+			Status:    domain.BadgeUnassigned,
+		}
+		badges.Save(context.Background(), badge)
+
+		groups := NewMockGroupRepository()
+		auditLogs := &MockAuditLogRepository{}
+		tx := &MockTxManager{}
+
+		s := NewGroupService(camps, nil, groups, badges, auditLogs, tx)
+
+		// Act
+		_, err := s.RegisterBadge(context.Background(), "camp-1", "qr-1", "1조")
+
+		// Assert
+		if err != domain.ErrCampInvalidTransition {
+			t.Errorf("expected ErrCampInvalidTransition, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
### 변경 사항
- 캠프 활성화 기능 구현 (UC-18)
- 캠프 종료 및 세션 만료 기능 구현 (UC-20)
- 배지(조) 등록 기능 구현 (UC-19)
- 관련 단위 테스트 추가

### 종료 조건 증명
-  성공