### PR TITLE
fix: 감사 로그 필터 및 복합 커서 페이지네이션 완성

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2702,7 +2702,8 @@ paths:
       description: |
         인증 성공/실패, 스캔, 규칙 변경, 기기 승인/철회, 트랙 관리 등의 감사 로그를 조회한다.
         메시지 통신 내역은 감사 대상에서 제외.
-        필터링·정렬을 쿼리 파라미터로 지정해 서버에서 처리한다.
+        필터링을 쿼리 파라미터로 지정해 서버에서 처리하며,
+        응답은 최신순 `(occurredAt, id)` 복합 커서로 페이지네이션한다.
       security:
         - AdminAuth: []
       parameters:
@@ -2722,18 +2723,6 @@ paths:
             type: string
             enum: [success, failure]
           description: "성공/실패 필터"
-        - name: sort
-          in: query
-          schema:
-            type: string
-            enum: [occurredAt, actor, action]
-          description: "정렬 기준"
-        - name: order
-          in: query
-          schema:
-            type: string
-            enum: [asc, desc]
-          default: desc
         - name: limit
           in: query
           schema:
@@ -2744,8 +2733,7 @@ paths:
           in: query
           schema:
             type: string
-            format: date-time
-          description: "커서 기반 페이지네이션: 이 시각 이전 항목 조회"
+          description: "이전 응답의 불투명 nextCursor"
       responses:
         "200":
           description: "감사 로그 목록"
@@ -2758,8 +2746,16 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/AuditLog'
-                  hasMore:
-                    type: boolean
+                  nextCursor:
+                    type: string
+                    description: "다음 페이지가 있을 때만 반환되는 불투명 커서"
+                required: [logs]
+        "400":
+          description: "잘못된 result, limit 또는 before"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         "401":
           $ref: '#/components/responses/Unauthorized'
         "403":

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -204,8 +204,15 @@ WHERE g.camp_id = $1;
 
 -- name: ListAuditLogs :many
 SELECT * FROM audit_logs
-ORDER BY occurred_at DESC
-LIMIT $1 OFFSET $2;
+WHERE (sqlc.narg(actor)::VARCHAR IS NULL OR actor ILIKE '%' || sqlc.narg(actor)::VARCHAR || '%')
+  AND (sqlc.narg(action)::VARCHAR IS NULL OR action = sqlc.narg(action)::VARCHAR)
+  AND (sqlc.narg(success)::BOOLEAN IS NULL OR success = sqlc.narg(success)::BOOLEAN)
+  AND (
+    sqlc.narg(before_occurred_at)::TIMESTAMPTZ IS NULL
+    OR (occurred_at, id) < (sqlc.narg(before_occurred_at)::TIMESTAMPTZ, sqlc.narg(before_id)::VARCHAR)
+  )
+ORDER BY occurred_at DESC, id DESC
+LIMIT sqlc.arg(page_limit);
 
 -- name: ListAdminSessionsByAdmin :many
 SELECT * FROM admin_sessions

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -218,6 +218,8 @@ COMMENT ON COLUMN audit_logs.id IS '감사 로그 고유 식별자';
 COMMENT ON COLUMN audit_logs.actor IS '행위자 (관리자 ID, 진행자 ID 등)';
 COMMENT ON COLUMN audit_logs.action IS '수행한 동작 (예: APPROVED_DEVICE, FAILED_PIN 등)';
 COMMENT ON COLUMN audit_logs.target IS '동작의 대상 (기기 ID, 트랙 ID 등)';
+CREATE INDEX idx_audit_logs_occurred_at_id ON audit_logs (occurred_at DESC, id DESC);
+CREATE INDEX idx_audit_logs_action_success_occurred_at_id ON audit_logs (action, success, occurred_at DESC, id DESC);
 COMMENT ON COLUMN audit_logs.success IS '동작 성공 여부';
 COMMENT ON COLUMN audit_logs.occurred_at IS '이벤트 발생 시간';
 COMMENT ON COLUMN audit_logs.metadata IS '이벤트와 관련된 추가 정보 (JSON)';

--- a/backend/docs/artifacts/plan/20260713_issue_48_audit_filters_cursor_plan_.md
+++ b/backend/docs/artifacts/plan/20260713_issue_48_audit_filters_cursor_plan_.md
@@ -1,0 +1,31 @@
+# GitHub Issue #48 — 감사 로그 필터·커서 페이지네이션 구현 계획
+
+> 이슈: https://github.com/lsjtop10/cornermon/issues/48
+
+## 구현 현황
+
+- [x] nullable actor/action/success 필터를 DB query에 적용
+- [x] `(occurred_at, id)` 내림차순 복합 keyset 조건 적용
+- [x] 조회 인덱스와 sqlc 원본/생성물 동기화
+- [x] `limit+1` 기반 next cursor 계산
+- [x] base64url JSON cursor codec와 query parameter 검증
+- [x] Swagger 및 OpenAPI 3.0 응답을 `{logs, nextCursor}`로 동기화
+- [x] handler 필터/경계/cursor 단위 테스트 추가
+- [x] repository 장애에 `errs.Wrap` 적용 및 하위 계층 무로깅 확인
+
+## 자체 리뷰
+
+- 커서에는 동일 시각 레코드의 안정적 tie-breaker인 ID가 포함된다.
+- SQL 정렬과 커서 비교가 모두 `occurred_at DESC, id DESC`로 일치한다.
+- actor 부분 검색, action 정확 일치, success nullable 조건은 전체 조회 후 필터링하지 않는다.
+- 공개 계약에 구현되지 않은 임의 정렬 파라미터를 남기지 않아 SQL 문자열 삽입 경로가 없다.
+- 원본 `query.sql`에서 sqlc 생성물을 재생성해 수동 생성물 편집 불일치를 제거했다.
+
+## 검증 체크리스트
+
+- [x] 필터가 전체 데이터가 아닌 DB query에 적용된다.
+- [x] 동일 timestamp 로그도 페이지 간 중복·누락되지 않는다.
+- [x] cursor는 opaque base64url 값이다.
+- [x] malformed cursor/잘못된 result/limit은 400이다.
+- [x] repository 오류는 `errs.Wrap`되고 하위 계층에서 직접 로그하지 않는다.
+- [x] Swagger 응답이 `{logs, nextCursor}` 형태와 일치한다.

--- a/backend/internal/infrastructure/web/audit_handler_test.go
+++ b/backend/internal/infrastructure/web/audit_handler_test.go
@@ -1,0 +1,105 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type auditLogQuerierStub struct {
+	query usecase.AuditLogQuery
+	page  *usecase.AuditLogPage
+}
+
+func (s *auditLogQuerierStub) List(_ context.Context, query usecase.AuditLogQuery) (*usecase.AuditLogPage, error) {
+	s.query = query
+	return s.page, nil
+}
+
+func TestListAuditLogsShoudApplyFiltersAndCursorWhenValid(t *testing.T) {
+	// arrange
+	e := echo.New()
+	cursor := usecase.AuditLogCursor{OccurredAt: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC), ID: "audit-2"}
+	stub := &auditLogQuerierStub{page: &usecase.AuditLogPage{
+		Logs: []*domain.AuditLog{{ID: "audit-1", Actor: "admin-1", Action: "UPDATE_CAMP", Success: true}},
+		NextCursor: domain.Some(cursor),
+	}}
+	req := httptest.NewRequest(http.MethodGet, "/audit-logs?actor=admin&action=UPDATE_CAMP&result=success&limit=25&before="+encodeAuditLogCursor(cursor), nil)
+	rec := httptest.NewRecorder()
+
+	// act
+	err := NewAuditHandler(stub).ListAuditLogs(e.NewContext(req, rec))
+
+	// assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.query.Actor != "admin" || stub.query.Action != "UPDATE_CAMP" || stub.query.Limit != 25 {
+		t.Fatalf("unexpected query: %+v", stub.query)
+	}
+	if stub.query.Success == nil || !*stub.query.Success {
+		t.Fatalf("success filter was not forwarded: %+v", stub.query.Success)
+	}
+	before, ok := stub.query.Before.Value()
+	if !ok || before != cursor {
+		t.Fatalf("cursor was not forwarded: %+v", before)
+	}
+	var response AuditLogPageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Logs) != 1 || response.NextCursor == "" {
+		t.Fatalf("unexpected page response: %+v", response)
+	}
+}
+
+func TestListAuditLogsShoudRejectInvalidParametersWhenMalformed(t *testing.T) {
+	tests := []string{
+		"/audit-logs?limit=0",
+		"/audit-logs?limit=201",
+		"/audit-logs?limit=invalid",
+		"/audit-logs?result=unknown",
+		"/audit-logs?before=not-base64",
+	}
+	for _, target := range tests {
+		t.Run(target, func(t *testing.T) {
+			// arrange
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+
+			// act
+			err := NewAuditHandler(nil).ListAuditLogs(e.NewContext(req, rec))
+
+			// assert
+			httpErr, ok := err.(*echo.HTTPError)
+			if !ok || httpErr.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 HTTP error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAuditLogCursorShoudPreserveTieBreakerWhenRoundTripped(t *testing.T) {
+	// arrange
+	want := usecase.AuditLogCursor{OccurredAt: time.Date(2026, 7, 13, 10, 0, 0, 123, time.UTC), ID: "audit-tie-breaker"}
+
+	// act
+	encoded := encodeAuditLogCursor(want)
+	got, err := decodeAuditLogCursor(encoded)
+
+	// assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("cursor mismatch: got %+v, want %+v", got, want)
+	}
+}

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -114,6 +114,28 @@ type AuditLogRepository interface {
 	Save(ctx context.Context, log *domain.AuditLog) error
 }
 
+type AuditLogQuerier interface {
+	List(ctx context.Context, query AuditLogQuery) (*AuditLogPage, error)
+}
+
+type AuditLogCursor struct {
+	OccurredAt time.Time
+	ID         domain.AuditLogID
+}
+
+type AuditLogQuery struct {
+	Actor   string
+	Action  string
+	Success *bool
+	Before  domain.Optional[AuditLogCursor]
+	Limit   int
+}
+
+type AuditLogPage struct {
+	Logs       []*domain.AuditLog
+	NextCursor domain.Optional[AuditLogCursor]
+}
+
 type NotificationEvent string
 
 const (


### PR DESCRIPTION
## 변경 사항
- 누락된 `AuditLogQuery`/page/cursor usecase 계약을 복구했습니다.
- actor/action/result 필터와 `(occurred_at, id)` keyset 조건을 sqlc 원본에 반영했습니다.
- 조회 인덱스, 요청 경계 검증, opaque cursor 응답 테스트를 추가했습니다.
- OpenAPI와 완료 체크리스트를 동기화했습니다.

## 변경 이유
기존 main은 생성된 repository가 누락된 usecase 타입을 참조해 빌드되지 않았고, SQL 원본은 여전히 OFFSET 방식이라 재생성 시 기능이 유실되는 상태였습니다.

## 종료 조건 증명
- `go test ./...` 통과
- malformed cursor/result/limit 400 테스트
- 필터 전달 및 `(occurredAt, id)` cursor round-trip 테스트
- PR diff: 182 additions / 19 deletions

Closes #48
