### PR TITLE
feat: implement track session migration (issues #30, #32)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -40,6 +40,10 @@ components:
       type: http
       scheme: bearer
       description: 관리자 승인된 기기 신뢰 토큰 (TRUSTED_DEVICE)
+    DeviceTokenAuth:
+      type: http
+      scheme: bearer
+      description: 승인/미승인(PENDING) 무관하게 기기 등록 요청 시 발급된 기기 신뢰 토큰
     TrackAuth:
       type: http
       scheme: bearer
@@ -57,6 +61,22 @@ components:
   # Common Schemas
   # ──────────────────────────────────────────────
   schemas:
+    TrackLoginResponse:
+      type: object
+      properties:
+        trackToken:
+          type: string
+          description: "트랙 세션 불투명 토큰"
+        track:
+          $ref: '#/components/schemas/Track'
+        corner:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            name:
+              type: string
 
     # ── Error ──────────────────────────────────
     ErrorResponse:
@@ -723,6 +743,7 @@ components:
             - camp_updated
             - messages_changed
             - track_deleted
+            - track_replaced
             - session_revoked
             - camp_ended
             - device_registration_updated
@@ -830,6 +851,27 @@ paths:
   # ════════════════════════════════════════════
   # A. 인증 / 기기 신뢰
   # ════════════════════════════════════════════
+
+  /device-registrations/me:
+    get:
+      tags: [A. Auth & Device Trust]
+      summary: "내 기기 등록 상태 자체 조회"
+      description: |
+        미승인(PENDING) 기기가 자신의 승인 상태를 확인하기 위해 호출한다.
+      security:
+        - DeviceTokenAuth: []
+      responses:
+        "200":
+          description: "상태 반환"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    $ref: '#/components/schemas/DeviceRegistrationStatus'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
 
   /device-registrations:
     post:
@@ -1018,21 +1060,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  trackToken:
-                    type: string
-                    description: "트랙 세션 불투명 토큰"
-                  track:
-                    $ref: '#/components/schemas/Track'
-                  corner:
-                    type: object
-                    properties:
-                      id:
-                        type: string
-                        format: uuid
-                      name:
-                        type: string
+                $ref: '#/components/schemas/TrackLoginResponse'
         "400":
           description: "잘못된 PIN"
           content:
@@ -1744,10 +1772,10 @@ paths:
         기존 트랙 삭제와 신규 코너에 신규 트랙 생성을 원자적으로 수행한다.
         IN_PROGRESS 방문이 있으면 하드 블록.
         새 트랙 정보(신규 PIN 포함)는 이 응답으로 직접 반환한다 — SSE로는 전달하지 않는다.
-        기존 트랙 세션은 트랙 삭제와 동일하게 즉시 무효화되며, 기존 기기는 `GET /events/track/{trackId}`로
-        `track_deleted` 알림을 받아 즉시 B1(로그인) 화면으로 전환한다. 관리자 대시보드는 `tracks_updated`
-        알림을 받아 트랙 목록을 재조회한다.
-        (세부 재인증 흐름 TBD)
+        기존 트랙 세션은 트랙 삭제와 동일하게 삭제되나, 백엔드 유즈케이스 내에서 기존 세션들에 새 트랙 ID를
+        마이그레이션 타겟으로 마킹한다. 클라이언트는 `GET /events/track/{trackId}`로 `track_replaced` 알림을
+        받고 즉시 `POST /tracks/{oldTrackId}/migrate-session`을 호출하여 새 세션으로 자동 전환한다.
+        관리자 대시보드는 `tracks_updated` 알림을 받아 트랙 목록을 재조회한다.
       security:
         - AdminAuth: []
       parameters:
@@ -1777,6 +1805,32 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+
+  /tracks/{id}/migrate-session:
+    post:
+      tags: [B. Camp / Corner / Track]
+      summary: "교체된 트랙의 세션 마이그레이션"
+      description: |
+        트랙이 교체되어 `track_replaced` 알림을 받은 기기가 호출한다.
+        유효한 기존 세션 토큰을 헤더에 담아 전송하면, 백엔드에 기록된 마이그레이션 타겟 트랙의
+        새 세션 토큰과 트랙/코너 정보를 반환하여 자동 로그인을 수행한다.
+      security:
+        - TrackAuth: []
+      parameters:
+        - $ref: '#/components/parameters/TrackIdPath'
+      responses:
+        "200":
+          description: "마이그레이션 완료 — 새 세션 및 트랙 정보 반환"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TrackLoginResponse'
+        "401":
+          $ref: '#/components/responses/Unauthorized'
+        "403":
+          $ref: '#/components/responses/Forbidden'
+        "404":
+          $ref: '#/components/responses/NotFound'
 
   /tracks/{id}/regenerate-pin:
     post:

--- a/backend/internal/domain/facilitator_session.go
+++ b/backend/internal/domain/facilitator_session.go
@@ -5,11 +5,17 @@ import (
 )
 
 type FacilitatorSession struct {
-	ID        FacilitatorSessionID
-	TrackID   TrackID
-	TokenHash string
-	CreatedAt time.Time
-	RevokedAt Optional[time.Time]
+	ID                     FacilitatorSessionID
+	TrackID                TrackID
+	TokenHash              string
+	CreatedAt              time.Time
+	RevokedAt              Optional[time.Time]
+	MigrationTargetTrackID Optional[TrackID]
+}
+
+// SetMigrationTarget은 트랙 교체 시 마이그레이션할 대상 트랙 ID를 기록합니다.
+func (s *FacilitatorSession) SetMigrationTarget(newTrackID TrackID) {
+	s.MigrationTargetTrackID = Some(newTrackID)
 }
 
 // Revoke는 세션을 즉시 무효화 처리합니다.

--- a/backend/internal/infrastructure/web/auth_handler.go
+++ b/backend/internal/infrastructure/web/auth_handler.go
@@ -22,6 +22,7 @@ type AdminAuthUsecase interface {
 type FacilitatorAuthUsecase interface {
 	Login(ctx context.Context, deviceToken, pin string) (*usecase.TrackLoginResult, error)
 	Logout(ctx context.Context, sessionID domain.FacilitatorSessionID) error
+	MigrateSession(ctx context.Context, oldSessionToken string) (*usecase.TrackLoginResult, error)
 }
 
 type AuthDeviceTrustUsecase interface {
@@ -291,4 +292,44 @@ func (h *AuthHandler) ReleaseLockout(c echo.Context) error {
 	}
 
 	return c.NoContent(http.StatusNoContent)
+}
+
+// @Summary      교체된 트랙의 세션 마이그레이션
+// @Description  트랙이 교체되어 `track_replaced` 알림을 받은 기기가 호출한다. 기존 세션 토큰을 Authorization 헤더에 담아 새 세션을 발급받는다.
+// @Tags         B. Camp / Corner / Track
+// @Security     TrackAuth
+// @Produce      json
+// @Param        id path string true "기존 트랙 ID"
+// @Success      200 {object} TrackLoginResponse
+// @Failure      401 {object} ErrorResponse "권한 없음 또는 세션 만료"
+// @Router       /tracks/{id}/migrate-session [post]
+func (h *AuthHandler) MigrateSession(c echo.Context) error {
+	sessionToken := extractToken(c.Request().Header.Get("Authorization"))
+	if sessionToken == "" {
+		return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "missing token"})
+	}
+
+	res, err := h.facilitatorAuth.MigrateSession(c.Request().Context(), sessionToken)
+	if err != nil {
+		if err == domain.ErrSessionRevoked {
+			return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: err.Error()})
+		}
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, TrackLoginResponse{
+		TrackToken: res.TrackToken,
+		Track: Track{
+			TrackSummary: TrackSummary{
+				ID:       string(res.Track.ID),
+				CornerID: string(res.Track.CornerID),
+				TrackNo:  res.Track.TrackNo,
+				Status:   string(res.Track.Status),
+			},
+		},
+		Corner: Corner{
+			ID:   string(res.Corner.ID),
+			Name: res.Corner.Name,
+		},
+	})
 }

--- a/backend/internal/infrastructure/web/device_handler.go
+++ b/backend/internal/infrastructure/web/device_handler.go
@@ -11,6 +11,7 @@ import (
 )
 
 type DeviceTrustUsecase interface {
+	GetMyRegistrationStatus(ctx context.Context, deviceToken string) (*domain.DeviceRegistrationStatus, error)
 	RequestRegistration(ctx context.Context, campID domain.CampID, deviceName string) (string, *domain.DeviceRegistration, error)
 	ApproveDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) error
 	RejectDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) error
@@ -32,6 +33,32 @@ type DeviceRegistrationRequest struct {
 	CampID     string `json:"campId"` // Using campId because RequestRegistration expects a campID
 	DeviceName string `json:"deviceName"`
 	Role       string `json:"role" enums:"ADMIN,FACILITATOR"`
+}
+
+// @Summary      내 기기 등록 상태 자체 조회
+// @Description  미승인(PENDING) 기기가 자신의 승인 상태를 확인하기 위해 호출한다.
+// @Tags         A. Auth & Device Trust
+// @Accept       json
+// @Produce      json
+// @Success      200 {object} map[string]interface{}
+// @Router       /device-registrations/me [get]
+func (h *DeviceHandler) GetMyRegistrationStatus(c echo.Context) error {
+	token := extractToken(c.Request().Header.Get("Authorization"))
+	if token == "" {
+		return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "missing token"})
+	}
+
+	status, err := h.deviceTrust.GetMyRegistrationStatus(c.Request().Context(), token)
+	if err != nil {
+		if err == domain.ErrDeviceNotApproved {
+			return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: err.Error()})
+		}
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()})
+	}
+
+	return c.JSON(http.StatusOK, map[string]interface{}{
+		"status": status,
+	})
 }
 
 // @Summary      기기 등록 요청 (최초 앱 실행 시)

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -31,6 +31,7 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 	auth.POST("/track/login", h.Auth.TrackLogin)
 
 	v1.POST("/device-registrations", h.Device.RequestRegistration)
+	v1.GET("/device-registrations/me", h.Device.GetMyRegistrationStatus)
 
 	admin := v1.Group("")
 	admin.Use(AdminAuthMiddleware(adminAuth))
@@ -121,6 +122,7 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 	track.Use(TrackAuthMiddleware(trackAuth))
 
 	track.POST("/auth/track/logout", h.Auth.TrackLogout)
+	track.POST("/tracks/:id/migrate-session", h.Auth.MigrateSession)
 
 	// ── C. Visit ──
 	if h.Visit != nil {

--- a/backend/internal/usecase/auth_facilitator.go
+++ b/backend/internal/usecase/auth_facilitator.go
@@ -176,6 +176,84 @@ func (s *FacilitatorAuthService) Login(
 	}, nil
 }
 
+// MigrateSession - UC-2 (이슈 #30)
+func (s *FacilitatorAuthService) MigrateSession(
+	ctx context.Context,
+	oldSessionToken string,
+) (*TrackLoginResult, error) {
+	now := s.nowFn()
+	oldSessionTokenHash := hashSHA256(oldSessionToken)
+
+	// 1. 기존 세션 검증
+	oldSession, err := s.sessions.GetByTokenHash(ctx, oldSessionTokenHash)
+	if err != nil {
+		return nil, err
+	}
+	if oldSession == nil || !oldSession.IsActive() {
+		return nil, domain.ErrSessionRevoked
+	}
+
+	// 2. 승계 대상 트랙 확인
+	if !oldSession.MigrationTargetTrackID.IsSet() {
+		return nil, errors.New("no migration target for this session")
+	}
+	newTrackID, _ := oldSession.MigrationTargetTrackID.Value()
+
+	// 3. 새 트랙 및 코너 조회
+	newTrack, err := s.tracks.Get(ctx, newTrackID)
+	if err != nil {
+		return nil, err
+	}
+	if newTrack == nil {
+		return nil, errors.New("migration target track not found")
+	}
+
+	corner, err := s.corners.Get(ctx, newTrack.CornerID)
+	if err != nil {
+		return nil, err
+	}
+	if corner == nil {
+		return nil, domain.ErrCornerNotInItinerary
+	}
+
+	// 4. 신규 세션 발급
+	plainToken, sessionTokenHash, err := generateOpaqueToken()
+	if err != nil {
+		return nil, err
+	}
+
+	sessionID := domain.FacilitatorSessionID(s.uuidFn())
+	newSession := &domain.FacilitatorSession{
+		ID:                     sessionID,
+		TrackID:                newTrackID,
+		TokenHash:              sessionTokenHash,
+		CreatedAt:              now,
+		RevokedAt:              domain.None[time.Time](),
+		MigrationTargetTrackID: domain.None[domain.TrackID](),
+	}
+
+	// 5. DB 트랜잭션 내에서 기존 세션 만료 및 신규 세션 저장
+	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		_ = oldSession.Revoke(now)
+		if err := s.sessions.Save(ctx, oldSession); err != nil {
+			return err
+		}
+		return s.sessions.Save(ctx, newSession)
+	})
+
+	if err != nil {
+		s.recordAuditLog(ctx, string(oldSession.TrackID), "SESSION_MIGRATE", string(newTrackID), false, map[string]any{"error": err.Error()})
+		return nil, err
+	}
+
+	s.recordAuditLog(ctx, string(oldSession.TrackID), "SESSION_MIGRATE", string(newSession.ID), true, nil)
+	return &TrackLoginResult{
+		TrackToken: plainToken,
+		Track:      newTrack,
+		Corner:     corner,
+	}, nil
+}
+
 // ValidateSession - UC-10
 func (s *FacilitatorAuthService) ValidateSession(
 	ctx context.Context,

--- a/backend/internal/usecase/device_trust.go
+++ b/backend/internal/usecase/device_trust.go
@@ -83,6 +83,22 @@ func (s *DeviceTrustService) RequestRegistration(
 	return plainToken, reg, nil
 }
 
+// GetMyRegistrationStatus - UC-1 (이슈 #32)
+func (s *DeviceTrustService) GetMyRegistrationStatus(
+	ctx context.Context,
+	deviceToken string,
+) (*domain.DeviceRegistrationStatus, error) {
+	deviceTokenHash := hashSHA256(deviceToken)
+	device, err := s.devices.GetByTokenHash(ctx, deviceTokenHash)
+	if err != nil {
+		return nil, err
+	}
+	if device == nil {
+		return nil, domain.ErrDeviceNotApproved // 혹은 NotFound 처리
+	}
+	return &device.Status, nil
+}
+
 // ApproveDevice - UC-14 (승인)
 func (s *DeviceTrustService) ApproveDevice(
 	ctx context.Context,

--- a/backend/internal/usecase/device_trust_test.go
+++ b/backend/internal/usecase/device_trust_test.go
@@ -92,3 +92,41 @@ func TestDeviceTrustService_ApproveDevice(t *testing.T) {
 		}
 	})
 }
+
+func TestDeviceTrustService_GetMyRegistrationStatus(t *testing.T) {
+	t.Run("ShouldReturnStatusWhenTokenIsValid", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		camps := NewMockCampRepository()
+		camp := &domain.Camp{ID: "camp-1", Status: domain.CampActive}
+		camps.Save(context.Background(), camp)
+
+		devices := NewMockDeviceRegistrationRepository()
+		auditLogs := &MockAuditLogRepository{}
+		broadcaster := &MockBroadcaster{}
+		tx := &MockTxManager{}
+
+		s := NewDeviceTrustService(camps, devices, auditLogs, broadcaster, tx)
+		s.nowFn = func() time.Time { return now }
+		s.uuidFn = func() string { return "device-uuid" }
+
+		plainToken, _, err := s.RequestRegistration(context.Background(), "camp-1", "iPad-1")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Act
+		status, err := s.GetMyRegistrationStatus(context.Background(), plainToken)
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if status == nil {
+			t.Fatalf("expected status to be not nil")
+		}
+		if *status != domain.DevicePending {
+			t.Errorf("expected status 'PENDING', got %s", *status)
+		}
+	})
+}

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -123,6 +123,7 @@ const (
 	EventCampUpdated               NotificationEvent = "camp_updated"
 	EventMessagesChanged           NotificationEvent = "messages_changed"
 	EventTrackDeleted              NotificationEvent = "track_deleted"
+	EventTrackReplaced             NotificationEvent = "track_replaced"
 	EventSessionRevoked            NotificationEvent = "session_revoked"
 	EventCampEnded                 NotificationEvent = "camp_ended"
 	EventDeviceRegistrationUpdated NotificationEvent = "device_registration_updated"

--- a/backend/internal/usecase/track.go
+++ b/backend/internal/usecase/track.go
@@ -220,19 +220,6 @@ func (s *TrackService) ReplaceTrack(
 			return err
 		}
 
-		// 기존 트랙 세션 일괄 Revoke
-		sessions, err := s.sessions.ListActiveByTrack(ctx, oldTrackID)
-		if err != nil {
-			return err
-		}
-		for _, sess := range sessions {
-			if err := sess.Revoke(now); err == nil {
-				if err := s.sessions.Save(ctx, sess); err != nil {
-					return err
-				}
-			}
-		}
-
 		if err := s.tracks.Save(ctx, oldTrack); err != nil {
 			return err
 		}
@@ -250,8 +237,9 @@ func (s *TrackService) ReplaceTrack(
 			}
 		}
 
+		newTrackID := domain.TrackID(s.uuidFn())
 		newTrack = &domain.Track{
-			ID:             domain.TrackID(s.uuidFn()),
+			ID:             newTrackID,
 			CornerID:       newCornerID,
 			TrackNo:        nextTrackNo,
 			Status:         domain.TrackActive,
@@ -259,7 +247,23 @@ func (s *TrackService) ReplaceTrack(
 			CurrentVisitID: domain.None[domain.VisitID](),
 		}
 
-		return s.tracks.Save(ctx, newTrack)
+		if err := s.tracks.Save(ctx, newTrack); err != nil {
+			return err
+		}
+
+		// 기존 트랙 세션에 마이그레이션 타겟 설정 (Revoke 하지 않음)
+		sessions, err := s.sessions.ListActiveByTrack(ctx, oldTrackID)
+		if err != nil {
+			return err
+		}
+		for _, sess := range sessions {
+			sess.SetMigrationTarget(newTrackID)
+			if err := s.sessions.Save(ctx, sess); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	})
 
 	if err != nil {
@@ -269,7 +273,7 @@ func (s *TrackService) ReplaceTrack(
 
 	s.recordAuditLog(ctx, "admin", "TRACK_REPLACE", string(newTrack.ID), true, map[string]any{"oldTrackID": string(oldTrackID)})
 	_ = s.broadcaster.Broadcast(ctx, newCorner.CampID, EventTracksUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, newCorner.CampID, EventTrackDeleted, "track:"+string(oldTrackID))
+	_ = s.broadcaster.Broadcast(ctx, newCorner.CampID, EventTrackReplaced, "track:"+string(oldTrackID))
 
 	return newTrack, plainPIN, nil
 }


### PR DESCRIPTION
This PR implements session migration and device status querying.

- Add /device-registrations/me GET handler
- Add /tracks/:id/migrate-session POST handler
- Update TrackService and AuthFacilitatorService to support session migration atomically
- Add unit tests for GetMyRegistrationStatus
- Adheres to workflow guidelines and verification checklist.