### PR TITLE
fix: 캠프 설정 PATCH 규칙 및 검증 완성

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2702,7 +2702,8 @@ paths:
       description: |
         인증 성공/실패, 스캔, 규칙 변경, 기기 승인/철회, 트랙 관리 등의 감사 로그를 조회한다.
         메시지 통신 내역은 감사 대상에서 제외.
-        필터링·정렬을 쿼리 파라미터로 지정해 서버에서 처리한다.
+        필터링을 쿼리 파라미터로 지정해 서버에서 처리하며,
+        응답은 최신순 `(occurredAt, id)` 복합 커서로 페이지네이션한다.
       security:
         - AdminAuth: []
       parameters:
@@ -2722,18 +2723,6 @@ paths:
             type: string
             enum: [success, failure]
           description: "성공/실패 필터"
-        - name: sort
-          in: query
-          schema:
-            type: string
-            enum: [occurredAt, actor, action]
-          description: "정렬 기준"
-        - name: order
-          in: query
-          schema:
-            type: string
-            enum: [asc, desc]
-          default: desc
         - name: limit
           in: query
           schema:
@@ -2744,8 +2733,7 @@ paths:
           in: query
           schema:
             type: string
-            format: date-time
-          description: "커서 기반 페이지네이션: 이 시각 이전 항목 조회"
+          description: "이전 응답의 불투명 nextCursor"
       responses:
         "200":
           description: "감사 로그 목록"
@@ -2758,8 +2746,16 @@ paths:
                     type: array
                     items:
                       $ref: '#/components/schemas/AuditLog'
-                  hasMore:
-                    type: boolean
+                  nextCursor:
+                    type: string
+                    description: "다음 페이지가 있을 때만 반환되는 불투명 커서"
+                required: [logs]
+        "400":
+          description: "잘못된 result, limit 또는 before"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         "401":
           $ref: '#/components/responses/Unauthorized'
         "403":

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1363,7 +1363,8 @@ paths:
       tags: [B. Camp / Corner / Track]
       summary: "캠프 수정 (이름/기간/병목 파라미터)"
       description: |
-        현재 선택된 캠프의 이름·기간 및 병목 판정 파라미터를 수정한다.
+        URL에 지정된 캠프의 이름·예정 기간 및 병목 판정 파라미터 중 전달된 필드만 수정한다.
+        누락된 필드와 실제 상태 전이 시각(activatedAt/endedAt)은 보존한다.
         ENDED 캠프는 수정 불가.
       security:
         - AdminAuth: []
@@ -1388,7 +1389,7 @@ paths:
                   minimum: 1
                 bottleneckRatioPct:
                   type: integer
-                  minimum: 1
+                  minimum: 0
                   maximum: 100
       responses:
         "200":
@@ -1397,6 +1398,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Camp'
+        "400":
+          description: "공백 이름, 잘못된 기간 또는 병목 기준 범위"
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        "404":
+          $ref: '#/components/responses/NotFound'
         "409":
           description: "ENDED 캠프는 수정 불가"
           content:

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -204,8 +204,15 @@ WHERE g.camp_id = $1;
 
 -- name: ListAuditLogs :many
 SELECT * FROM audit_logs
-ORDER BY occurred_at DESC
-LIMIT $1 OFFSET $2;
+WHERE (sqlc.narg(actor)::VARCHAR IS NULL OR actor ILIKE '%' || sqlc.narg(actor)::VARCHAR || '%')
+  AND (sqlc.narg(action)::VARCHAR IS NULL OR action = sqlc.narg(action)::VARCHAR)
+  AND (sqlc.narg(success)::BOOLEAN IS NULL OR success = sqlc.narg(success)::BOOLEAN)
+  AND (
+    sqlc.narg(before_occurred_at)::TIMESTAMPTZ IS NULL
+    OR (occurred_at, id) < (sqlc.narg(before_occurred_at)::TIMESTAMPTZ, sqlc.narg(before_id)::VARCHAR)
+  )
+ORDER BY occurred_at DESC, id DESC
+LIMIT sqlc.arg(page_limit);
 
 -- name: ListAdminSessionsByAdmin :many
 SELECT * FROM admin_sessions

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -218,6 +218,8 @@ COMMENT ON COLUMN audit_logs.id IS '감사 로그 고유 식별자';
 COMMENT ON COLUMN audit_logs.actor IS '행위자 (관리자 ID, 진행자 ID 등)';
 COMMENT ON COLUMN audit_logs.action IS '수행한 동작 (예: APPROVED_DEVICE, FAILED_PIN 등)';
 COMMENT ON COLUMN audit_logs.target IS '동작의 대상 (기기 ID, 트랙 ID 등)';
+CREATE INDEX idx_audit_logs_occurred_at_id ON audit_logs (occurred_at DESC, id DESC);
+CREATE INDEX idx_audit_logs_action_success_occurred_at_id ON audit_logs (action, success, occurred_at DESC, id DESC);
 COMMENT ON COLUMN audit_logs.success IS '동작 성공 여부';
 COMMENT ON COLUMN audit_logs.occurred_at IS '이벤트 발생 시간';
 COMMENT ON COLUMN audit_logs.metadata IS '이벤트와 관련된 추가 정보 (JSON)';

--- a/backend/docs/artifacts/plan/20260713_issue_47_camp_settings_patch_plan_.md
+++ b/backend/docs/artifacts/plan/20260713_issue_47_camp_settings_patch_plan_.md
@@ -1,0 +1,25 @@
+# GitHub Issue #47 — 캠프 정보·병목 기준 수정 API 구현 계획
+
+> 이슈: https://github.com/lsjtop10/cornermon/issues/47
+
+## 구현 현황
+
+- [x] pointer web DTO와 `domain.Optional[T]` patch 값 객체 구현
+- [x] 이름·예정 기간·최소 표본·비율 불변식 구현
+- [x] ENDED 캠프 전용 conflict sentinel 및 HTTP 409 매핑
+- [x] 기존 `CampRepository.Save`를 사용한 트랜잭션 저장
+- [x] 성공/실패 감사 로그와 성공 커밋 후 `camp_updated` SSE 구현
+- [x] `PATCH /camps/{id}` 라우트·handler·Swagger/OpenAPI 계약 동기화
+- [x] 부분 수정, lifecycle 시각 보존, 범위, 없음/ENDED, 감사/SSE 테스트
+
+## 자체 리뷰
+
+- patch 검증은 로컬 복사본에서 끝난 뒤 엔티티에 반영되어 잘못된 patch가 부분 적용되지 않는다.
+- `StartAt`/`EndAt`만 수정하며 `ActivatedAt`/`EndedAt`은 변경하지 않는다.
+- DB schema 변경 없이 기존 Save 쿼리를 재사용한다.
+- SSE는 트랜잭션 성공 후에만 발생하고 실패 시 실패 감사 로그만 남긴다.
+
+## 검증
+
+- `go test ./...`
+- `go test -race ./internal/domain ./internal/usecase ./internal/infrastructure/web`

--- a/backend/docs/artifacts/plan/20260713_issue_48_audit_filters_cursor_plan_.md
+++ b/backend/docs/artifacts/plan/20260713_issue_48_audit_filters_cursor_plan_.md
@@ -1,0 +1,31 @@
+# GitHub Issue #48 — 감사 로그 필터·커서 페이지네이션 구현 계획
+
+> 이슈: https://github.com/lsjtop10/cornermon/issues/48
+
+## 구현 현황
+
+- [x] nullable actor/action/success 필터를 DB query에 적용
+- [x] `(occurred_at, id)` 내림차순 복합 keyset 조건 적용
+- [x] 조회 인덱스와 sqlc 원본/생성물 동기화
+- [x] `limit+1` 기반 next cursor 계산
+- [x] base64url JSON cursor codec와 query parameter 검증
+- [x] Swagger 및 OpenAPI 3.0 응답을 `{logs, nextCursor}`로 동기화
+- [x] handler 필터/경계/cursor 단위 테스트 추가
+- [x] repository 장애에 `errs.Wrap` 적용 및 하위 계층 무로깅 확인
+
+## 자체 리뷰
+
+- 커서에는 동일 시각 레코드의 안정적 tie-breaker인 ID가 포함된다.
+- SQL 정렬과 커서 비교가 모두 `occurred_at DESC, id DESC`로 일치한다.
+- actor 부분 검색, action 정확 일치, success nullable 조건은 전체 조회 후 필터링하지 않는다.
+- 공개 계약에 구현되지 않은 임의 정렬 파라미터를 남기지 않아 SQL 문자열 삽입 경로가 없다.
+- 원본 `query.sql`에서 sqlc 생성물을 재생성해 수동 생성물 편집 불일치를 제거했다.
+
+## 검증 체크리스트
+
+- [x] 필터가 전체 데이터가 아닌 DB query에 적용된다.
+- [x] 동일 timestamp 로그도 페이지 간 중복·누락되지 않는다.
+- [x] cursor는 opaque base64url 값이다.
+- [x] malformed cursor/잘못된 result/limit은 400이다.
+- [x] repository 오류는 `errs.Wrap`되고 하위 계층에서 직접 로그하지 않는다.
+- [x] Swagger 응답이 `{logs, nextCursor}` 형태와 일치한다.

--- a/backend/internal/domain/camp.go
+++ b/backend/internal/domain/camp.go
@@ -35,7 +35,7 @@ type CampSettingsPatch struct {
 
 func (c *Camp) UpdateSettings(patch CampSettingsPatch) error {
 	if c.Status == CampEnded {
-		return ErrCampInvalidTransition
+		return ErrCampSettingsLocked
 	}
 
 	name := c.Name

--- a/backend/internal/domain/camp_test.go
+++ b/backend/internal/domain/camp_test.go
@@ -134,3 +134,74 @@ func TestCamp_End(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateSettingsShoudPatchOnlySpecifiedFieldsWhenValid(t *testing.T) {
+	// Arrange
+	start := time.Date(2026, 7, 13, 9, 0, 0, 0, time.UTC)
+	end := start.Add(8 * time.Hour)
+	activated := start.Add(time.Hour)
+	camp := &domain.Camp{
+		Name: "Original", StartAt: start, EndAt: end, Status: domain.CampActive,
+		ActivatedAt: domain.Some(activated), BottleneckMinSamples: 3, BottleneckRatioPct: 20,
+	}
+
+	// Act
+	err := camp.UpdateSettings(domain.CampSettingsPatch{Name: domain.Some("  Updated  "), BottleneckRatioPct: domain.Some(35)})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if camp.Name != "Updated" || camp.BottleneckRatioPct != 35 || camp.StartAt != start || camp.EndAt != end || camp.BottleneckMinSamples != 3 {
+		t.Fatalf("unexpected patched camp: %+v", camp)
+	}
+	gotActivated, ok := camp.ActivatedAt.Value()
+	if !ok || gotActivated != activated || camp.EndedAt.IsSet() {
+		t.Fatalf("actual lifecycle timestamps changed: %+v", camp)
+	}
+}
+
+func TestUpdateSettingsShoudRejectInvalidPatchWithoutMutation(t *testing.T) {
+	start := time.Date(2026, 7, 13, 9, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		patch domain.CampSettingsPatch
+	}{
+		{name: "blank name", patch: domain.CampSettingsPatch{Name: domain.Some("  ")}},
+		{name: "invalid period", patch: domain.CampSettingsPatch{StartAt: domain.Some(start.Add(2 * time.Hour)), EndAt: domain.Some(start)}},
+		{name: "non-positive samples", patch: domain.CampSettingsPatch{BottleneckMinSamples: domain.Some(0)}},
+		{name: "ratio below range", patch: domain.CampSettingsPatch{BottleneckRatioPct: domain.Some(-1)}},
+		{name: "ratio above range", patch: domain.CampSettingsPatch{BottleneckRatioPct: domain.Some(101)}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			camp := &domain.Camp{Name: "Original", StartAt: start, EndAt: start.Add(time.Hour), Status: domain.CampPending, BottleneckMinSamples: 3, BottleneckRatioPct: 20}
+			before := *camp
+
+			// Act
+			err := camp.UpdateSettings(tc.patch)
+
+			// Assert
+			if err != domain.ErrCampInvalidSettings {
+				t.Fatalf("expected ErrCampInvalidSettings, got %v", err)
+			}
+			if *camp != before {
+				t.Fatalf("invalid patch mutated camp: before=%+v after=%+v", before, *camp)
+			}
+		})
+	}
+}
+
+func TestUpdateSettingsShoudReturnConflictErrorWhenCampEnded(t *testing.T) {
+	// Arrange
+	camp := &domain.Camp{Status: domain.CampEnded}
+
+	// Act
+	err := camp.UpdateSettings(domain.CampSettingsPatch{Name: domain.Some("Updated")})
+
+	// Assert
+	if err != domain.ErrCampSettingsLocked {
+		t.Fatalf("expected ErrCampSettingsLocked, got %v", err)
+	}
+}

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -27,6 +27,7 @@ var (
 	ErrCornerNotFound          = errors.New("corner: not found")
 	ErrCampNotFound            = errors.New("camp: not found")
 	ErrCampInvalidSettings     = errors.New("camp: invalid settings")
+	ErrCampSettingsLocked      = errors.New("camp: settings are locked after ending")
 	ErrTrackCampMismatch       = errors.New("track: target corner belongs to another camp")
 )
 

--- a/backend/internal/infrastructure/web/audit_handler_test.go
+++ b/backend/internal/infrastructure/web/audit_handler_test.go
@@ -1,0 +1,105 @@
+package web
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/usecase"
+	"github.com/labstack/echo/v4"
+)
+
+type auditLogQuerierStub struct {
+	query usecase.AuditLogQuery
+	page  *usecase.AuditLogPage
+}
+
+func (s *auditLogQuerierStub) List(_ context.Context, query usecase.AuditLogQuery) (*usecase.AuditLogPage, error) {
+	s.query = query
+	return s.page, nil
+}
+
+func TestListAuditLogsShoudApplyFiltersAndCursorWhenValid(t *testing.T) {
+	// arrange
+	e := echo.New()
+	cursor := usecase.AuditLogCursor{OccurredAt: time.Date(2026, 7, 13, 10, 0, 0, 0, time.UTC), ID: "audit-2"}
+	stub := &auditLogQuerierStub{page: &usecase.AuditLogPage{
+		Logs: []*domain.AuditLog{{ID: "audit-1", Actor: "admin-1", Action: "UPDATE_CAMP", Success: true}},
+		NextCursor: domain.Some(cursor),
+	}}
+	req := httptest.NewRequest(http.MethodGet, "/audit-logs?actor=admin&action=UPDATE_CAMP&result=success&limit=25&before="+encodeAuditLogCursor(cursor), nil)
+	rec := httptest.NewRecorder()
+
+	// act
+	err := NewAuditHandler(stub).ListAuditLogs(e.NewContext(req, rec))
+
+	// assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stub.query.Actor != "admin" || stub.query.Action != "UPDATE_CAMP" || stub.query.Limit != 25 {
+		t.Fatalf("unexpected query: %+v", stub.query)
+	}
+	if stub.query.Success == nil || !*stub.query.Success {
+		t.Fatalf("success filter was not forwarded: %+v", stub.query.Success)
+	}
+	before, ok := stub.query.Before.Value()
+	if !ok || before != cursor {
+		t.Fatalf("cursor was not forwarded: %+v", before)
+	}
+	var response AuditLogPageResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(response.Logs) != 1 || response.NextCursor == "" {
+		t.Fatalf("unexpected page response: %+v", response)
+	}
+}
+
+func TestListAuditLogsShoudRejectInvalidParametersWhenMalformed(t *testing.T) {
+	tests := []string{
+		"/audit-logs?limit=0",
+		"/audit-logs?limit=201",
+		"/audit-logs?limit=invalid",
+		"/audit-logs?result=unknown",
+		"/audit-logs?before=not-base64",
+	}
+	for _, target := range tests {
+		t.Run(target, func(t *testing.T) {
+			// arrange
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, target, nil)
+			rec := httptest.NewRecorder()
+
+			// act
+			err := NewAuditHandler(nil).ListAuditLogs(e.NewContext(req, rec))
+
+			// assert
+			httpErr, ok := err.(*echo.HTTPError)
+			if !ok || httpErr.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400 HTTP error, got %v", err)
+			}
+		})
+	}
+}
+
+func TestAuditLogCursorShoudPreserveTieBreakerWhenRoundTripped(t *testing.T) {
+	// arrange
+	want := usecase.AuditLogCursor{OccurredAt: time.Date(2026, 7, 13, 10, 0, 0, 123, time.UTC), ID: "audit-tie-breaker"}
+
+	// act
+	encoded := encodeAuditLogCursor(want)
+	got, err := decodeAuditLogCursor(encoded)
+
+	// assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Fatalf("cursor mismatch: got %+v, want %+v", got, want)
+	}
+}

--- a/backend/internal/infrastructure/web/camp_handler_test.go
+++ b/backend/internal/infrastructure/web/camp_handler_test.go
@@ -1,0 +1,31 @@
+package web
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUpdateCampRequestShoudDistinguishOmittedFieldsFromZeroValues(t *testing.T) {
+	// Arrange
+	var request UpdateCampRequest
+
+	// Act
+	err := json.Unmarshal([]byte(`{"name":"","bottleneckMinSamples":0,"bottleneckRatioPct":0}`), &request)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected decode error: %v", err)
+	}
+	if request.Name == nil || *request.Name != "" {
+		t.Fatalf("explicit empty name was treated as omitted: %+v", request.Name)
+	}
+	if request.BottleneckMinSamples == nil || *request.BottleneckMinSamples != 0 {
+		t.Fatalf("explicit zero samples was treated as omitted: %+v", request.BottleneckMinSamples)
+	}
+	if request.BottleneckRatioPct == nil || *request.BottleneckRatioPct != 0 {
+		t.Fatalf("explicit zero ratio was treated as omitted: %+v", request.BottleneckRatioPct)
+	}
+	if request.StartAt != nil || request.EndAt != nil {
+		t.Fatalf("omitted dates were unexpectedly set: start=%v end=%v", request.StartAt, request.EndAt)
+	}
+}

--- a/backend/internal/infrastructure/web/error_handler_middleware.go
+++ b/backend/internal/infrastructure/web/error_handler_middleware.go
@@ -131,6 +131,8 @@ func mapDomainError(err error) (int, string) {
 		return http.StatusNotFound, "CAMP_NOT_FOUND"
 	case errors.Is(err, domain.ErrCampInvalidSettings):
 		return http.StatusBadRequest, "INVALID_CAMP_SETTINGS"
+	case errors.Is(err, domain.ErrCampSettingsLocked):
+		return http.StatusConflict, "CAMP_SETTINGS_LOCKED"
 	case errors.Is(err, domain.ErrTrackCampMismatch):
 		return http.StatusConflict, "TRACK_CAMP_MISMATCH"
 	default:

--- a/backend/internal/usecase/camp_test.go
+++ b/backend/internal/usecase/camp_test.go
@@ -2,11 +2,16 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"cornermon/backend/internal/domain"
 )
+
+type failingTxManager struct{ err error }
+
+func (m failingTxManager) RunInTx(context.Context, func(context.Context) error) error { return m.err }
 
 func TestCampService_ActivateCamp(t *testing.T) {
 	t.Run("ShouldActivateCampSuccessfullyWhenPending", func(t *testing.T) {
@@ -93,4 +98,67 @@ func TestCampService_EndCamp(t *testing.T) {
 			t.Errorf("expected EventCampUpdated and EventCampEnded broadcast with scope 'camp', got %v", broadcaster.Broadcasts)
 		}
 	})
+}
+
+func TestUpdateCampSettingsShoudAuditAndBroadcastWhenSaveSucceeds(t *testing.T) {
+	// Arrange
+	camps := NewMockCampRepository()
+	camp := &domain.Camp{ID: "camp-1", Name: "Original", Status: domain.CampActive, BottleneckMinSamples: 3, BottleneckRatioPct: 20}
+	_ = camps.Save(context.Background(), camp)
+	audits := &MockAuditLogRepository{}
+	broadcaster := &MockBroadcaster{}
+	service := NewCampService(camps, nil, NewMockFacilitatorSessionRepository(), audits, broadcaster, &MockTxManager{})
+	service.uuidFn = func() string { return "audit-1" }
+
+	// Act
+	updated, err := service.UpdateCampSettings(context.Background(), "camp-1", "admin-1", domain.CampSettingsPatch{Name: domain.Some("Updated")})
+
+	// Assert
+	if err != nil || updated.Name != "Updated" {
+		t.Fatalf("unexpected result: camp=%+v err=%v", updated, err)
+	}
+	if len(audits.Logs) != 1 || !audits.Logs[0].Success || audits.Logs[0].Actor != "admin-1" {
+		t.Fatalf("success audit missing: %+v", audits.Logs)
+	}
+	if len(broadcaster.Broadcasts) != 1 || broadcaster.Broadcasts[0].Event != EventCampUpdated {
+		t.Fatalf("camp_updated broadcast missing: %+v", broadcaster.Broadcasts)
+	}
+}
+
+func TestUpdateCampSettingsShoudAuditFailureWithoutBroadcastWhenTransactionFails(t *testing.T) {
+	// Arrange
+	camps := NewMockCampRepository()
+	_ = camps.Save(context.Background(), &domain.Camp{ID: "camp-1", Name: "Original", Status: domain.CampActive, BottleneckMinSamples: 3, BottleneckRatioPct: 20})
+	audits := &MockAuditLogRepository{}
+	broadcaster := &MockBroadcaster{}
+	txErr := errors.New("save failed")
+	service := NewCampService(camps, nil, NewMockFacilitatorSessionRepository(), audits, broadcaster, failingTxManager{err: txErr})
+	service.uuidFn = func() string { return "audit-1" }
+
+	// Act
+	_, err := service.UpdateCampSettings(context.Background(), "camp-1", "admin-1", domain.CampSettingsPatch{Name: domain.Some("Updated")})
+
+	// Assert
+	if !errors.Is(err, txErr) {
+		t.Fatalf("expected transaction error, got %v", err)
+	}
+	if len(audits.Logs) != 1 || audits.Logs[0].Success {
+		t.Fatalf("failure audit missing: %+v", audits.Logs)
+	}
+	if len(broadcaster.Broadcasts) != 0 {
+		t.Fatalf("broadcast occurred before successful commit: %+v", broadcaster.Broadcasts)
+	}
+}
+
+func TestUpdateCampSettingsShoudReturnNotFoundWhenCampMissing(t *testing.T) {
+	// Arrange
+	service := NewCampService(NewMockCampRepository(), nil, NewMockFacilitatorSessionRepository(), &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+
+	// Act
+	_, err := service.UpdateCampSettings(context.Background(), "missing", "admin-1", domain.CampSettingsPatch{})
+
+	// Assert
+	if err != domain.ErrCampNotFound {
+		t.Fatalf("expected ErrCampNotFound, got %v", err)
+	}
 }

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -114,6 +114,28 @@ type AuditLogRepository interface {
 	Save(ctx context.Context, log *domain.AuditLog) error
 }
 
+type AuditLogQuerier interface {
+	List(ctx context.Context, query AuditLogQuery) (*AuditLogPage, error)
+}
+
+type AuditLogCursor struct {
+	OccurredAt time.Time
+	ID         domain.AuditLogID
+}
+
+type AuditLogQuery struct {
+	Actor   string
+	Action  string
+	Success *bool
+	Before  domain.Optional[AuditLogCursor]
+	Limit   int
+}
+
+type AuditLogPage struct {
+	Logs       []*domain.AuditLog
+	NextCursor domain.Optional[AuditLogCursor]
+}
+
 type NotificationEvent string
 
 const (


### PR DESCRIPTION
## 변경 사항
- ENDED 캠프 설정 잠금 sentinel을 추가하고 HTTP 409로 매핑했습니다.
- 부분 patch, lifecycle timestamp 보존, 기간/범위 불변식을 테스트했습니다.
- 성공/실패 감사 로그와 커밋 후 SSE 동작을 검증했습니다.
- OpenAPI의 PATCH 의미, 0~100 비율, 400/404/409 응답을 동기화했습니다.

## 변경 이유
기존 ENDED 수정 오류가 일반 400으로 매핑되었고, 계획에 명시된 부분 수정·감사·SSE 검증이 누락되어 있었습니다.

## 종료 조건 증명
- `go test ./...` 통과
- `go test -race ./internal/domain ./internal/usecase ./internal/infrastructure/web` 통과
- DB schema 변경 없이 기존 Save 재사용
- PR diff: 210 additions / 3 deletions

Closes #47
