### PR TITLE
fix(auth): update Track PIN login to conform to OpenAPI spec

### DIFF
--- a/backend/internal/usecase/auth_facilitator.go
+++ b/backend/internal/usecase/auth_facilitator.go
@@ -48,8 +48,6 @@ func NewFacilitatorAuthService(
 // Login - UC-9
 func (s *FacilitatorAuthService) Login(
 	ctx context.Context,
-	campID domain.CampID,
-	trackID domain.TrackID,
 	deviceToken string,
 	pin string,
 ) (string, *domain.FacilitatorSession, error) {
@@ -62,37 +60,42 @@ func (s *FacilitatorAuthService) Login(
 		return "", nil, err
 	}
 	if device == nil || device.Status != domain.DeviceApproved {
-		s.recordAuditLog(ctx, "anonymous", "FACILITATOR_LOGIN", string(trackID), false, map[string]any{"error": domain.ErrDeviceNotApproved.Error()})
+		s.recordAuditLog(ctx, "anonymous", "FACILITATOR_LOGIN", "", false, map[string]any{"error": domain.ErrDeviceNotApproved.Error()})
 		return "", nil, domain.ErrDeviceNotApproved
 	}
 
 	if device.IsLocked(now) {
-		s.recordAuditLog(ctx, "anonymous", "FACILITATOR_LOGIN", string(trackID), false, map[string]any{"error": domain.ErrDeviceLocked.Error()})
+		s.recordAuditLog(ctx, "anonymous", "FACILITATOR_LOGIN", "", false, map[string]any{"error": domain.ErrDeviceLocked.Error()})
 		return "", nil, domain.ErrDeviceLocked
 	}
 
-	// 2. 트랙 정보 조회 및 검증
-	track, err := s.tracks.Get(ctx, trackID)
-	if err != nil {
-		return "", nil, err
-	}
-	if track == nil || track.Status != domain.TrackActive {
-		s.recordAuditLog(ctx, "anonymous", "FACILITATOR_LOGIN", string(trackID), false, map[string]any{"error": domain.ErrTrackNotActive.Error()})
-		return "", nil, domain.ErrTrackNotActive
-	}
+	campID := device.CampID
 
-	// 3. 캠프 정보 조회 및 검증
+	// 2. 캠프 정보 조회 및 검증
 	camp, err := s.camps.Get(ctx, campID)
 	if err != nil {
 		return "", nil, err
 	}
 	if camp == nil || !camp.IsActive() {
-		s.recordAuditLog(ctx, "anonymous", "FACILITATOR_LOGIN", string(trackID), false, map[string]any{"error": domain.ErrCampInvalidTransition.Error()})
+		s.recordAuditLog(ctx, "anonymous", "FACILITATOR_LOGIN", "", false, map[string]any{"error": domain.ErrCampInvalidTransition.Error()})
 		return "", nil, domain.ErrCampInvalidTransition
 	}
 
-	// 4. PIN 검증
-	if err := verifyPassword(track.PINHash, pin); err != nil {
+	// 3. 트랙 찾기 및 PIN 검증
+	activeTracks, err := s.tracks.ListActiveByCamp(ctx, campID)
+	if err != nil {
+		return "", nil, err
+	}
+
+	var track *domain.Track
+	for _, t := range activeTracks {
+		if err := verifyPassword(t.PINHash, pin); err == nil {
+			track = t
+			break
+		}
+	}
+
+	if track == nil {
 		// PIN 검증 실패 시
 		_, needsAdminAlert := device.RecordPinFailure(now)
 		_ = s.devices.Save(ctx, device)
@@ -101,14 +104,16 @@ func (s *FacilitatorAuthService) Login(
 			_ = s.broadcaster.Broadcast(ctx, device.CampID, EventLockoutAlert, "device:"+string(device.ID))
 		}
 
-		s.recordAuditLog(ctx, "anonymous", "FACILITATOR_LOGIN", string(trackID), false, map[string]any{"error": "invalid pin", "device_failures": device.FailedPinAttempts})
+		s.recordAuditLog(ctx, "anonymous", "FACILITATOR_LOGIN", "", false, map[string]any{"error": "invalid pin", "device_failures": device.FailedPinAttempts})
 		return "", nil, errors.New("invalid pin")
 	}
+
+	trackID := track.ID
 
 	// PIN 검증 성공 시 실패 횟수 리셋
 	device.ResetPinFailures()
 
-	// 5. 신규 세션 토큰 및 세션 정보 생성
+	// 4. 신규 세션 토큰 및 세션 정보 생성
 	plainToken, sessionTokenHash, err := generateOpaqueToken()
 	if err != nil {
 		return "", nil, err
@@ -123,7 +128,7 @@ func (s *FacilitatorAuthService) Login(
 		RevokedAt: domain.None[time.Time](),
 	}
 
-	// 6. DB 트랜잭션 내에서 기기 상태 및 세션 정보 저장
+	// 5. DB 트랜잭션 내에서 기기 상태 및 세션 정보 저장
 	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
 		if err := s.devices.Save(ctx, device); err != nil {
 			return err

--- a/backend/internal/usecase/auth_facilitator_test.go
+++ b/backend/internal/usecase/auth_facilitator_test.go
@@ -47,7 +47,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 		s.uuidFn = func() string { return "session-uuid" }
 
 		// Act
-		plainToken, session, err := s.Login(context.Background(), "camp-1", "track-1", deviceToken, "123456")
+		plainToken, session, err := s.Login(context.Background(), deviceToken, "123456")
 
 		// Assert
 		if err != nil {
@@ -104,7 +104,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 		s.nowFn = func() time.Time { return now }
 
 		// Act
-		_, _, err := s.Login(context.Background(), "camp-1", "track-1", deviceToken, "123456")
+		_, _, err := s.Login(context.Background(), deviceToken, "123456")
 
 		// Assert
 		if err != domain.ErrDeviceNotApproved {
@@ -150,7 +150,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 		s.nowFn = func() time.Time { return now }
 
 		// Act
-		_, _, err := s.Login(context.Background(), "camp-1", "track-1", deviceToken, "123456")
+		_, _, err := s.Login(context.Background(), deviceToken, "123456")
 
 		// Assert
 		if err != domain.ErrDeviceLocked {
@@ -196,7 +196,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 		s.nowFn = func() time.Time { return now }
 
 		// Act
-		_, _, err := s.Login(context.Background(), "camp-1", "track-1", deviceToken, "wrong-pin")
+		_, _, err := s.Login(context.Background(), deviceToken, "wrong-pin")
 
 		// Assert
 		if err == nil || err.Error() != "invalid pin" {


### PR DESCRIPTION
# Fix: 진행자 트랙 PIN 로그인 요구사항 불일치 수정

## 변경 사항
OpenAPI 명세(`openapi.yaml`)의 `/auth/track/login` 설계에 맞춰 `FacilitatorAuthService.Login`의 동작을 수정했습니다.

- **문제점:** 기존 `Login` 유즈케이스가 `campID`, `trackID`를 인자로 요구하여, `pin`만 전송하는 클라이언트의 스펙과 맞지 않음. (또한 `TrackRepository`에 PIN으로 트랙을 찾는 기능이 부재)
- **수정안:**
  1. `FacilitatorAuthService.Login` 시그니처에서 `campID`, `trackID` 파라미터를 제거했습니다.
  2. 기기 신뢰 토큰(`deviceToken`)을 통해 승인된 `DeviceRegistration`을 조회하고, 여기 포함된 `CampID`를 추출합니다.
  3. `CampID`에 속한 활성 트랙(`ActiveTracks`) 목록을 조회(`s.tracks.ListActiveByCamp`)한 후, 반복문을 통해 전달된 `pin`과 `PINHash`를 bcrypt 대조하여 일치하는 트랙을 동적으로 찾도록 수정했습니다.
  4. 관련 테스트 코드(`auth_facilitator_test.go`)의 인자 전달을 수정하여 모든 테스트가 통과함을 확인했습니다.

## 연관 파일
- `backend/internal/usecase/auth_facilitator.go`
- `backend/internal/usecase/auth_facilitator_test.go`
