### PR TITLE
docs: add developer guides and missing features report

### DIFF
--- a/backend/docs/DEVELOPER_GUIDE.md
+++ b/backend/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,230 @@
+# Backend Developer Guide
+
+이 문서는 `backend/` 코드베이스의 실제 구현을 기준으로 정리한 개발 가이드라인입니다.
+설계 의도는 `docs/technical-design.md`, `docs/domain-model.md`를 따르되, 이 문서는 "실제 코드가
+어떻게 그 의도를 구현하고 있는지"를 다룹니다. 새 유스케이스/리포지토리/핸들러를 추가할 때
+이 문서의 패턴을 따르세요.
+
+## 1. 레이어 구조
+
+```
+cmd/server/main.go                      # 의존성 조립(wiring)만 담당
+internal/
+  domain/                                # 순수 Go. 외부 패키지 import 금지
+  usecase/                               # 애플리케이션 서비스 + 포트(interface) 정의
+  infrastructure/
+    postgres/                            # 리포지토리 구현체 (pgx + sqlc)
+    web/                                 # echo 핸들러, 미들웨어, DTO
+    sse/                                 # Broadcaster 구현체
+  config/                                # 환경설정 로딩
+docs/                                    # sqlc/swag 생성 산출물 포함
+db/                                      # 마이그레이션, sqlc 쿼리 소스
+```
+
+> CLAUDE.md에는 `adapter/postgres`, `adapter/http`라는 이름이 나오지만 실제 패키지 경로는
+> `infrastructure/postgres`, `infrastructure/web`입니다. 이 문서에서는 실제 경로를 기준으로 설명합니다.
+
+**의존 방향은 항상 안쪽을 향합니다**: `web`/`postgres`/`sse` → `usecase` → `domain`.
+`domain`은 `errors`, `time` 등 표준 라이브러리 외에는 아무것도 import하지 않습니다
+(`internal/domain/errors.go`, `optional.go` 참고). `usecase`는 리포지토리/브로드캐스터를
+인터페이스(`internal/usecase/port.go`)로만 알고, 구현은 `infrastructure/*`에서 주입됩니다.
+
+## 2. Domain 계층
+
+### 2.1 ID 타입
+
+모든 엔티티 ID는 `string` 기반 named type (`internal/domain/id.go`)입니다.
+`uuid.NewString()`으로 생성하고 캐스팅해서 사용합니다 (`domain.VisitID(s.uuidFn())`).
+새 엔티티를 추가할 때 `string` 원시 타입을 그대로 노출하지 말고 여기에 named type을 추가하세요.
+
+### 2.2 Optional[T]
+
+"필드가 없음"을 포인터의 암묵적 관례 대신 `domain.Optional[T]` (`internal/domain/optional.go`)로
+명시적으로 표현합니다.
+
+```go
+badge.AssignedGroupID Optional[GroupID]
+
+groupID, ok := badge.AssignedGroupID.Value()  // 읽기
+badge.AssignedGroupID = domain.Some(groupID)  // 설정
+badge.AssignedGroupID = domain.None[domain.GroupID]()  // 미지정
+```
+
+Postgres 매핑 시 `pgtype.Text{Valid: bool}` ↔ `Optional[T]` 변환은 리포지토리 계층
+(`mapBadge` 같은 헬퍼)에서 담당합니다. `domain` 패키지가 `pgtype`을 알아서는 안 됩니다.
+
+### 2.3 불변식은 도메인 메서드에
+
+상태 전이 로직은 구조체 메서드로 구현하고, 실패 시 `errors.go`에 정의된 sentinel error를
+반환합니다.
+
+```go
+func (t *Track) StartVisit(visitID VisitID) error
+func (g *Group) MarkVisitStarted(cornerID CornerID) error
+func (v *Visit) Complete(now time.Time) error
+```
+
+usecase 계층은 이 메서드들을 호출만 하고, 상태를 직접 조작하지 않습니다
+(`internal/usecase/visit.go` 참고).
+
+### 2.4 Sentinel error 컨벤션
+
+- 모든 도메인 에러는 `internal/domain/errors.go`에 `var Err... = errors.New(...)`로 선언합니다.
+- 문자열 비교(`err.Error() == "..."`) 금지. 항상 `errors.Is(err, domain.ErrXxx)` 사용.
+- 추가 데이터(락 해제 시각 등)가 필요한 에러는 별도 struct로 감싸고 `Is(target error) bool`을
+  구현해 `errors.Is`와 호환되게 합니다 (`DeviceLockedError`, `InvalidPinError` 참고).
+- 새 도메인 에러를 추가하면 **반드시** `internal/infrastructure/web/error_handler_middleware.go`의
+  `mapDomainError`에 HTTP 상태코드/에러코드 매핑을 추가해야 합니다. 매핑이 없으면 500으로
+  떨어집니다.
+
+## 3. Usecase 계층
+
+### 3.1 서비스 구조
+
+기능 단위(Visit, Camp, Badge, ...)별로 `XxxService` struct를 두고, 생성자에서 필요한
+포트(리포지토리, `TxManager`, `Broadcaster`, `AuditLogRepository`)를 주입받습니다
+(`internal/usecase/visit.go`의 `VisitService` 참고).
+
+테스트 결정성을 위해 시간/UUID 생성은 필드로 주입 가능하게 만듭니다:
+
+```go
+nowFn  func() time.Time  // 기본값: func() time.Time { return time.Now().UTC() }
+uuidFn func() string     // 기본값: uuid.NewString
+```
+
+새 서비스를 만들 때도 이 패턴을 따라 테스트에서 `nowFn`/`uuidFn`을 오버라이드할 수 있게 하세요.
+
+### 3.2 유스케이스 메서드의 표준 흐름
+
+각 메서드는 대체로 이 순서를 따릅니다:
+
+1. 인증/세션 검증 (토큰 해시 조회 → `IsActive()` 체크)
+2. `tx.RunInTx(ctx, func(ctx) error { ... })` 안에서:
+   - 필요한 엔티티 로드 (`Get`)
+   - nil 체크 → 적절한 sentinel error 반환
+   - 도메인 메서드 호출로 상태 전이
+   - 변경된 엔티티들을 `Save`
+3. 트랜잭션 커밋 **이후**에만:
+   - `recordAuditLog` 호출 (성공/실패 모두 기록)
+   - `broadcaster.Broadcast` 호출
+
+```go
+err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
+    // 로드 → 검증 → 도메인 메서드 → Save
+})
+if err != nil {
+    s.recordAuditLog(ctx, actor, "VISIT_START", ..., false, map[string]any{"error": err.Error()})
+    return nil, err
+}
+s.recordAuditLog(ctx, actor, "VISIT_START", ..., true, map[string]any{...})
+_ = s.broadcaster.Broadcast(ctx, campID, EventXxxUpdated, "camp")
+return result, nil
+```
+
+**절대 트랜잭션 함수 내부에서 `Broadcast`를 호출하지 마세요.** 롤백된 변경이 클라이언트에
+푸시되면 안 됩니다 (기술설계 §SSE 원칙). `Broadcast` 에러는 `_ =`로 무시합니다 — 실시간 알림
+실패가 비즈니스 트랜잭션 자체를 실패시켜서는 안 되기 때문입니다.
+
+### 3.3 포트(인터페이스) 정의 위치
+
+모든 리포지토리/브로드캐스터/쿼리어 인터페이스는 `internal/usecase/port.go` 한 곳에 모아
+정의합니다. 새 엔티티를 추가하면 여기에 `XxxRepository` 인터페이스를 추가하고, 구현체는
+`internal/infrastructure/postgres/xxx_repo.go`에 작성합니다.
+
+리포지토리 메서드는 최소 집합만 정의합니다 (`Get`, `Save`, 필요한 `ListXxx`류). 범용
+`Update`/`Delete`를 미리 만들어두지 않고, 실제로 필요한 usecase가 생겼을 때 추가합니다.
+
+### 3.4 이벤트/브로드캐스트
+
+`NotificationEvent` 상수와 scope 문자열(`"camp"`, `"track:"+id`)은 `port.go`에 정의되어
+있습니다. 새 이벤트를 추가할 때:
+- SSE 페이로드는 항상 **풀 스냅샷**이지 델타가 아닙니다 (CLAUDE.md, 기술설계 원칙).
+- scope는 `"camp"`(캠프 전체 구독자) 또는 `"track:{id}"`(특정 트랙 구독자) 형태를 따릅니다.
+
+## 4. Infrastructure 계층
+
+### 4.1 Postgres 리포지토리
+
+- SQL은 직접 작성하지 않고 [sqlc](https://sqlc.dev)로 생성된 `internal/infrastructure/postgres/db`
+  패키지(`Queries`, `*Params`, 모델 struct)를 사용합니다. 쿼리 소스는 `backend/db/`에 있습니다.
+- 리포지토리 struct는 `*pgxpool.Pool`을 들고, `queries(ctx)` 헬퍼로 트랜잭션 유무에 따라
+  `db.New(tx)` 또는 `db.New(pool)`을 선택합니다:
+
+```go
+func (r *pgBadgeRepository) queries(ctx context.Context) *db.Queries {
+    if tx := ExtractTx(ctx); tx != nil {
+        return db.New(tx)
+    }
+    return db.New(r.pool)
+}
+```
+
+  새 리포지토리를 추가할 때 이 헬퍼를 그대로 복사해서 씁니다. `ExtractTx`
+  (`tx_manager.go`)는 `TxManager.RunInTx`가 context에 심어둔 `pgx.Tx`를 꺼냅니다.
+
+- `pgx.ErrNoRows`는 항상 `(nil, nil)`로 변환합니다 — "존재하지 않음"을 에러가 아니라 nil
+  반환으로 표현하고, usecase 계층에서 nil 체크로 sentinel error를 던집니다.
+- DB row ↔ domain 구조체 매핑은 `mapXxx(row db.Xxx) *domain.Xxx` 형태의 비공개 함수로
+  분리합니다 (`mapBadge` 참고). `pgtype.Text` 등 DB 전용 타입은 이 매핑 함수 밖으로 나가지
+  않습니다.
+- 벌크 저장(`SaveBulk`)은 이미 트랜잭션 안이면 그 트랜잭션을 재사용하고, 아니면 자체
+  트랜잭션을 새로 열어 원자성을 보장합니다 (`badge_repo.go`의 `SaveBulk` 참고).
+
+### 4.2 Web (echo) 핸들러
+
+- 라우트는 `internal/infrastructure/web/router.go` 한 곳에서 등록합니다. 핸들러 그룹은
+  `Handlers` struct 필드로 관리하고, `nil` 체크(`if h.Camp != nil`)로 옵션 등록 — 이는 통합
+  테스트에서 일부 핸들러만 wiring할 때 nil panic을 피하기 위함입니다.
+- 인증 요구 수준별로 라우트 그룹을 나눕니다: 공개(`v1`), 관리자(`admin` — `AdminAuthMiddleware`),
+  트랙/진행자(`track` — `TrackAuthMiddleware`).
+- 에러 처리는 핸들러가 아니라 `ErrorHandler()` 미들웨어(`error_handler_middleware.go`)가
+  중앙에서 담당합니다. 핸들러는 usecase 에러를 그대로 리턴하면 됩니다 — 직접 `c.JSON`으로
+  에러 응답을 만들지 마세요. `echo.HTTPError`(바인딩/검증 실패)와 domain sentinel error를
+  구분해서 처리합니다.
+- 응답 DTO는 `api_dtos.go`, `auth_dtos.go`, `report_dtos.go` 등 기능별 파일에 모읍니다.
+  API 계약(`api/openapi.yaml`)과 필드명이 1:1로 대응해야 합니다 — 이름이 어긋나면
+  `workflow/Collaborate.md` 프로토콜 위반입니다.
+
+### 4.3 SSE Broadcaster
+
+`internal/infrastructure/sse/broadcaster.go`가 `usecase.Broadcaster` 인터페이스를 구현합니다.
+usecase는 이 구현을 모르고 인터페이스로만 호출하므로, 브로드캐스터 구현을 교체해도(예: Redis
+pub/sub로 전환) usecase 코드는 변경되지 않습니다.
+
+## 5. 인증
+
+- 모든 토큰(진행자 트랙 PIN 세션, 기기 신뢰 토큰, 관리자 access/refresh)은 **opaque token**이며
+  JWT가 아닙니다. DB에는 해시(`hashSHA256`, `internal/usecase/utils.go`)만 저장합니다. 이는
+  확정된 설계 결정이며 재검토 대상이 아닙니다.
+- 리포지토리 조회는 항상 `GetByTokenHash`/`GetByAccessTokenHash` 형태 — 평문 토큰을 저장하거나
+  DB에서 평문으로 비교하지 않습니다.
+
+## 6. 테스트
+
+- Domain 계층 테스트는 `domain_test` 외부 패키지로 작성하고(`camp_test.go`,
+  `group_test.go` 등), `t.Run`으로 서브테스트를 나눕니다. 외부 의존성 없이 순수 struct/메서드
+  호출만으로 작성 가능해야 합니다 — 이게 안 되면 도메인 로직이 usecase로 새어나간 신호입니다.
+- Usecase 테스트는 `port.go`의 인터페이스를 in-memory/mock 구현으로 만족시키고,
+  `nowFn`/`uuidFn`을 고정값으로 주입해 결정적으로 만듭니다.
+- 실행:
+
+```bash
+cd backend
+go test ./...                                   # 전체
+go test ./internal/domain/...                   # 패키지 단위
+go test ./internal/domain/... -run TestCampActivate  # 단일 테스트
+gofmt -w . && go vet ./...                       # 커밋 전
+```
+
+## 7. 새 유스케이스 추가 체크리스트
+
+1. `docs/domain-model.md`에 도메인 개념이 이미 있는지 확인 (없으면 도메인 모델 먼저 갱신).
+2. `internal/domain/`에 필요한 ID 타입(`id.go`), 상태 전이 메서드, sentinel error(`errors.go`) 추가.
+3. `internal/usecase/port.go`에 리포지토리 인터페이스 추가/확장.
+4. `internal/infrastructure/postgres/`에 sqlc 쿼리 + 리포지토리 구현체 + `mapXxx` 매핑 함수 추가.
+5. `internal/usecase/xxx.go`에 서비스 메서드 추가 — 트랜잭션 내부 로드/검증/도메인호출/Save,
+   트랜잭션 밖에서 audit log + broadcast.
+6. `internal/infrastructure/web/error_handler_middleware.go`의 `mapDomainError`에 새 에러 매핑 추가.
+7. `internal/infrastructure/web/`에 핸들러 + DTO 추가, `router.go`에 라우트 등록.
+8. `api/openapi.yaml` 갱신 (`workflow/Collaborate.md` 프로토콜).
+9. domain 단위 테스트 + usecase 테스트 작성, `go test ./...` 통과 확인.

--- a/backend/docs/artifacts/plan/backend_issues_plan_20260710.md
+++ b/backend/docs/artifacts/plan/backend_issues_plan_20260710.md
@@ -1,0 +1,135 @@
+# 백엔드 이슈 #32, #30 해결 계획
+
+## 1. 유즈케이스 우선 정의
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-1: 기기 등록 상태 자체 조회 (#32) | 대기 중(PENDING)인 기기가 자신의 승인 상태(APPROVED/REJECTED 등)를 풀링하여 알아냅니다. | **프로덕션 핵심 로직** |
+| **P0** | UC-2: 트랙 교체 시 기존 기기 세션 승계 (#30) | 관리자가 트랙을 교체할 때, 기존 트랙 세션을 가진 진행자 기기가 재로그인(PIN) 없이 새 트랙 세션으로 전환됩니다. | **프로덕션 핵심 로직** |
+
+---
+
+## 2. 객체 중심 설계 (Object-Oriented Design)
+
+### 2.1 이슈 #32 (기기 상태 조회)
+
+**Domain / Usecase Layer**
+```go
+package usecase
+
+// DeviceRegistrationService는 기기 등록 관련 비즈니스 흐름을 제어합니다.
+type DeviceRegistrationService interface {
+    // GetMyRegistrationStatus는 디바이스 토큰(PENDING 포함)을 기반으로 현재 기기의 등록 상태를 반환합니다.
+    GetMyRegistrationStatus(ctx context.Context, deviceToken string) (*domain.DeviceRegistrationStatus, error)
+}
+```
+
+**Adapter (HTTP) Layer**
+- `GET /device-registrations/me` 핸들러 추가
+- PENDING 상태의 디바이스 토큰도 접근할 수 있도록 보안 미들웨어 분기(DeviceTokenAuth)
+
+### 2.2 이슈 #30 (트랙 교체 시 세션 승계)
+
+**Domain / Usecase Layer**
+```go
+package usecase
+
+type FacilitatorAuthService interface { 
+    // MigrateSession은 이전 세션 토큰을 검증하고, 승계 대상 트랙(MigrationTarget)에 대한 새로운 세션을 생성하여 LogIn과 동일한 형태의 결과를 반환합니다.
+    MigrateSession(ctx context.Context, oldSessionToken string) (*usecase.TrackLoginResult, error)
+}
+
+type AdminTrackService interface { 
+    // ReplaceTrack은 기존 트랙을 삭제하고 새 코너에 트랙을 생성하며, 기존 세션들의 MigrationTarget을 갱신하는 모든 작업을 **단일 트랜잭션**으로 처리합니다.
+    ReplaceTrack(ctx context.Context, oldTrackId string, newCornerId string) (*domain.Track, error)
+}
+```
+*참고: 컨트롤러(HTTP 핸들러)에서 생성/삭제/마이그레이션을 각각 조합하면 트랜잭션 원자성이 깨집니다. 따라서 관리자 유즈케이스인 `ReplaceTrack` 내부에서 트랜잭션(tx)을 열고, 새 트랙 생성 -> 기존 트랙 삭제 -> 기존 세션 조회 및 마이그레이션 타겟 설정 -> DB 커밋 -> SSE(`track_replaced`) 발송을 한 번에 처리합니다.*
+
+**Adapter (SSE & HTTP) Layer**
+- OpenAPI `SseEvent` enum에 `track_replaced` 추가
+- `POST /tracks/{oldTrackId}/migrate-session` 엔드포인트 추가 (기존 TrackAuth 토큰 필요)
+
+---
+
+## 3. 아키텍처 원칙 명시
+
+- **Domain Layer**: 외부 라이브러리 참조 없이 순수 Go로 작성. 비즈니스 룰(토큰 상태 전이, 세션 승계 유효기간 등) 검증.
+- **Service(Usecase) Layer**: 트랜잭션 경계를 관리하고, 도메인 객체의 상태를 업데이트한 후 SSE Broadcaster를 통해 알림 이벤트를 발행.
+- **API (OpenAPI)**: 프론트엔드와 백엔드의 계약인 `api/openapi.yaml`을 먼저 갱신.
+
+---
+
+## 4. 계층별 책임 분리
+
+### Domain Layer
+```go
+// 도메인 모델 확장을 고려 (진행자 세션 승계)
+type FacilitatorSession struct {
+    // ...
+    MigrationTargetTrackID Optional[TrackID] // 트랙 교체 시 이동할 새 트랙 ID
+}
+
+func (s *FacilitatorSession) SetMigrationTarget(newTrackId TrackID) {
+    s.MigrationTargetTrackID = Some(newTrackId)
+}
+```
+
+### Infrastructure Layer (HTTP Handler)
+```go
+// UC-1 (이슈 #32) 핸들러
+func (h *DeviceRegistrationHandler) GetMe(w http.ResponseWriter, r *http.Request) {
+    // HTTP 헤더에서 디바이스 토큰 추출
+    // usecase.GetMyRegistrationStatus 호출
+    // JSON 응답
+}
+
+// UC-2 (이슈 #30) 핸들러
+func (h *TrackHandler) MigrateSession(w http.ResponseWriter, r *http.Request) {
+    // 헤더에서 기존 트랙 세션 토큰 추출, Path에서 oldTrackId 추출
+    // usecase.MigrateSession 호출
+    // 새 세션 정보 응답
+}
+```
+
+---
+
+## 5. 구현 단계 (Implementation Phases)
+
+### Phase 1: OpenAPI 명세 업데이트 (예상 소요: 1시간)
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| 1-1 | `GET /device-registrations/me` 추가 | `api/openapi.yaml` |
+| 1-2 | `POST /tracks/{id}/migrate-session` 추가 | `api/openapi.yaml` |
+| 1-3 | SSE 이벤트 목록에 `track_replaced` 추가 | `api/openapi.yaml` |
+
+### Phase 2: 도메인 & 유즈케이스 확장 (예상 소요: 2시간)
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| 2-1 | `FacilitatorSession` 도메인에 승계 대상 트랙(MigrationTargetTrackID) 로직 추가 | `backend/internal/domain/facilitator_session.go` |
+| 2-2 | `DeviceRegistrationService`에 GetMe 메서드 추가 | `backend/internal/usecase/...` |
+| 2-3 | `FacilitatorAuthService`에 `MigrateSession` 메서드 추가 | `backend/internal/usecase/...` |
+| 2-4 | `AdminTrackService`의 `ReplaceTrack` 메서드 내에 단일 트랜잭션으로 세션 승계 로직 추가 | `backend/internal/usecase/...` |
+
+### Phase 3: HTTP 어댑터 구현 (예상 소요: 2시간)
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| 3-1 | `GET /device-registrations/me` 라우팅 및 핸들러 구현 | `backend/internal/adapter/http/...` |
+| 3-2 | `POST /tracks/{id}/migrate-session` 라우팅 및 핸들러 구현 | `backend/internal/adapter/http/...` |
+| 3-3 | 트랙 교체 비즈니스 로직(PUT)에서 `track_replaced` SSE 발송 로직 추가 | `backend/internal/adapter/http/...` |
+
+---
+
+## 6. 검증 체크리스트
+
+### 6.1 아키텍처 및 API 검증
+- [x] `api/openapi.yaml`에 추가된 명세가 기존 인증(Security) 규칙을 준수하는가?
+- [x] Domain 영역에서 외부 인프라스트럭처 패키지(DB, HTTP)를 참조하지 않는가?
+- [x] 기존 로직(트랙 삭제 등)의 동작을 손상시키지 않고 확장되었는가?
+
+### 6.2 기능(유즈케이스) 검증
+- [x] (UC-1) PENDING 상태의 디바이스 토큰으로 `/device-registrations/me` 호출 시 200 OK와 상태값이 반환되는가?
+- [x] (UC-1) APPROVED 이후에도 정상 조회되는가?
+- [x] (UC-2) 트랙 교체 시 이전 기기에 `track_replaced` SSE 알림이 도달하는가?
+- [x] (UC-2) 이전 기기의 유효한 토큰으로 `migrate-session`을 호출했을 때 새 트랙 세션 토큰이 발급되는가?
+- [x] (UC-2) 이미 만료되거나 관련 없는 트랙 세션 토큰으로 마이그레이션 시 401/403 오류가 반환되는가?

--- a/backend/docs/artifacts/report/Phase_1_2_completion_report_20260711.md
+++ b/backend/docs/artifacts/report/Phase_1_2_completion_report_20260711.md
@@ -1,0 +1,27 @@
+# Phase 1 & 2 Completion Report
+
+## 1. 개요
+* **진행 완료 항목**: `missing_features_report_20260711.md` 에 기재된 미구현/누락 핸들러 전체에 대한 Usecase 구현 및 Handler 연동을 완료하였습니다.
+* **추가 반영 사항**: 기획 스펙 변경에 따라 "중복 방문 금지의 재방문 승인" 기능 삭제, 배지 데이터 Export 시 CSV 대신 JSON 반환으로 변경 등 사용자 요구사항을 모두 반영하였습니다.
+
+## 2. 작업 상세 내용
+
+### Phase 1: 기본 도메인(캠프/코너/트랙/조) 누락 항목 완료
+- **`GetCorner` (CornerHandler)**: `CornerService.GetCorner` 구현, DB 매핑 및 NotFound 에러 404 연동 완료.
+- **`ListGroupVisits` (GroupHandler)**: `db/query.sql` 에 `ListVisitsByGroup` 쿼리 추가, sqlc 기반 Repository 연동 및 `GroupService.ListGroupVisitDetails` 구현. `GroupHandler` 에서 DTO 매핑하여 반환.
+- **`GetCurrentVisit` (VisitHandler)**: `VisitService.GetCurrentVisit` 구현. 인증 토큰으로부터 TrackID를 도출하여 현재 진행 중인 Visit 반환. (없을 시 404 리턴).
+
+### Phase 2: 핵심 도메인 로직(방문/배지) 완성
+- **`AssignBadge` / `ScanAssignBadge` (BadgeHandler)**: 
+  - 관리자 앱(수동 배정 및 스캔 기반 배정)에서 미배정 배지를 할당하고 조(Group)를 즉시 생성하는 흐름 연동. 
+  - `GroupService.RegisterBadge` 유즈케이스에 배지 ID 및 QR Payload 조회를 연동하도록 Handler 로직 수정.
+- **`ExportCurrentReport` (ReportHandler)**: 
+  - 관리자 앱에서 리포트 다운로드 시, CSV가 아닌 JSON 원본 형식으로 반환하도록 변경 (클라이언트 앱에서 PDF 인쇄 등 렌더링 목적 달성을 위해 바이너리/JSON payload 유지).
+
+## 3. 테스트 및 검증
+- 모든 패키지에 대해 `go test ./...` 통과 확인.
+- DB 쿼리 생성(`make sqlc`) 정상 동작 확인.
+- DI 설정(`cmd/server/main.go`) 검증 및 의존성 주입 완료.
+
+## 4. 향후 계획 (Next Steps)
+이제 Phase 3(보안 및 권한)와 Phase 4(실시간 통신 SSE/웹소켓) 기능 고도화를 진행할 준비가 되었습니다. 지시가 있다면 바로 진행하겠습니다.

--- a/backend/docs/artifacts/report/missing_features_report_20260711.md
+++ b/backend/docs/artifacts/report/missing_features_report_20260711.md
@@ -1,0 +1,76 @@
+# Cornermon 백엔드 기능 누락 및 미완성 항목 조사 보고서
+
+## 1. 개요
+* **목적**: 기획 및 설계 문서(`docs/domain/domain-model.md`), API 명세(`api/openapi.yaml`)와 현재 Go 백엔드 구현체 간의 차이를 전수조사하여, 라우터에 매핑되어 있으나 실제 동작하지 않는 미구현(Stub/Mock) 기능을 식별하고 조치 계획을 수립합니다.
+* **배경**: Swaggo 마이그레이션(`openapi_to_swaggo_plan_20260710.md`) 과정에서 명세 일치(48개 엔드포인트)를 목적으로 핸들러 구조만 생성(Scaffold)하고, 실제 Usecase 및 비즈니스 로직 연동 단계(Phase D)가 온전히 수행되지 않아 상당수의 핵심 API가 `501 Not Implemented` 또는 더미 데이터를 반환하는 상태로 방치되었습니다.
+
+---
+
+## 2. 미완성/누락 기능 상세 목록
+
+현재 라우터(`router.go`)에 등록은 되어 있으나, 실제 핸들러 구현이 비어있는 엔드포인트 목록입니다.
+
+### 2.1. 코너 단건 조회 (`GET /corners/{id}`)
+* **담당 핸들러**: `CornerHandler.GetCorner`
+* **현재 상태**: `501 Not Implemented` 반환.
+* **누락 원인**: 최초 Usecase 서비스 설계 및 `missing_usecases_plan_20260710.md`에서 코너의 전체 목록 조회(`ListCorners`) 및 추가/수정/삭제만 다루고 단건 조회(`GetCorner`)를 유즈케이스 목록에서 빠뜨렸습니다.
+* **필요 조치**: 
+  - `CornerService`에 `GetCorner` 유즈케이스 추가.
+  - `CornerRepository` 포트에 `Get` 메서드 추가 및 Postgres 레포지토리 구현.
+  - 핸들러 연동.
+
+### 2.2. 조(Group)별 방문 기록 조회 (`GET /groups/{id}/visits`)
+* **담당 핸들러**: `GroupHandler.ListGroupVisits`
+* **현재 상태**: `501 Not Implemented` 반환.
+* **누락 원인**: 조별 통계 및 순회 타임라인 조회를 위한 Usecase 및 Repository 쿼리가 설계되지 않았습니다.
+* **필요 조치**:
+  - 특정 조의 모든 방문 기록(`domain.Visit`)을 시작 시각 순으로 정렬하여 조회하는 유즈케이스 구현.
+  - `VisitRepository` 또는 `ReportQuerier`에 특정 조 기준 조회 포트 추가.
+
+### 2.3. 트랙의 현재 방문 조회 (`GET /tracks/{trackId}/visits/current`)
+* **담당 핸들러**: `VisitHandler.GetCurrentVisit`
+* **현재 상태**: `501 Not Implemented` 반환.
+* **누락 원인**: 진행자가 현재 자신의 트랙에서 학습 중인 조의 상태(`IN_PROGRESS` 방문 엔티티)를 실시간으로 확인하는 API이나, 방문의 시작/종료 API만 구현하고 현재 진행 중인 상태 조회 로직이 Usecase 및 핸들러에서 누락되었습니다.
+* **필요 조치**:
+  - `VisitService` 또는 신규 Usecase를 통해 해당 트랙에 활성화된(종료되지 않은) 방문 레코드를 단건 조회하는 로직 구현.
+
+### 2.4. 수동 배지 등록/배정 API (`POST /badges/{id}/register`, `POST /badges/scan-register`)
+* **담당 핸들러**: `BadgeHandler.AssignBadge`, `BadgeHandler.ScanAssignBadge`
+* **현재 상태**: `501 Not Implemented` 반환.
+* **누락 원인**: 미배정 QR 배지를 조와 매핑하여 조(Group)를 활성화하는 핵심 비즈니스 규칙이지만, Usecase 계획서에서 배지 벌크 생성(`IssueInitialBadges`) 및 조회만 다루고 실제 배정(Assign) 흐름이 반영되지 않았습니다.
+* **필요 조치**:
+  - 배지 ID 혹은 QR 페이로드를 읽어 특정 조(Group)에 배지를 매핑(할당)하고 배지 상태를 `ASSIGNED`로 변경하는 Usecase 로직 추가.
+  - 중복 등록 방지 등 불변식 검증 추가.
+
+### 2.5. 현재 리포트 CSV 내보내기 (`GET /reports/current/export`)
+* **담당 핸들러**: `ReportHandler.ExportCurrentReport`
+* **현재 상태**: **하드코딩된 Mock CSV 반환** (`CampID,TotalGroups,FinishedGroups\n...`)
+* **누락 원인**: 보고서 조회 기능(`QueryCampReport`)은 구현되었으나, 이를 실제 CSV 포맷으로 마샬링(직렬화)하여 HTTP 응답 스트림으로 내보내는 로직이 누락되어 더미 데이터를 반환하도록 구현되었습니다.
+* **필요 조치**:
+  - `ReportQuerier`를 통해 활성 캠프의 리포트 데이터를 조회한 후, `encoding/csv` 패키지를 사용해 동적으로 CSV 파일을 생성하여 스트림으로 응답하도록 수정.
+
+---
+
+## 3. 삭제 및 수정 완료 사항 (2026-07-11 완료)
+
+### 3.1. 중복 방문 예외 강제 승인 (`POST /visits/exception-approve`)
+* **기존 기획**: 진행 중인 방문이 차단되거나 앱 오류로 이미 스캔된 방문 처리가 필요할 때 관리자가 강제로 예외를 인정하는 API.
+* **조치 내용**: **해당 유즈케이스 삭제 결정에 따라 전방위 제거 완료**.
+  - `backend/internal/infrastructure/web/router.go`에서 해당 라우트 제거.
+  - `backend/internal/infrastructure/web/visit_handler.go`에서 `ExceptionApprove` 핸들러 및 관련 DTO 삭제.
+  - `docs/domain/domain-model.md` 및 `docs/domain/analytics-model.md` 내 예외 승인 관련 서술 및 규칙 제거.
+  - `api/openapi.yaml`에서 `/visits/exception-approve` 명세 완전 삭제.
+  - `swag init`을 실행하여 swagger API 명세서 재생성 및 검증 완료.
+
+---
+
+## 4. 향후 작업 로드맵
+
+위 미구현 사항들을 완결 짓기 위해 다음과 같은 순서로 작업을 추진할 것을 권장합니다.
+
+1. **[Phase 1] 리소스 조회 및 CSV 다운로드 구현**:
+   - 비교적 단순한 단건 조회(`GetCorner`) 및 CSV 익스포트(`ExportCurrentReport`) 수정.
+2. **[Phase 2] 핵심 도메인 로직(방문/배지) 완성**:
+   - `GetCurrentVisit` 구현.
+   - `AssignBadge`/`ScanAssignBadge` 유즈케이스와 도메인 상태 변경 흐름 완성.
+   - `ListGroupVisits` 타임라인 조회 구현.


### PR DESCRIPTION
### 변경 요약
- 백엔드 미구현 기능 현황 분석 보고서(`missing_features_report_20260711.md`) 추가
- 백엔드 이슈 대응 계획서(`backend_issues_plan_20260710.md`) 및 Phase 1/2 완료 보고서(`Phase_1_2_completion_report_20260711.md`) 추가
- 프로젝트 신규 참여자를 위한 개발자 가이드(`DEVELOPER_GUIDE.md`) 추가

### 동기 및 이유
- Swaggo 마이그레이션 이후 더미 데이터 또는 501 에러를 응답하는 미구현 기능(코너 조회, 조별 방문, 트랙 현재 방문, 수동 배지 등록, 리포트 CSV 내보내기)의 구현 현황 및 요구사항과 실제 코드의 갭을 분석하고 해결책을 문서화
- 개발 가이드를 작성하여 팀원들이 로컬 환경에서 원활히 개발 및 빌드할 수 있도록 유도

### 종료 조건 증명
- 문서 파일 4종이 `backend/docs/` 및 `backend/docs/artifacts/` 하위에 올바르게 배치됨