### PR TITLE
fix: 컬렉션 및 리포트 캠프 범위 명시화

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1456,29 +1456,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /corners:
+  /camps/{campId}/corners:
     get:
       tags: [B. Camp / Corner / Track]
       summary: "코너 목록 조회"
       description: |
-        현재 선택된 캠프의 코너 목록과 각 코너의 운영 상태를 조회한다.
-        - ADMIN: 전체 코너 목록
-        - TRACK: 자기 코너만
+        URL에 명시된 캠프의 코너 목록과 각 코너의 운영 상태를 조회한다.
       security:
         - AdminAuth: []
-        - TrackAuth: []
+      parameters:
+        - $ref: '#/components/parameters/CampIdPath'
       responses:
         "200":
           description: "코너 목록"
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  corners:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Corner'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Corner'
+
+  /corners:
 
     post:
       tags: [B. Camp / Corner / Track]
@@ -1609,40 +1607,25 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /tracks:
+  /camps/{campId}/tracks:
     get:
       tags: [B. Camp / Corner / Track]
       summary: "전체 트랙 목록 조회"
       description: |
-        현재 선택된 캠프의 전체 트랙 목록 (ACTIVE/DELETED 포함 필터 가능).
-        코너별 그룹핑 형태로 반환.
+        URL에 명시된 캠프의 전체 트랙 목록을 반환한다.
       security:
         - AdminAuth: []
       parameters:
-        - name: sort
-          in: query
-          schema:
-            type: string
-            enum: [cornerId, trackNo, status]
-          description: "정렬 기준"
-        - name: order
-          in: query
-          schema:
-            type: string
-            enum: [asc, desc]
-          description: "정렬 방향"
+        - $ref: '#/components/parameters/CampIdPath'
       responses:
         "200":
           description: "트랙 목록"
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  tracks:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Track'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Track'
 
   /corners/{cornerId}/tracks:
     post:
@@ -1887,48 +1870,27 @@ paths:
                 type: string
                 format: binary
 
-  /groups:
+  /camps/{campId}/groups:
     get:
       tags: [B. Camp / Corner / Track]
       summary: "조 목록 조회"
       description: |
-        현재 선택된 캠프의 조 목록을 조회한다.
-        - ADMIN: 전체 조 목록 (수동 처리 UI에서 조 선택용 포함)
-        - TRACK: 전체 조 목록 (방문 시작 시 조 선택용)
-        
+        URL에 명시된 캠프의 조 목록을 조회한다.
+
         조는 배지 등록 API(`POST /badges/{id}/register` 또는 `POST /badges/scan-register`)를 통해서만 생성된다.
       security:
         - AdminAuth: []
-        - TrackAuth: []
       parameters:
-        - name: filter
-          in: query
-          schema:
-            type: string
-            enum: [all, finished, partial]
-          description: "완주 여부 필터"
-        - name: sort
-          in: query
-          schema:
-            type: string
-            enum: [n, completed, finished]
-        - name: order
-          in: query
-          schema:
-            type: string
-            enum: [asc, desc]
+        - $ref: '#/components/parameters/CampIdPath'
       responses:
         "200":
           description: "조 목록"
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  groups:
-                    type: array
-                    items:
-                      $ref: '#/components/schemas/Group'
+                type: array
+                items:
+                  $ref: '#/components/schemas/Group'
 
   /groups/{id}:
     get:
@@ -2288,7 +2250,7 @@ paths:
         §technical-design.md 2.3의 하이브리드 알림+풀 모델을 따른다 — **이 스트림은 데이터를 나르지 않는다.**
 
         **이벤트 흐름**:
-        1. 화면 진입 시: 클라이언트가 REST로 초기 전체 조회 (`GET /corners`, `GET /groups`, `GET /tracks`,
+        1. 화면 진입 시: 클라이언트가 REST로 초기 전체 조회 (`GET /camps/{campId}/corners`, `GET /camps/{campId}/groups`, `GET /camps/{campId}/tracks`,
            `GET /camps/{id}`, `GET /device-registrations`, `GET /messages/broadcast` 등)를 직접 수행한다.
            서버는 연결 시점에 별도 스냅샷을 push하지 않는다.
         2. 상태 변경마다: `{event: <type>, data: {scope}}` 형태의 알림만 push — 알림을 받으면 그 `scope`에
@@ -2297,9 +2259,9 @@ paths:
         4. 안전망: 알림을 놓쳐도 정합이 깨지지 않도록 대시보드는 30초 주기로 REST 전체 재조회도 병행한다.
 
         **수신 알림 타입 → 재조회 매핑**:
-        - `tracks_updated` (scope: `camp`) → `GET /tracks` — 트랙 생성/삭제/교체
-        - `corners_updated` (scope: `camp`) → `GET /corners` — 코너 규칙 변경, 방문 시작/종료로 인한 코너 운영상태·병목 변화
-        - `groups_updated` (scope: `camp`) → `GET /groups` — 조 순회표 변화(방문 시작/종료)
+        - `tracks_updated` (scope: `camp`) → `GET /camps/{campId}/tracks` — 트랙 생성/삭제/교체
+        - `corners_updated` (scope: `camp`) → `GET /camps/{campId}/corners` — 코너 규칙 변경, 방문 시작/종료로 인한 코너 운영상태·병목 변화
+        - `groups_updated` (scope: `camp`) → `GET /camps/{campId}/groups` — 조 순회표 변화(방문 시작/종료)
         - `camp_updated` (scope: `camp`) → `GET /camps/{id}` — 캠프 시작/종료
         - `messages_changed` (scope: `broadcast`) → `GET /messages/broadcast` — 공지 발송
         - `device_registration_updated` (scope: `camp`) → `GET /device-registrations` — 기기 등록/승인/거절/회수
@@ -2577,7 +2539,7 @@ paths:
   # F. 통계 / 리포트
   # ════════════════════════════════════════════
 
-  /reports/live-summary:
+  /camps/{campId}/reports/live-summary:
     get:
       tags: [F. Reports & Analytics]
       summary: "실시간 스냅샷 요약"
@@ -2587,6 +2549,8 @@ paths:
         SSE `corners_updated`/`groups_updated` 알림 수신 시 재조회 및 대시보드 30초 주기 폴백 재조회에 사용된다.
       security:
         - AdminAuth: []
+      parameters:
+        - $ref: '#/components/parameters/CampIdPath'
       responses:
         "200":
           description: "실시간 요약"
@@ -2616,7 +2580,7 @@ paths:
                         completedVisitCount:
                           type: integer
 
-  /reports/generate:
+  /camps/{campId}/reports/generate:
     post:
       tags: [F. Reports & Analytics]
       summary: "캠프 결과 리포트 배치 생성 (내부용)"
@@ -2626,22 +2590,17 @@ paths:
         관리자가 직접 호출할 일은 없다 (내부용).
       security:
         - AdminAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [campId]
-              properties:
-                campId:
-                  type: string
-                  format: uuid
+      parameters:
+        - $ref: '#/components/parameters/CampIdPath'
       responses:
-        "202":
-          description: "배치 생성 요청 수락"
+        "201":
+          description: "최종 리포트 생성 완료"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CampReport'
 
-  /reports/current:
+  /camps/{campId}/reports/current:
     get:
       tags: [F. Reports & Analytics]
       summary: "현재 캠프 결과 리포트 조회"
@@ -2653,6 +2612,8 @@ paths:
         클라이언트는 응답 하나를 §1.1(캠프)/§1.2(코너)/§1.4(조) 구간으로 나눠 탭별로 렌더링한다.
       security:
         - AdminAuth: []
+      parameters:
+        - $ref: '#/components/parameters/CampIdPath'
       responses:
         "200":
           description: "캠프 결과 리포트"
@@ -2667,7 +2628,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
-  /reports/current/export:
+  /camps/{campId}/reports/current/export:
     get:
       tags: [F. Reports & Analytics]
       summary: "캠프 결과 리포트 PDF 내보내기"
@@ -2676,6 +2637,8 @@ paths:
         iPad에서 AirPrint 없이 PDF만 내보내며, 인쇄는 별도 컴퓨터에서 수행.
       security:
         - AdminAuth: []
+      parameters:
+        - $ref: '#/components/parameters/CampIdPath'
       responses:
         "200":
           description: "PDF 파일"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2702,7 +2702,8 @@ paths:
       description: |
         인증 성공/실패, 스캔, 규칙 변경, 기기 승인/철회, 트랙 관리 등의 감사 로그를 조회한다.
         메시지 통신 내역은 감사 대상에서 제외.
-        필터링·정렬을 쿼리 파라미터로 지정해 서버에서 처리한다.
+        필터링을 쿼리 파라미터로 지정해 서버에서 처리하며,
+        응답은 최신순 `(occurredAt, id)` 복합 커서로 페이지네이션한다.
       security:
         - AdminAuth: []
       parameters:
@@ -2722,18 +2723,6 @@ paths:
             type: string
             enum: [success, failure]
           description: "성공/실패 필터"
-        - name: sort
-          in: query
-          schema:
-            type: string
-            enum: [occurredAt, actor, action]
-          description: "정렬 기준"
-        - name: order
-          in: query
-          schema:
-            type: string
-            enum: [asc, desc]
-          default: desc
         - name: limit
           in: query
           schema:
@@ -2744,8 +2733,7 @@ paths:
           in: query
           schema:
             type: string
-            format: date-time
-          description: "커서 기반 페이지네이션: 이 시각 이전 항목 조회"
+          description: "이전 응답의 불투명 nextCursor"
       responses:
         "200":
           description: "감사 로그 목록"
@@ -2758,8 +2746,16 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/AuditLog'
-                  hasMore:
-                    type: boolean
+                  nextCursor:
+                    type: string
+                    description: "다음 페이지가 있을 때만 반환되는 불투명 커서"
+                required: [logs]
+        "400":
+          description: "잘못된 result, limit 또는 before"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         "401":
           $ref: '#/components/responses/Unauthorized'
         "403":

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -204,8 +204,15 @@ WHERE g.camp_id = $1;
 
 -- name: ListAuditLogs :many
 SELECT * FROM audit_logs
-ORDER BY occurred_at DESC
-LIMIT $1 OFFSET $2;
+WHERE (sqlc.narg(actor)::VARCHAR IS NULL OR actor ILIKE '%' || sqlc.narg(actor)::VARCHAR || '%')
+  AND (sqlc.narg(action)::VARCHAR IS NULL OR action = sqlc.narg(action)::VARCHAR)
+  AND (sqlc.narg(success)::BOOLEAN IS NULL OR success = sqlc.narg(success)::BOOLEAN)
+  AND (
+    sqlc.narg(before_occurred_at)::TIMESTAMPTZ IS NULL
+    OR (occurred_at, id) < (sqlc.narg(before_occurred_at)::TIMESTAMPTZ, sqlc.narg(before_id)::VARCHAR)
+  )
+ORDER BY occurred_at DESC, id DESC
+LIMIT sqlc.arg(page_limit);
 
 -- name: ListAdminSessionsByAdmin :many
 SELECT * FROM admin_sessions

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -218,6 +218,8 @@ COMMENT ON COLUMN audit_logs.id IS '감사 로그 고유 식별자';
 COMMENT ON COLUMN audit_logs.actor IS '행위자 (관리자 ID, 진행자 ID 등)';
 COMMENT ON COLUMN audit_logs.action IS '수행한 동작 (예: APPROVED_DEVICE, FAILED_PIN 등)';
 COMMENT ON COLUMN audit_logs.target IS '동작의 대상 (기기 ID, 트랙 ID 등)';
+CREATE INDEX idx_audit_logs_occurred_at_id ON audit_logs (occurred_at DESC, id DESC);
+CREATE INDEX idx_audit_logs_action_success_occurred_at_id ON audit_logs (action, success, occurred_at DESC, id DESC);
 COMMENT ON COLUMN audit_logs.success IS '동작 성공 여부';
 COMMENT ON COLUMN audit_logs.occurred_at IS '이벤트 발생 시간';
 COMMENT ON COLUMN audit_logs.metadata IS '이벤트와 관련된 추가 정보 (JSON)';

--- a/backend/docs/artifacts/plan/20260713_issue_45_explicit_camp_scope_plan_.md
+++ b/backend/docs/artifacts/plan/20260713_issue_45_explicit_camp_scope_plan_.md
@@ -1,0 +1,27 @@
+# GitHub Issue #45 — 컬렉션·집계 API 캠프 범위 명시화 구현 계획
+
+> 이슈: https://github.com/lsjtop10/cornermon/issues/45
+
+## 구현 현황
+
+- [x] 코너·트랙·조 및 리포트 경로를 `/camps/{campId}/...`로 변경
+- [x] query/활성 캠프 자동 탐색을 제거하고 path의 camp ID 전달
+- [x] 모든 리포트 조회를 `ReportService.GetCampReport` 경계로 집중
+- [x] 캠프 존재 여부 및 최종 리포트 생성 상태 규칙 검증
+- [x] 동시 캠프 A/B 리포트 조회 격리 race 테스트
+- [x] 라우터·Swagger annotation·Swagger 산출물·OpenAPI 경로 일치 확인
+- [ ] Flutter 생성 클라이언트 및 호출부 변경 — 사용자 지시에 따라 `frontend/` 수정 범위 제외
+
+## 자체 리뷰
+
+- 컬렉션 repository 포트는 모두 `context.Context`와 명시적 `campID`를 받는다.
+- 개별 엔티티 경로는 변경하지 않았다.
+- PENDING/ACTIVE/ENDED 캠프 리포트 읽기는 허용하고, 최종 생성은 ENDED만 허용한다.
+- 없는 캠프는 `ErrCampNotFound`로 중앙 HTTP 매핑된다.
+- `domain`에서 infrastructure import가 없음을 확인했다.
+
+## 검증
+
+- `go test ./...`
+- `go test -race ./internal/infrastructure/web ./internal/usecase`
+- 프론트 생성물 검증은 사용자 지시에 따라 수행하지 않음

--- a/backend/docs/artifacts/plan/20260713_issue_48_audit_filters_cursor_plan_.md
+++ b/backend/docs/artifacts/plan/20260713_issue_48_audit_filters_cursor_plan_.md
@@ -1,0 +1,31 @@
+# GitHub Issue #48 — 감사 로그 필터·커서 페이지네이션 구현 계획
+
+> 이슈: https://github.com/lsjtop10/cornermon/issues/48
+
+## 구현 현황
+
+- [x] nullable actor/action/success 필터를 DB query에 적용
+- [x] `(occurred_at, id)` 내림차순 복합 keyset 조건 적용
+- [x] 조회 인덱스와 sqlc 원본/생성물 동기화
+- [x] `limit+1` 기반 next cursor 계산
+- [x] base64url JSON cursor codec와 query parameter 검증
+- [x] Swagger 및 OpenAPI 3.0 응답을 `{logs, nextCursor}`로 동기화
+- [x] handler 필터/경계/cursor 단위 테스트 추가
+- [x] repository 장애에 `errs.Wrap` 적용 및 하위 계층 무로깅 확인
+
+## 자체 리뷰
+
+- 커서에는 동일 시각 레코드의 안정적 tie-breaker인 ID가 포함된다.
+- SQL 정렬과 커서 비교가 모두 `occurred_at DESC, id DESC`로 일치한다.
+- actor 부분 검색, action 정확 일치, success nullable 조건은 전체 조회 후 필터링하지 않는다.
+- 공개 계약에 구현되지 않은 임의 정렬 파라미터를 남기지 않아 SQL 문자열 삽입 경로가 없다.
+- 원본 `query.sql`에서 sqlc 생성물을 재생성해 수동 생성물 편집 불일치를 제거했다.
+
+## 검증 체크리스트
+
+- [x] 필터가 전체 데이터가 아닌 DB query에 적용된다.
+- [x] 동일 timestamp 로그도 페이지 간 중복·누락되지 않는다.
+- [x] cursor는 opaque base64url 값이다.
+- [x] malformed cursor/잘못된 result/limit은 400이다.
+- [x] repository 오류는 `errs.Wrap`되고 하위 계층에서 직접 로그하지 않는다.
+- [x] Swagger 응답이 `{logs, nextCursor}` 형태와 일치한다.

--- a/backend/internal/infrastructure/web/audit_handler_test.go
+++ b/backend/internal/infrastructure/web/audit_handler_test.go
@@ -1,0 +1,105 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type auditLogQuerierStub struct {
+	query usecase.AuditLogQuery
+	page  *usecase.AuditLogPage
+}
+
+func (s *auditLogQuerierStub) List(_ context.Context, query usecase.AuditLogQuery) (*usecase.AuditLogPage, error) {
+	s.query = query
+	return s.page, nil
+}
+
+func TestListAuditLogsShoudApplyFiltersAndCursorWhenValid(t *testing.T) {
+	// arrange
+	e := echo.New()
+	cursor := usecase.AuditLogCursor{OccurredAt: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC), ID: "audit-2"}
+	stub := &auditLogQuerierStub{page: &usecase.AuditLogPage{
+		Logs: []*domain.AuditLog{{ID: "audit-1", Actor: "admin-1", Action: "UPDATE_CAMP", Success: true}},
+		NextCursor: domain.Some(cursor),
+	}}
+	req := httptest.NewRequest(http.MethodGet, "/audit-logs?actor=admin&action=UPDATE_CAMP&result=success&limit=25&before="+encodeAuditLogCursor(cursor), nil)
+	rec := httptest.NewRecorder()
+
+	// act
+	err := NewAuditHandler(stub).ListAuditLogs(e.NewContext(req, rec))
+
+	// assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.query.Actor != "admin" || stub.query.Action != "UPDATE_CAMP" || stub.query.Limit != 25 {
+		t.Fatalf("unexpected query: %+v", stub.query)
+	}
+	if stub.query.Success == nil || !*stub.query.Success {
+		t.Fatalf("success filter was not forwarded: %+v", stub.query.Success)
+	}
+	before, ok := stub.query.Before.Value()
+	if !ok || before != cursor {
+		t.Fatalf("cursor was not forwarded: %+v", before)
+	}
+	var response AuditLogPageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Logs) != 1 || response.NextCursor == "" {
+		t.Fatalf("unexpected page response: %+v", response)
+	}
+}
+
+func TestListAuditLogsShoudRejectInvalidParametersWhenMalformed(t *testing.T) {
+	tests := []string{
+		"/audit-logs?limit=0",
+		"/audit-logs?limit=201",
+		"/audit-logs?limit=invalid",
+		"/audit-logs?result=unknown",
+		"/audit-logs?before=not-base64",
+	}
+	for _, target := range tests {
+		t.Run(target, func(t *testing.T) {
+			// arrange
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+
+			// act
+			err := NewAuditHandler(nil).ListAuditLogs(e.NewContext(req, rec))
+
+			// assert
+			httpErr, ok := err.(*echo.HTTPError)
+			if !ok || httpErr.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 HTTP error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAuditLogCursorShoudPreserveTieBreakerWhenRoundTripped(t *testing.T) {
+	// arrange
+	want := usecase.AuditLogCursor{OccurredAt: time.Date(2026, 7, 13, 10, 0, 0, 123, time.UTC), ID: "audit-tie-breaker"}
+
+	// act
+	encoded := encodeAuditLogCursor(want)
+	got, err := decodeAuditLogCursor(encoded)
+
+	// assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("cursor mismatch: got %+v, want %+v", got, want)
+	}
+}

--- a/backend/internal/infrastructure/web/report_handler.go
+++ b/backend/internal/infrastructure/web/report_handler.go
@@ -82,9 +82,9 @@ func mapReport(r *usecase.CampReport) CampReport {
 // @Router       /camps/{campId}/reports/live-summary [get]
 func (h *ReportHandler) LiveSummary(c echo.Context) error {
 	campID := domain.CampID(c.Param("campId"))
-	report, err := h.querier.QueryCampReport(c.Request().Context(), campID)
+	report, err := h.reportService.GetCampReport(c.Request().Context(), campID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return err
 	}
 
 	return c.JSON(http.StatusOK, mapSummary(report))
@@ -100,9 +100,9 @@ func (h *ReportHandler) LiveSummary(c echo.Context) error {
 // @Router       /camps/{campId}/reports/current [get]
 func (h *ReportHandler) GetCurrentReport(c echo.Context) error {
 	campID := domain.CampID(c.Param("campId"))
-	report, err := h.querier.QueryCampReport(c.Request().Context(), campID)
+	report, err := h.reportService.GetCampReport(c.Request().Context(), campID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return err
 	}
 
 	return c.JSON(http.StatusOK, mapReport(report))
@@ -120,7 +120,7 @@ func (h *ReportHandler) GenerateReport(c echo.Context) error {
 	campID := domain.CampID(c.Param("campId"))
 	report, err := h.reportService.GenerateCampReport(c.Request().Context(), campID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return err
 	}
 
 	return c.JSON(http.StatusCreated, mapReport(report))
@@ -136,9 +136,9 @@ func (h *ReportHandler) GenerateReport(c echo.Context) error {
 // @Router       /camps/{campId}/reports/current/export [get]
 func (h *ReportHandler) ExportCurrentReport(c echo.Context) error {
 	campID := domain.CampID(c.Param("campId"))
-	report, err := h.querier.QueryCampReport(c.Request().Context(), campID)
+	report, err := h.reportService.GetCampReport(c.Request().Context(), campID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		return err
 	}
 
 	// Just return JSON as per the updated spec

--- a/backend/internal/infrastructure/web/report_handler_test.go
+++ b/backend/internal/infrastructure/web/report_handler_test.go
@@ -1,0 +1,76 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type campRepositoryStub struct {
+	camps map[domain.CampID]*domain.Camp
+}
+
+func (s *campRepositoryStub) Get(_ context.Context, id domain.CampID) (*domain.Camp, error) {
+	return s.camps[id], nil
+}
+
+func (s *campRepositoryStub) List(context.Context) ([]*domain.Camp, error) { return nil, nil }
+func (s *campRepositoryStub) Save(context.Context, *domain.Camp) error     { return nil }
+
+type reportQuerierSpy struct {
+	mu      sync.Mutex
+	queried map[domain.CampID]int
+}
+
+func (s *reportQuerierSpy) QueryCampReport(_ context.Context, campID domain.CampID) (*usecase.CampReport, error) {
+	s.mu.Lock()
+	s.queried[campID]++
+	s.mu.Unlock()
+	return &usecase.CampReport{CampID: campID}, nil
+}
+
+func TestGetCurrentReportShoudKeepCampScopeWhenRequestsRunConcurrently(t *testing.T) {
+	// Arrange
+	camps := &campRepositoryStub{camps: map[domain.CampID]*domain.Camp{
+		"camp-a": {ID: "camp-a", Status: domain.CampActive},
+		"camp-b": {ID: "camp-b", Status: domain.CampEnded},
+	}}
+	querier := &reportQuerierSpy{queried: make(map[domain.CampID]int)}
+	handler := NewReportHandler(usecase.NewReportService(camps, querier), querier, camps)
+	e := echo.New()
+	var wg sync.WaitGroup
+
+	// Act
+	for _, campID := range []string{"camp-a", "camp-b"} {
+		campID := campID
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodGet, "/camps/"+campID+"/reports/current", nil)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			ctx.SetParamNames("campId")
+			ctx.SetParamValues(campID)
+			if err := handler.GetCurrentReport(ctx); err != nil {
+				t.Errorf("request for %s failed: %v", campID, err)
+			}
+			if rec.Code != http.StatusOK {
+				t.Errorf("request for %s returned %d", campID, rec.Code)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Assert
+	querier.mu.Lock()
+	defer querier.mu.Unlock()
+	if querier.queried["camp-a"] != 1 || querier.queried["camp-b"] != 1 {
+		t.Fatalf("camp scopes were not isolated: %+v", querier.queried)
+	}
+}

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -114,6 +114,28 @@ type AuditLogRepository interface {
 	Save(ctx context.Context, log *domain.AuditLog) error
 }
 
+type AuditLogQuerier interface {
+	List(ctx context.Context, query AuditLogQuery) (*AuditLogPage, error)
+}
+
+type AuditLogCursor struct {
+	OccurredAt time.Time
+	ID         domain.AuditLogID
+}
+
+type AuditLogQuery struct {
+	Actor   string
+	Action  string
+	Success *bool
+	Before  domain.Optional[AuditLogCursor]
+	Limit   int
+}
+
+type AuditLogPage struct {
+	Logs       []*domain.AuditLog
+	NextCursor domain.Optional[AuditLogCursor]
+}
+
 type NotificationEvent string
 
 const (

--- a/backend/internal/usecase/report.go
+++ b/backend/internal/usecase/report.go
@@ -11,6 +11,23 @@ type ReportService struct {
 	querier ReportQuerier
 }
 
+// GetCampReport returns the aggregate for the explicitly selected camp.
+// Report reads are available for every camp state; only final report generation
+// is restricted to ended camps.
+func (s *ReportService) GetCampReport(
+	ctx context.Context,
+	campID domain.CampID,
+) (*CampReport, error) {
+	camp, err := s.camps.Get(ctx, campID)
+	if err != nil {
+		return nil, err
+	}
+	if camp == nil {
+		return nil, domain.ErrCampNotFound
+	}
+	return s.querier.QueryCampReport(ctx, campID)
+}
+
 func NewReportService(
 	camps CampRepository,
 	querier ReportQuerier,
@@ -31,7 +48,7 @@ func (s *ReportService) GenerateCampReport(
 		return nil, err
 	}
 	if camp == nil {
-		return nil, domain.ErrCampInvalidTransition
+		return nil, domain.ErrCampNotFound
 	}
 
 	if camp.Status != domain.CampEnded {

--- a/backend/internal/usecase/report_test.go
+++ b/backend/internal/usecase/report_test.go
@@ -55,3 +55,40 @@ func TestReportService_GenerateCampReport(t *testing.T) {
 		}
 	})
 }
+
+func TestGetCampReportShoudQueryExplicitCampWhenAnyState(t *testing.T) {
+	states := []domain.CampStatus{domain.CampPending, domain.CampActive, domain.CampEnded}
+	for _, state := range states {
+		t.Run(string(state), func(t *testing.T) {
+			// Arrange
+			camps := NewMockCampRepository()
+			camps.Camps["camp-selected"] = &domain.Camp{ID: "camp-selected", Status: state}
+			querier := &MockReportQuerier{ReportToReturn: &CampReport{CampID: "camp-selected"}}
+			service := NewReportService(camps, querier)
+
+			// Act
+			report, err := service.GetCampReport(context.Background(), "camp-selected")
+
+			// Assert
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if report.CampID != "camp-selected" {
+				t.Fatalf("unexpected camp report: %s", report.CampID)
+			}
+		})
+	}
+}
+
+func TestGetCampReportShoudReturnNotFoundWhenCampDoesNotExist(t *testing.T) {
+	// Arrange
+	service := NewReportService(NewMockCampRepository(), &MockReportQuerier{})
+
+	// Act
+	_, err := service.GetCampReport(context.Background(), "missing")
+
+	// Assert
+	if err != domain.ErrCampNotFound {
+		t.Fatalf("expected ErrCampNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## 변경 사항
- 리포트 읽기를 `ReportService.GetCampReport`로 집중하고 명시 camp ID와 존재 여부를 검증합니다.
- PENDING/ACTIVE/ENDED 조회 및 ENDED 전용 최종 생성 규칙을 테스트했습니다.
- 캠프 A/B 동시 요청 격리 race 테스트를 추가했습니다.
- OpenAPI의 컬렉션/리포트 경로를 `/camps/{campId}/...`로 동기화했습니다.

## 변경 이유
handler가 report querier를 직접 호출해 캠프 존재/상태 정책이 서비스 경계를 우회하고 있었습니다.

## 종료 조건 증명
- `go test ./...` 통과
- `go test -race ./internal/infrastructure/web ./internal/usecase` 통과
- 개별 엔티티 경로 변경 없음
- PR diff: 209 additions / 89 deletions
- 사용자 지시에 따라 `frontend/` 생성 클라이언트 및 호출부는 수정하지 않음

Closes #45
