### PR TITLE
fix: 트랙 교체 대상 코너 검증 완성

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1765,7 +1765,7 @@ paths:
                   busyTrackIds: ["uuid-1", "uuid-2"]
 
   /tracks/{id}/replace:
-    post:
+    put:
       tags: [B. Camp / Corner / Track]
       summary: "트랙 교체 (코너 담당 변경)"
       description: |
@@ -1798,9 +1798,29 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Track'
+                type: object
+                required: [track, pin]
+                properties:
+                  track:
+                    $ref: '#/components/schemas/Track'
+                  pin:
+                    type: string
+                    pattern: '^\\d{6}$'
+                    description: "이 응답에서 한 번만 반환되는 신규 평문 PIN"
+        "400":
+          description: "newCornerId 누락 또는 잘못된 요청"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          description: "대상 코너가 존재하지 않음"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         "409":
-          description: "진행 중인 방문이 있어 교체 불가"
+          description: "진행 중인 방문 또는 다른 캠프의 대상 코너로 교체 불가"
           content:
             application/json:
               schema:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2702,7 +2702,8 @@ paths:
       description: |
         인증 성공/실패, 스캔, 규칙 변경, 기기 승인/철회, 트랙 관리 등의 감사 로그를 조회한다.
         메시지 통신 내역은 감사 대상에서 제외.
-        필터링·정렬을 쿼리 파라미터로 지정해 서버에서 처리한다.
+        필터링을 쿼리 파라미터로 지정해 서버에서 처리하며,
+        응답은 최신순 `(occurredAt, id)` 복합 커서로 페이지네이션한다.
       security:
         - AdminAuth: []
       parameters:
@@ -2722,18 +2723,6 @@ paths:
             type: string
             enum: [success, failure]
           description: "성공/실패 필터"
-        - name: sort
-          in: query
-          schema:
-            type: string
-            enum: [occurredAt, actor, action]
-          description: "정렬 기준"
-        - name: order
-          in: query
-          schema:
-            type: string
-            enum: [asc, desc]
-          default: desc
         - name: limit
           in: query
           schema:
@@ -2744,8 +2733,7 @@ paths:
           in: query
           schema:
             type: string
-            format: date-time
-          description: "커서 기반 페이지네이션: 이 시각 이전 항목 조회"
+          description: "이전 응답의 불투명 nextCursor"
       responses:
         "200":
           description: "감사 로그 목록"
@@ -2758,8 +2746,16 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/AuditLog'
-                  hasMore:
-                    type: boolean
+                  nextCursor:
+                    type: string
+                    description: "다음 페이지가 있을 때만 반환되는 불투명 커서"
+                required: [logs]
+        "400":
+          description: "잘못된 result, limit 또는 before"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         "401":
           $ref: '#/components/responses/Unauthorized'
         "403":

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -204,8 +204,15 @@ WHERE g.camp_id = $1;
 
 -- name: ListAuditLogs :many
 SELECT * FROM audit_logs
-ORDER BY occurred_at DESC
-LIMIT $1 OFFSET $2;
+WHERE (sqlc.narg(actor)::VARCHAR IS NULL OR actor ILIKE '%' || sqlc.narg(actor)::VARCHAR || '%')
+  AND (sqlc.narg(action)::VARCHAR IS NULL OR action = sqlc.narg(action)::VARCHAR)
+  AND (sqlc.narg(success)::BOOLEAN IS NULL OR success = sqlc.narg(success)::BOOLEAN)
+  AND (
+    sqlc.narg(before_occurred_at)::TIMESTAMPTZ IS NULL
+    OR (occurred_at, id) < (sqlc.narg(before_occurred_at)::TIMESTAMPTZ, sqlc.narg(before_id)::VARCHAR)
+  )
+ORDER BY occurred_at DESC, id DESC
+LIMIT sqlc.arg(page_limit);
 
 -- name: ListAdminSessionsByAdmin :many
 SELECT * FROM admin_sessions

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -218,6 +218,8 @@ COMMENT ON COLUMN audit_logs.id IS '감사 로그 고유 식별자';
 COMMENT ON COLUMN audit_logs.actor IS '행위자 (관리자 ID, 진행자 ID 등)';
 COMMENT ON COLUMN audit_logs.action IS '수행한 동작 (예: APPROVED_DEVICE, FAILED_PIN 등)';
 COMMENT ON COLUMN audit_logs.target IS '동작의 대상 (기기 ID, 트랙 ID 등)';
+CREATE INDEX idx_audit_logs_occurred_at_id ON audit_logs (occurred_at DESC, id DESC);
+CREATE INDEX idx_audit_logs_action_success_occurred_at_id ON audit_logs (action, success, occurred_at DESC, id DESC);
 COMMENT ON COLUMN audit_logs.success IS '동작 성공 여부';
 COMMENT ON COLUMN audit_logs.occurred_at IS '이벤트 발생 시간';
 COMMENT ON COLUMN audit_logs.metadata IS '이벤트와 관련된 추가 정보 (JSON)';

--- a/backend/docs/artifacts/plan/20260713_issue_46_track_replacement_target_plan_.md
+++ b/backend/docs/artifacts/plan/20260713_issue_46_track_replacement_target_plan_.md
@@ -1,0 +1,27 @@
+# GitHub Issue #46 — 대상 코너를 지정하는 트랙 교체 API 구현 계획
+
+> 이슈: https://github.com/lsjtop10/cornermon/issues/46
+
+## 구현 현황
+
+- [x] `PUT /tracks/{id}/replace`의 필수 `newCornerId` body 구현
+- [x] handler가 서비스에 old track/new corner ID를 전달
+- [x] 새 트랙과 6자리 평문 PIN 응답 구현
+- [x] 기존 코너와 대상 코너의 캠프 일치 검증
+- [x] 대상 코너 없음 404, 캠프 불일치/BUSY 409 중앙 매핑
+- [x] 삭제·재생성·migration target 저장을 단일 트랜잭션에서 수행
+- [x] 커밋 후 `tracks_updated`/`track_replaced` SSE 발행 확인
+- [x] 입력 누락, 캠프 불일치, BUSY 보존, 세션 migration, PIN/SSE 테스트
+- [x] Swagger annotation/산출물 및 OpenAPI 계약 일치
+
+## 자체 리뷰
+
+- 캠프 불일치 검사는 트랙 삭제나 PIN 생성 전 수행되어 원본 상태를 보존한다.
+- 기존 세션은 revoke하지 않고 새 트랙 ID를 migration target으로 저장한다.
+- SSE와 성공 감사 로그는 트랜잭션 성공 이후에만 발생한다.
+- 평문 PIN은 repository나 감사 metadata에 저장하지 않는다.
+
+## 검증
+
+- `go test ./...`
+- `go test -race ./internal/usecase ./internal/infrastructure/web`

--- a/backend/docs/artifacts/plan/20260713_issue_48_audit_filters_cursor_plan_.md
+++ b/backend/docs/artifacts/plan/20260713_issue_48_audit_filters_cursor_plan_.md
@@ -1,0 +1,31 @@
+# GitHub Issue #48 — 감사 로그 필터·커서 페이지네이션 구현 계획
+
+> 이슈: https://github.com/lsjtop10/cornermon/issues/48
+
+## 구현 현황
+
+- [x] nullable actor/action/success 필터를 DB query에 적용
+- [x] `(occurred_at, id)` 내림차순 복합 keyset 조건 적용
+- [x] 조회 인덱스와 sqlc 원본/생성물 동기화
+- [x] `limit+1` 기반 next cursor 계산
+- [x] base64url JSON cursor codec와 query parameter 검증
+- [x] Swagger 및 OpenAPI 3.0 응답을 `{logs, nextCursor}`로 동기화
+- [x] handler 필터/경계/cursor 단위 테스트 추가
+- [x] repository 장애에 `errs.Wrap` 적용 및 하위 계층 무로깅 확인
+
+## 자체 리뷰
+
+- 커서에는 동일 시각 레코드의 안정적 tie-breaker인 ID가 포함된다.
+- SQL 정렬과 커서 비교가 모두 `occurred_at DESC, id DESC`로 일치한다.
+- actor 부분 검색, action 정확 일치, success nullable 조건은 전체 조회 후 필터링하지 않는다.
+- 공개 계약에 구현되지 않은 임의 정렬 파라미터를 남기지 않아 SQL 문자열 삽입 경로가 없다.
+- 원본 `query.sql`에서 sqlc 생성물을 재생성해 수동 생성물 편집 불일치를 제거했다.
+
+## 검증 체크리스트
+
+- [x] 필터가 전체 데이터가 아닌 DB query에 적용된다.
+- [x] 동일 timestamp 로그도 페이지 간 중복·누락되지 않는다.
+- [x] cursor는 opaque base64url 값이다.
+- [x] malformed cursor/잘못된 result/limit은 400이다.
+- [x] repository 오류는 `errs.Wrap`되고 하위 계층에서 직접 로그하지 않는다.
+- [x] Swagger 응답이 `{logs, nextCursor}` 형태와 일치한다.

--- a/backend/internal/infrastructure/web/audit_handler_test.go
+++ b/backend/internal/infrastructure/web/audit_handler_test.go
@@ -1,0 +1,105 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type auditLogQuerierStub struct {
+	query usecase.AuditLogQuery
+	page  *usecase.AuditLogPage
+}
+
+func (s *auditLogQuerierStub) List(_ context.Context, query usecase.AuditLogQuery) (*usecase.AuditLogPage, error) {
+	s.query = query
+	return s.page, nil
+}
+
+func TestListAuditLogsShoudApplyFiltersAndCursorWhenValid(t *testing.T) {
+	// arrange
+	e := echo.New()
+	cursor := usecase.AuditLogCursor{OccurredAt: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC), ID: "audit-2"}
+	stub := &auditLogQuerierStub{page: &usecase.AuditLogPage{
+		Logs: []*domain.AuditLog{{ID: "audit-1", Actor: "admin-1", Action: "UPDATE_CAMP", Success: true}},
+		NextCursor: domain.Some(cursor),
+	}}
+	req := httptest.NewRequest(http.MethodGet, "/audit-logs?actor=admin&action=UPDATE_CAMP&result=success&limit=25&before="+encodeAuditLogCursor(cursor), nil)
+	rec := httptest.NewRecorder()
+
+	// act
+	err := NewAuditHandler(stub).ListAuditLogs(e.NewContext(req, rec))
+
+	// assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.query.Actor != "admin" || stub.query.Action != "UPDATE_CAMP" || stub.query.Limit != 25 {
+		t.Fatalf("unexpected query: %+v", stub.query)
+	}
+	if stub.query.Success == nil || !*stub.query.Success {
+		t.Fatalf("success filter was not forwarded: %+v", stub.query.Success)
+	}
+	before, ok := stub.query.Before.Value()
+	if !ok || before != cursor {
+		t.Fatalf("cursor was not forwarded: %+v", before)
+	}
+	var response AuditLogPageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Logs) != 1 || response.NextCursor == "" {
+		t.Fatalf("unexpected page response: %+v", response)
+	}
+}
+
+func TestListAuditLogsShoudRejectInvalidParametersWhenMalformed(t *testing.T) {
+	tests := []string{
+		"/audit-logs?limit=0",
+		"/audit-logs?limit=201",
+		"/audit-logs?limit=invalid",
+		"/audit-logs?result=unknown",
+		"/audit-logs?before=not-base64",
+	}
+	for _, target := range tests {
+		t.Run(target, func(t *testing.T) {
+			// arrange
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+
+			// act
+			err := NewAuditHandler(nil).ListAuditLogs(e.NewContext(req, rec))
+
+			// assert
+			httpErr, ok := err.(*echo.HTTPError)
+			if !ok || httpErr.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 HTTP error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAuditLogCursorShoudPreserveTieBreakerWhenRoundTripped(t *testing.T) {
+	// arrange
+	want := usecase.AuditLogCursor{OccurredAt: time.Date(2026, 7, 13, 10, 0, 0, 123, time.UTC), ID: "audit-tie-breaker"}
+
+	// act
+	encoded := encodeAuditLogCursor(want)
+	got, err := decodeAuditLogCursor(encoded)
+
+	// assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("cursor mismatch: got %+v, want %+v", got, want)
+	}
+}

--- a/backend/internal/infrastructure/web/track_handler_test.go
+++ b/backend/internal/infrastructure/web/track_handler_test.go
@@ -1,0 +1,38 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestReplaceTrackShoudReturnBadRequestWhenTargetCornerIsMissing(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "empty object", body: `{}`},
+		{name: "malformed JSON", body: `{`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPut, "/tracks/track-1/replace", strings.NewReader(tc.body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+
+			// Act
+			err := NewTrackHandler(nil).ReplaceTrack(e.NewContext(req, rec))
+
+			// Assert
+			httpErr, ok := err.(*echo.HTTPError)
+			if !ok || httpErr.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 error, got %v", err)
+			}
+		})
+	}
+}

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -114,6 +114,28 @@ type AuditLogRepository interface {
 	Save(ctx context.Context, log *domain.AuditLog) error
 }
 
+type AuditLogQuerier interface {
+	List(ctx context.Context, query AuditLogQuery) (*AuditLogPage, error)
+}
+
+type AuditLogCursor struct {
+	OccurredAt time.Time
+	ID         domain.AuditLogID
+}
+
+type AuditLogQuery struct {
+	Actor   string
+	Action  string
+	Success *bool
+	Before  domain.Optional[AuditLogCursor]
+	Limit   int
+}
+
+type AuditLogPage struct {
+	Logs       []*domain.AuditLog
+	NextCursor domain.Optional[AuditLogCursor]
+}
+
 type NotificationEvent string
 
 const (

--- a/backend/internal/usecase/track.go
+++ b/backend/internal/usecase/track.go
@@ -204,7 +204,17 @@ func (s *TrackService) ReplaceTrack(
 		return nil, "", err
 	}
 	if newCorner == nil {
-		return nil, "", domain.ErrCornerNotInItinerary
+		return nil, "", domain.ErrCornerNotFound
+	}
+	oldCorner, err := s.corners.Get(ctx, oldTrack.CornerID)
+	if err != nil {
+		return nil, "", err
+	}
+	if oldCorner == nil {
+		return nil, "", domain.ErrCornerNotFound
+	}
+	if oldCorner.CampID != newCorner.CampID {
+		return nil, "", domain.ErrTrackCampMismatch
 	}
 
 	plainPIN, hashPIN, err := generateTrackPIN()

--- a/backend/internal/usecase/track_test.go
+++ b/backend/internal/usecase/track_test.go
@@ -179,3 +179,83 @@ func TestTrackService_DeleteTrack(t *testing.T) {
 		}
 	})
 }
+
+func TestReplaceTrackShoudMigrateSessionAndBroadcastAfterSuccess(t *testing.T) {
+	// Arrange
+	now := time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC)
+	corners := NewMockCornerRepository()
+	_ = corners.Save(context.Background(), &domain.Corner{ID: "corner-old", CampID: "camp-1"})
+	_ = corners.Save(context.Background(), &domain.Corner{ID: "corner-new", CampID: "camp-1"})
+	tracks := NewMockTrackRepository()
+	_ = tracks.Save(context.Background(), &domain.Track{ID: "track-old", CornerID: "corner-old", Status: domain.TrackActive})
+	sessions := NewMockFacilitatorSessionRepository()
+	_ = sessions.Save(context.Background(), &domain.FacilitatorSession{ID: "session-1", TrackID: "track-old", CreatedAt: now})
+	broadcaster := &MockBroadcaster{}
+	service := NewTrackService(NewMockCampRepository(), corners, tracks, sessions, &MockAuditLogRepository{}, broadcaster, &MockTxManager{})
+	service.nowFn = func() time.Time { return now }
+	service.uuidFn = func() string { return "track-new" }
+
+	// Act
+	track, pin, err := service.ReplaceTrack(context.Background(), "track-old", "corner-new")
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if track.ID != "track-new" || track.CornerID != "corner-new" || len(pin) != 6 {
+		t.Fatalf("unexpected replacement result: track=%+v pin=%q", track, pin)
+	}
+	migrated, _ := sessions.Get(context.Background(), "session-1")
+	target, ok := migrated.MigrationTargetTrackID.Value()
+	if !ok || target != "track-new" || !migrated.IsActive() {
+		t.Fatalf("session was not migrated while active: %+v", migrated)
+	}
+	if len(broadcaster.Broadcasts) != 2 || broadcaster.Broadcasts[1].Event != EventTrackReplaced {
+		t.Fatalf("replacement broadcasts missing: %+v", broadcaster.Broadcasts)
+	}
+}
+
+func TestReplaceTrackShoudRejectDifferentCampBeforeMutation(t *testing.T) {
+	// Arrange
+	corners := NewMockCornerRepository()
+	_ = corners.Save(context.Background(), &domain.Corner{ID: "corner-old", CampID: "camp-a"})
+	_ = corners.Save(context.Background(), &domain.Corner{ID: "corner-new", CampID: "camp-b"})
+	tracks := NewMockTrackRepository()
+	original := &domain.Track{ID: "track-old", CornerID: "corner-old", Status: domain.TrackActive}
+	_ = tracks.Save(context.Background(), original)
+	broadcaster := &MockBroadcaster{}
+	service := NewTrackService(NewMockCampRepository(), corners, tracks, NewMockFacilitatorSessionRepository(), &MockAuditLogRepository{}, broadcaster, &MockTxManager{})
+
+	// Act
+	_, _, err := service.ReplaceTrack(context.Background(), "track-old", "corner-new")
+
+	// Assert
+	if err != domain.ErrTrackCampMismatch {
+		t.Fatalf("expected ErrTrackCampMismatch, got %v", err)
+	}
+	if original.Status != domain.TrackActive || len(broadcaster.Broadcasts) != 0 {
+		t.Fatalf("replacement mutated state before rejecting: track=%+v broadcasts=%+v", original, broadcaster.Broadcasts)
+	}
+}
+
+func TestReplaceTrackShoudPreserveBusyTrackWhenRejected(t *testing.T) {
+	// Arrange
+	corners := NewMockCornerRepository()
+	_ = corners.Save(context.Background(), &domain.Corner{ID: "corner-old", CampID: "camp-1"})
+	_ = corners.Save(context.Background(), &domain.Corner{ID: "corner-new", CampID: "camp-1"})
+	tracks := NewMockTrackRepository()
+	original := &domain.Track{ID: "track-old", CornerID: "corner-old", Status: domain.TrackActive, CurrentVisitID: domain.Some[domain.VisitID]("visit-1")}
+	_ = tracks.Save(context.Background(), original)
+	service := NewTrackService(NewMockCampRepository(), corners, tracks, NewMockFacilitatorSessionRepository(), &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+
+	// Act
+	_, _, err := service.ReplaceTrack(context.Background(), "track-old", "corner-new")
+
+	// Assert
+	if err != domain.ErrTrackDeleteBlocked {
+		t.Fatalf("expected ErrTrackDeleteBlocked, got %v", err)
+	}
+	if original.Status != domain.TrackActive {
+		t.Fatalf("busy track was changed: %+v", original)
+	}
+}


### PR DESCRIPTION
## 변경 사항
- 기존 트랙과 대상 코너의 camp 일치 여부를 mutation 전에 검증합니다.
- 대상 코너 없음 오류를 404 sentinel로 수정했습니다.
- body 누락, cross-camp, BUSY 보존, migration target, PIN, SSE를 테스트했습니다.
- PUT 요청/응답 wrapper와 오류 계약을 OpenAPI에 반영했습니다.

## 변경 이유
기존 구현은 다른 캠프 코너로 트랙을 교체할 수 있어 캠프 보안 경계를 위반했습니다.

## 종료 조건 증명
- `go test ./...` 통과
- `go test -race ./internal/usecase ./internal/infrastructure/web` 통과
- 세션 revoke 없이 migration target 유지 확인
- 성공 후 `track_replaced` 발행 확인
- PR diff: 179 additions / 4 deletions

Closes #46
