### PR TITLE
fix: SSE broadcaster 캠프 격리와 Scope 타입화

### DIFF
--- a/backend/internal/infrastructure/sse/broadcaster.go
+++ b/backend/internal/infrastructure/sse/broadcaster.go
@@ -28,6 +28,10 @@ func NewBroadcaster() *BroadcasterImpl {
 	}
 }
 
+// Broadcast는 커밋된 변경을 알리는 best-effort fan-out이다. 요청 context 취소는 이미
+// 커밋된 알림을 취소해서는 안 되므로 여기서 사용하지 않고, 연결 수명은 구독 context가 관리한다.
+// 버퍼가 찬 구독자에게 서버가 메시지를 재시도·저장하지 않는 이유는 SSE 알림이 최신 상태를
+// REST로 다시 조회하라는 신호이기 때문이다. 해당 연결을 닫아 클라이언트가 재연결·resync하도록 한다.
 func (b *BroadcasterImpl) Broadcast(_ context.Context, campID domain.CampID, event usecase.NotificationEvent, scope usecase.Scope) error {
 	message := usecase.SSEMessage{Event: event, Scope: scope}
 	var fullAdminSubs []chan usecase.SSEMessage

--- a/backend/internal/infrastructure/sse/broadcaster.go
+++ b/backend/internal/infrastructure/sse/broadcaster.go
@@ -2,96 +2,154 @@ package sse
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"sync"
 
 	"cornermon/backend/internal/domain"
 	"cornermon/backend/internal/usecase"
 )
 
+const subscriberBufferSize = 100
+
+type trackSubscription struct {
+	campID domain.CampID
+	chans  map[chan usecase.SSEMessage]struct{}
+}
+
 type BroadcasterImpl struct {
 	mu        sync.RWMutex
-	adminSubs map[chan string]struct{}
-	trackSubs map[string]map[chan string]struct{}
+	adminSubs map[domain.CampID]map[chan usecase.SSEMessage]struct{}
+	trackSubs map[domain.TrackID]*trackSubscription
 }
 
 func NewBroadcaster() *BroadcasterImpl {
 	return &BroadcasterImpl{
-		adminSubs: make(map[chan string]struct{}),
-		trackSubs: make(map[string]map[chan string]struct{}),
+		adminSubs: make(map[domain.CampID]map[chan usecase.SSEMessage]struct{}),
+		trackSubs: make(map[domain.TrackID]*trackSubscription),
 	}
 }
 
-func (b *BroadcasterImpl) Broadcast(ctx context.Context, campID domain.CampID, event usecase.NotificationEvent, scope string) error {
+func (b *BroadcasterImpl) Broadcast(_ context.Context, campID domain.CampID, event usecase.NotificationEvent, scope usecase.Scope) error {
+	message := usecase.SSEMessage{Event: event, Scope: scope}
+	var fullAdminSubs []chan usecase.SSEMessage
+	var fullTrackSubs []chan usecase.SSEMessage
+
 	b.mu.RLock()
-	defer b.mu.RUnlock()
-
-	msg := fmt.Sprintf("event: %s\ndata: {\"scope\": \"%s\"}", event, scope)
-
-	for ch := range b.adminSubs {
+	for ch := range b.adminSubs[campID] {
 		select {
-		case ch <- msg:
+		case ch <- message:
 		default:
+			fullAdminSubs = append(fullAdminSubs, ch)
 		}
 	}
 
-	isBroadcast := scope == "broadcast"
-	var targetTrackID string
-	if strings.HasPrefix(scope, "track:") {
-		targetTrackID = strings.TrimPrefix(scope, "track:")
-	}
-
-	for trackID, subs := range b.trackSubs {
-		if isBroadcast || scope == "camp" || targetTrackID == trackID {
-			for ch := range subs {
-				select {
-				case ch <- msg:
-				default:
-				}
+	for trackID, subscription := range b.trackSubs {
+		if subscription.campID != campID || (scope.Kind == usecase.ScopeTrack && scope.TrackID != trackID) {
+			continue
+		}
+		for ch := range subscription.chans {
+			select {
+			case ch <- message:
+			default:
+				fullTrackSubs = append(fullTrackSubs, ch)
 			}
 		}
 	}
+	b.mu.RUnlock()
 
+	if len(fullAdminSubs) > 0 || len(fullTrackSubs) > 0 {
+		b.removeFullSubscribers(campID, fullAdminSubs, fullTrackSubs)
+	}
 	return nil
 }
 
-func (b *BroadcasterImpl) SubscribeAdmin(ctx context.Context) (<-chan string, error) {
-	ch := make(chan string, 100)
+func (b *BroadcasterImpl) SubscribeAdmin(ctx context.Context, campID domain.CampID) (<-chan usecase.SSEMessage, error) {
+	ch := make(chan usecase.SSEMessage, subscriberBufferSize)
 	b.mu.Lock()
-	b.adminSubs[ch] = struct{}{}
+	if b.adminSubs[campID] == nil {
+		b.adminSubs[campID] = make(map[chan usecase.SSEMessage]struct{})
+	}
+	b.adminSubs[campID][ch] = struct{}{}
 	b.mu.Unlock()
 
 	go func() {
 		<-ctx.Done()
-		b.mu.Lock()
-		delete(b.adminSubs, ch)
-		b.mu.Unlock()
-		close(ch)
+		b.removeAdminSubscriber(campID, ch)
 	}()
 	return ch, nil
 }
 
-func (b *BroadcasterImpl) SubscribeTrack(ctx context.Context, trackID string) (<-chan string, error) {
-	ch := make(chan string, 100)
+func (b *BroadcasterImpl) SubscribeTrack(ctx context.Context, campID domain.CampID, trackID domain.TrackID) (<-chan usecase.SSEMessage, error) {
+	ch := make(chan usecase.SSEMessage, subscriberBufferSize)
 	b.mu.Lock()
 	if b.trackSubs[trackID] == nil {
-		b.trackSubs[trackID] = make(map[chan string]struct{})
+		b.trackSubs[trackID] = &trackSubscription{
+			campID: campID,
+			chans:  make(map[chan usecase.SSEMessage]struct{}),
+		}
 	}
-	b.trackSubs[trackID][ch] = struct{}{}
+	b.trackSubs[trackID].chans[ch] = struct{}{}
 	b.mu.Unlock()
 
 	go func() {
 		<-ctx.Done()
-		b.mu.Lock()
-		if subs, ok := b.trackSubs[trackID]; ok {
-			delete(subs, ch)
-			if len(subs) == 0 {
-				delete(b.trackSubs, trackID)
-			}
-		}
-		b.mu.Unlock()
-		close(ch)
+		b.removeTrackSubscriber(trackID, ch)
 	}()
 	return ch, nil
+}
+
+func (b *BroadcasterImpl) removeFullSubscribers(campID domain.CampID, adminSubs, trackSubs []chan usecase.SSEMessage) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for _, ch := range adminSubs {
+		if _, ok := b.adminSubs[campID][ch]; ok {
+			delete(b.adminSubs[campID], ch)
+			close(ch)
+		}
+	}
+	if len(b.adminSubs[campID]) == 0 {
+		delete(b.adminSubs, campID)
+	}
+
+	for trackID, subscription := range b.trackSubs {
+		for _, ch := range trackSubs {
+			if _, ok := subscription.chans[ch]; ok {
+				delete(subscription.chans, ch)
+				close(ch)
+			}
+		}
+		if len(subscription.chans) == 0 {
+			delete(b.trackSubs, trackID)
+		}
+	}
+}
+
+func (b *BroadcasterImpl) removeAdminSubscriber(campID domain.CampID, ch chan usecase.SSEMessage) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if _, ok := b.adminSubs[campID][ch]; !ok {
+		return
+	}
+	delete(b.adminSubs[campID], ch)
+	if len(b.adminSubs[campID]) == 0 {
+		delete(b.adminSubs, campID)
+	}
+	close(ch)
+}
+
+func (b *BroadcasterImpl) removeTrackSubscriber(trackID domain.TrackID, ch chan usecase.SSEMessage) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	subscription, ok := b.trackSubs[trackID]
+	if !ok {
+		return
+	}
+	if _, ok := subscription.chans[ch]; !ok {
+		return
+	}
+	delete(subscription.chans, ch)
+	if len(subscription.chans) == 0 {
+		delete(b.trackSubs, trackID)
+	}
+	close(ch)
 }

--- a/backend/internal/infrastructure/sse/broadcaster_test.go
+++ b/backend/internal/infrastructure/sse/broadcaster_test.go
@@ -1,0 +1,111 @@
+package sse
+
+import (
+	"context"
+	"testing"
+
+	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/usecase"
+)
+
+func TestShouldIsolateSubscribersWhenBroadcastingAcrossCamps(t *testing.T) {
+	// Arrange
+	broadcaster := NewBroadcaster()
+	campAAdmin, _ := broadcaster.SubscribeAdmin(context.Background(), "camp-a")
+	campBAdmin, _ := broadcaster.SubscribeAdmin(context.Background(), "camp-b")
+	campATrack, _ := broadcaster.SubscribeTrack(context.Background(), "camp-a", "track-a")
+	campBTrack, _ := broadcaster.SubscribeTrack(context.Background(), "camp-b", "track-b")
+
+	// Act
+	err := broadcaster.Broadcast(context.Background(), "camp-a", usecase.EventCampUpdated, usecase.CampScope())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Broadcast() error = %v", err)
+	}
+	assertMessageReceived(t, campAAdmin, usecase.EventCampUpdated)
+	assertMessageReceived(t, campATrack, usecase.EventCampUpdated)
+	assertNoMessage(t, campBAdmin)
+	assertNoMessage(t, campBTrack)
+}
+
+func TestShouldSendOnlyTargetTrackWhenBroadcastingTrackScope(t *testing.T) {
+	// Arrange
+	broadcaster := NewBroadcaster()
+	target, _ := broadcaster.SubscribeTrack(context.Background(), "camp-a", "track-a")
+	other, _ := broadcaster.SubscribeTrack(context.Background(), "camp-a", "track-b")
+
+	// Act
+	_ = broadcaster.Broadcast(context.Background(), "camp-a", usecase.EventTrackUpdated, usecase.TrackScope("track-a"))
+
+	// Assert
+	assertMessageReceived(t, target, usecase.EventTrackUpdated)
+	assertNoMessage(t, other)
+}
+
+func TestShouldCloseSubscriberWhenBufferIsFull(t *testing.T) {
+	// Arrange
+	broadcaster := NewBroadcaster()
+	admin, _ := broadcaster.SubscribeAdmin(context.Background(), "camp-a")
+	for range subscriberBufferSize {
+		_ = broadcaster.Broadcast(context.Background(), "camp-a", usecase.EventCampUpdated, usecase.CampScope())
+	}
+
+	// Act
+	_ = broadcaster.Broadcast(context.Background(), "camp-a", usecase.EventCampUpdated, usecase.CampScope())
+
+	// Assert
+	for range subscriberBufferSize {
+		<-admin
+	}
+	if _, ok := <-admin; ok {
+		t.Fatal("full subscriber channel should be closed")
+	}
+	if _, ok := broadcaster.adminSubs[domain.CampID("camp-a")]; ok {
+		t.Fatal("full subscriber should be removed from registry")
+	}
+}
+
+func TestShouldCloseTrackSubscriberWhenBufferIsFull(t *testing.T) {
+	// Arrange
+	broadcaster := NewBroadcaster()
+	track, _ := broadcaster.SubscribeTrack(context.Background(), "camp-a", "track-a")
+	for range subscriberBufferSize {
+		_ = broadcaster.Broadcast(context.Background(), "camp-a", usecase.EventTrackUpdated, usecase.TrackScope("track-a"))
+	}
+
+	// Act
+	_ = broadcaster.Broadcast(context.Background(), "camp-a", usecase.EventTrackUpdated, usecase.TrackScope("track-a"))
+
+	// Assert
+	for range subscriberBufferSize {
+		<-track
+	}
+	if _, ok := <-track; ok {
+		t.Fatal("full track subscriber channel should be closed")
+	}
+	if _, ok := broadcaster.trackSubs[domain.TrackID("track-a")]; ok {
+		t.Fatal("full track subscriber should be removed from registry")
+	}
+}
+
+func assertMessageReceived(t *testing.T, ch <-chan usecase.SSEMessage, event usecase.NotificationEvent) {
+	t.Helper()
+	select {
+	case message := <-ch:
+		if message.Event != event {
+			t.Fatalf("message event = %q, want %q", message.Event, event)
+		}
+	default:
+		t.Fatal("expected message, got none")
+	}
+}
+
+func assertNoMessage(t *testing.T, ch <-chan usecase.SSEMessage) {
+	t.Helper()
+	select {
+	case message := <-ch:
+		t.Fatalf("unexpected message: %+v", message)
+	default:
+	}
+}

--- a/backend/internal/usecase/auth_admin.go
+++ b/backend/internal/usecase/auth_admin.go
@@ -263,6 +263,6 @@ func (s *AdminAuthService) ForceTrackLogout(ctx context.Context, trackID domain.
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), "TRACK_FORCE_LOGOUT", string(trackID), true, nil)
-	_ = s.broadcaster.Broadcast(ctx, corner.CampID, EventSessionRevoked, string(trackID))
+	_ = s.broadcaster.Broadcast(ctx, corner.CampID, EventSessionRevoked, TrackScope(trackID))
 	return nil
 }

--- a/backend/internal/usecase/auth_facilitator.go
+++ b/backend/internal/usecase/auth_facilitator.go
@@ -111,7 +111,7 @@ func (s *FacilitatorAuthService) Login(
 		_ = s.devices.Save(ctx, device)
 
 		if needsAdminAlert {
-			_ = s.broadcaster.Broadcast(ctx, device.CampID, EventLockoutAlert, "device:"+string(device.ID))
+			_ = s.broadcaster.Broadcast(ctx, device.CampID, EventLockoutAlert, CampScope())
 		}
 
 		s.recordAuditLog(ctx, "anonymous", "FACILITATOR_LOGIN", "", false, map[string]any{"error": "invalid pin", "device_failures": device.FailedPinAttempts})

--- a/backend/internal/usecase/auth_facilitator_test.go
+++ b/backend/internal/usecase/auth_facilitator_test.go
@@ -235,7 +235,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 		if len(broadcaster.Broadcasts) != 1 ||
 			broadcaster.Broadcasts[0].CampID != "camp-1" ||
 			broadcaster.Broadcasts[0].Event != EventLockoutAlert ||
-			broadcaster.Broadcasts[0].Scope != "device:device-1" {
+			broadcaster.Broadcasts[0].Scope != CampScope() {
 			t.Errorf("expected EventLockoutAlert broadcast, got %v", broadcaster.Broadcasts)
 		}
 	})

--- a/backend/internal/usecase/camp.go
+++ b/backend/internal/usecase/camp.go
@@ -97,7 +97,7 @@ func (s *CampService) UpdateCampSettings(
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), "CAMP_SETTINGS_UPDATE", string(campID), true, nil)
-	_ = s.broadcaster.Broadcast(ctx, campID, EventCampUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, campID, EventCampUpdated, CampScope())
 	return camp, nil
 }
 
@@ -130,7 +130,7 @@ func (s *CampService) ActivateCamp(
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), "CAMP_ACTIVATE", string(campID), true, nil)
-	_ = s.broadcaster.Broadcast(ctx, campID, EventCampUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, campID, EventCampUpdated, CampScope())
 
 	return nil
 }
@@ -177,8 +177,8 @@ func (s *CampService) EndCamp(
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), "CAMP_END", string(campID), true, nil)
-	_ = s.broadcaster.Broadcast(ctx, campID, EventCampUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, campID, EventCampEnded, "camp")
+	_ = s.broadcaster.Broadcast(ctx, campID, EventCampUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, campID, EventCampEnded, CampScope())
 
 	return nil
 }

--- a/backend/internal/usecase/camp_test.go
+++ b/backend/internal/usecase/camp_test.go
@@ -43,7 +43,7 @@ func TestCampService_ActivateCamp(t *testing.T) {
 			t.Errorf("expected status 'ACTIVE', got %s", updated.Status)
 		}
 
-		if len(broadcaster.Broadcasts) != 1 || broadcaster.Broadcasts[0].Event != EventCampUpdated || broadcaster.Broadcasts[0].Scope != "camp" {
+		if len(broadcaster.Broadcasts) != 1 || broadcaster.Broadcasts[0].Event != EventCampUpdated || broadcaster.Broadcasts[0].Scope != CampScope() {
 			t.Errorf("expected EventCampUpdated broadcast with scope 'camp', got %v", broadcaster.Broadcasts)
 		}
 	})
@@ -93,8 +93,8 @@ func TestCampService_EndCamp(t *testing.T) {
 		}
 
 		if len(broadcaster.Broadcasts) != 2 ||
-			broadcaster.Broadcasts[0].Event != EventCampUpdated || broadcaster.Broadcasts[0].Scope != "camp" ||
-			broadcaster.Broadcasts[1].Event != EventCampEnded || broadcaster.Broadcasts[1].Scope != "camp" {
+			broadcaster.Broadcasts[0].Event != EventCampUpdated || broadcaster.Broadcasts[0].Scope != CampScope() ||
+			broadcaster.Broadcasts[1].Event != EventCampEnded || broadcaster.Broadcasts[1].Scope != CampScope() {
 			t.Errorf("expected EventCampUpdated and EventCampEnded broadcast with scope 'camp', got %v", broadcaster.Broadcasts)
 		}
 	})

--- a/backend/internal/usecase/corner.go
+++ b/backend/internal/usecase/corner.go
@@ -64,7 +64,7 @@ func (s *CornerService) AddLearningCorner(ctx context.Context, campID domain.Cam
 	}
 
 	s.recordAuditLog(ctx, "admin", "CORNER_CREATE", string(corner.ID), true, map[string]any{"campID": string(campID), "name": name})
-	_ = s.broadcaster.Broadcast(ctx, campID, EventCornersUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, campID, EventCornersUpdated, CampScope())
 
 	return corner, nil
 }
@@ -108,7 +108,7 @@ func (s *CornerService) ModifyCornerSpecification(ctx context.Context, id domain
 	}
 
 	s.recordAuditLog(ctx, "admin", "CORNER_UPDATE", string(id), true, map[string]any{"name": name})
-	_ = s.broadcaster.Broadcast(ctx, corner.CampID, EventCornersUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, corner.CampID, EventCornersUpdated, CampScope())
 
 	return corner, nil
 }
@@ -133,7 +133,7 @@ func (s *CornerService) RemoveCornerFromCamp(ctx context.Context, id domain.Corn
 	}
 
 	s.recordAuditLog(ctx, "admin", "CORNER_DELETE", string(id), true, nil)
-	_ = s.broadcaster.Broadcast(ctx, corner.CampID, EventCornersUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, corner.CampID, EventCornersUpdated, CampScope())
 
 	return nil
 }

--- a/backend/internal/usecase/device_trust.go
+++ b/backend/internal/usecase/device_trust.go
@@ -79,7 +79,7 @@ func (s *DeviceTrustService) RequestRegistration(
 	}
 
 	s.recordAuditLog(ctx, "anonymous", "DEVICE_REQUEST", string(reg.ID), true, map[string]any{"campID": string(campID)})
-	_ = s.broadcaster.Broadcast(ctx, campID, EventDeviceRegistrationUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, campID, EventDeviceRegistrationUpdated, CampScope())
 	return plainToken, reg, nil
 }
 
@@ -128,7 +128,7 @@ func (s *DeviceTrustService) ApproveDevice(
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), "DEVICE_APPROVED", string(regID), true, nil)
-	_ = s.broadcaster.Broadcast(ctx, device.CampID, EventDeviceRegistrationUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, device.CampID, EventDeviceRegistrationUpdated, CampScope())
 	return nil
 }
 
@@ -160,7 +160,7 @@ func (s *DeviceTrustService) RejectDevice(
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), "DEVICE_REJECTED", string(regID), true, nil)
-	_ = s.broadcaster.Broadcast(ctx, device.CampID, EventDeviceRegistrationUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, device.CampID, EventDeviceRegistrationUpdated, CampScope())
 	return nil
 }
 
@@ -192,7 +192,7 @@ func (s *DeviceTrustService) RevokeDevice(
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), "DEVICE_REVOKED", string(regID), true, nil)
-	_ = s.broadcaster.Broadcast(ctx, device.CampID, EventDeviceRegistrationUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, device.CampID, EventDeviceRegistrationUpdated, CampScope())
 	return nil
 }
 
@@ -222,7 +222,7 @@ func (s *DeviceTrustService) ResetPinFailures(
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), "PIN_LOCK_RESET", string(regID), true, nil)
-	_ = s.broadcaster.Broadcast(ctx, device.CampID, EventDeviceRegistrationUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, device.CampID, EventDeviceRegistrationUpdated, CampScope())
 	return nil
 }
 

--- a/backend/internal/usecase/device_trust_test.go
+++ b/backend/internal/usecase/device_trust_test.go
@@ -44,7 +44,7 @@ func TestDeviceTrustService_RequestRegistration(t *testing.T) {
 		if len(broadcaster.Broadcasts) != 1 ||
 			broadcaster.Broadcasts[0].CampID != "camp-1" ||
 			broadcaster.Broadcasts[0].Event != EventDeviceRegistrationUpdated ||
-			broadcaster.Broadcasts[0].Scope != "camp" {
+			broadcaster.Broadcasts[0].Scope != CampScope() {
 			t.Errorf("expected EventDeviceRegistrationUpdated broadcast, got %v", broadcaster.Broadcasts)
 		}
 	})
@@ -87,7 +87,7 @@ func TestDeviceTrustService_ApproveDevice(t *testing.T) {
 		if len(broadcaster.Broadcasts) != 1 ||
 			broadcaster.Broadcasts[0].CampID != "camp-1" ||
 			broadcaster.Broadcasts[0].Event != EventDeviceRegistrationUpdated ||
-			broadcaster.Broadcasts[0].Scope != "camp" {
+			broadcaster.Broadcasts[0].Scope != CampScope() {
 			t.Errorf("expected EventDeviceRegistrationUpdated broadcast, got %v", broadcaster.Broadcasts)
 		}
 	})

--- a/backend/internal/usecase/message.go
+++ b/backend/internal/usecase/message.go
@@ -106,7 +106,7 @@ func (s *MessageService) SendBroadcast(
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), "MESSAGE_BROADCAST", string(msg.ID), true, map[string]any{"campID": string(campID)})
-	_ = s.broadcaster.Broadcast(ctx, campID, EventMessagesChanged, "broadcast")
+	_ = s.broadcaster.Broadcast(ctx, campID, EventMessagesChanged, CampScope())
 
 	return msg, nil
 }
@@ -162,7 +162,7 @@ func (s *MessageService) SendDirect(
 		return nil, domain.ErrCornerNotInItinerary
 	}
 
-	_ = s.broadcaster.Broadcast(ctx, corner.CampID, EventMessagesChanged, "track:"+string(trackID))
+	_ = s.broadcaster.Broadcast(ctx, corner.CampID, EventMessagesChanged, TrackScope(trackID))
 
 	return msg, nil
 }

--- a/backend/internal/usecase/message_test.go
+++ b/backend/internal/usecase/message_test.go
@@ -55,7 +55,7 @@ func TestMessageService_SendBroadcast(t *testing.T) {
 		if len(broadcaster.Broadcasts) != 1 ||
 			broadcaster.Broadcasts[0].CampID != "camp-1" ||
 			broadcaster.Broadcasts[0].Event != EventMessagesChanged ||
-			broadcaster.Broadcasts[0].Scope != "broadcast" {
+			broadcaster.Broadcasts[0].Scope != CampScope() {
 			t.Errorf("expected EventMessagesChanged broadcast with scope 'broadcast', got %v", broadcaster.Broadcasts)
 		}
 	})
@@ -105,7 +105,7 @@ func TestMessageService_SendDirect(t *testing.T) {
 		if len(broadcaster.Broadcasts) != 1 ||
 			broadcaster.Broadcasts[0].CampID != "camp-1" ||
 			broadcaster.Broadcasts[0].Event != EventMessagesChanged ||
-			broadcaster.Broadcasts[0].Scope != "track:track-1" {
+			broadcaster.Broadcasts[0].Scope != TrackScope("track-1") {
 			t.Errorf("expected EventMessagesChanged broadcast with scope 'track:track-1', got %v", broadcaster.Broadcasts)
 		}
 	})

--- a/backend/internal/usecase/mock_test.go
+++ b/backend/internal/usecase/mock_test.go
@@ -534,7 +534,7 @@ func (r *MockAuditLogRepository) Save(ctx context.Context, log *domain.AuditLog)
 type BroadcastCall struct {
 	CampID domain.CampID
 	Event  NotificationEvent
-	Scope  string
+	Scope  Scope
 }
 
 // MockBroadcaster
@@ -542,7 +542,7 @@ type MockBroadcaster struct {
 	Broadcasts []BroadcastCall
 }
 
-func (b *MockBroadcaster) Broadcast(ctx context.Context, campID domain.CampID, event NotificationEvent, scope string) error {
+func (b *MockBroadcaster) Broadcast(ctx context.Context, campID domain.CampID, event NotificationEvent, scope Scope) error {
 	b.Broadcasts = append(b.Broadcasts, BroadcastCall{
 		CampID: campID,
 		Event:  event,

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -153,9 +153,51 @@ const (
 	EventLockoutAlert              NotificationEvent = "lockout_alert"
 )
 
+func NotificationEvents() []NotificationEvent {
+	return []NotificationEvent{
+		EventTracksUpdated,
+		EventTrackUpdated,
+		EventCornersUpdated,
+		EventGroupsUpdated,
+		EventCampUpdated,
+		EventMessagesChanged,
+		EventTrackDeleted,
+		EventTrackReplaced,
+		EventSessionRevoked,
+		EventCampEnded,
+		EventDeviceRegistrationUpdated,
+		EventLockoutAlert,
+	}
+}
+
+type ScopeKind string
+
+const (
+	ScopeCamp  ScopeKind = "camp"
+	ScopeTrack ScopeKind = "track"
+)
+
+type Scope struct {
+	Kind    ScopeKind
+	TrackID domain.TrackID
+}
+
+func CampScope() Scope {
+	return Scope{Kind: ScopeCamp}
+}
+
+func TrackScope(trackID domain.TrackID) Scope {
+	return Scope{Kind: ScopeTrack, TrackID: trackID}
+}
+
+type SSEMessage struct {
+	Event NotificationEvent
+	Scope Scope
+}
+
 // Broadcaster는 트랜잭션 성공 후 SSE 클라이언트에게 실시간 알림을 푸시하는 포트입니다.
 type Broadcaster interface {
-	Broadcast(ctx context.Context, campID domain.CampID, event NotificationEvent, scope string) error
+	Broadcast(ctx context.Context, campID domain.CampID, event NotificationEvent, scope Scope) error
 }
 
 // ReportQuerier는 캠프 종료 시 사후 통계 집계를 담당하는 포트입니다.

--- a/backend/internal/usecase/track.go
+++ b/backend/internal/usecase/track.go
@@ -103,7 +103,7 @@ func (s *TrackService) CreateTrack(
 	}
 
 	s.recordAuditLog(ctx, "admin", "TRACK_CREATE", string(track.ID), true, map[string]any{"campID": string(campID), "cornerID": string(cornerID)})
-	_ = s.broadcaster.Broadcast(ctx, campID, EventTracksUpdated, "camp")
+	_ = s.broadcaster.Broadcast(ctx, campID, EventTracksUpdated, CampScope())
 
 	return track, plainPIN, nil
 }
@@ -177,8 +177,8 @@ func (s *TrackService) DeleteTrack(
 
 	s.recordAuditLog(ctx, "admin", "TRACK_DELETE", string(trackID), true, map[string]any{"isLastTrack": isLastTrack})
 	if cornerCampID != "" {
-		_ = s.broadcaster.Broadcast(ctx, cornerCampID, EventTracksUpdated, "camp")
-		_ = s.broadcaster.Broadcast(ctx, cornerCampID, EventTrackDeleted, "track:"+string(trackID))
+		_ = s.broadcaster.Broadcast(ctx, cornerCampID, EventTracksUpdated, CampScope())
+		_ = s.broadcaster.Broadcast(ctx, cornerCampID, EventTrackDeleted, TrackScope(trackID))
 	}
 
 	return isLastTrack, nil
@@ -282,8 +282,8 @@ func (s *TrackService) ReplaceTrack(
 	}
 
 	s.recordAuditLog(ctx, "admin", "TRACK_REPLACE", string(newTrack.ID), true, map[string]any{"oldTrackID": string(oldTrackID)})
-	_ = s.broadcaster.Broadcast(ctx, newCorner.CampID, EventTracksUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, newCorner.CampID, EventTrackReplaced, "track:"+string(oldTrackID))
+	_ = s.broadcaster.Broadcast(ctx, newCorner.CampID, EventTracksUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, newCorner.CampID, EventTrackReplaced, TrackScope(oldTrackID))
 
 	return newTrack, plainPIN, nil
 }
@@ -346,8 +346,8 @@ func (s *TrackService) RegeneratePIN(
 
 	s.recordAuditLog(ctx, "admin", "PIN_REGENERATE", string(trackID), true, nil)
 	if cornerCampID != "" {
-		_ = s.broadcaster.Broadcast(ctx, cornerCampID, EventTracksUpdated, "camp")
-		_ = s.broadcaster.Broadcast(ctx, cornerCampID, EventSessionRevoked, "track:"+string(trackID))
+		_ = s.broadcaster.Broadcast(ctx, cornerCampID, EventTracksUpdated, CampScope())
+		_ = s.broadcaster.Broadcast(ctx, cornerCampID, EventSessionRevoked, TrackScope(trackID))
 	}
 
 	return plainPIN, nil

--- a/backend/internal/usecase/track_test.go
+++ b/backend/internal/usecase/track_test.go
@@ -52,7 +52,7 @@ func TestTrackService_CreateTrack(t *testing.T) {
 		if len(broadcaster.Broadcasts) != 1 ||
 			broadcaster.Broadcasts[0].CampID != "camp-1" ||
 			broadcaster.Broadcasts[0].Event != EventTracksUpdated ||
-			broadcaster.Broadcasts[0].Scope != "camp" {
+			broadcaster.Broadcasts[0].Scope != CampScope() {
 			t.Errorf("expected EventTracksUpdated broadcast with scope 'camp', got %v", broadcaster.Broadcasts)
 		}
 	})
@@ -142,8 +142,8 @@ func TestTrackService_DeleteTrack(t *testing.T) {
 		}
 
 		if len(broadcaster.Broadcasts) != 2 ||
-			broadcaster.Broadcasts[0].Event != EventTracksUpdated || broadcaster.Broadcasts[0].Scope != "camp" ||
-			broadcaster.Broadcasts[1].Event != EventTrackDeleted || broadcaster.Broadcasts[1].Scope != "track:track-1" {
+			broadcaster.Broadcasts[0].Event != EventTracksUpdated || broadcaster.Broadcasts[0].Scope != CampScope() ||
+			broadcaster.Broadcasts[1].Event != EventTrackDeleted || broadcaster.Broadcasts[1].Scope != TrackScope("track-1") {
 			t.Errorf("expected EventTracksUpdated and EventTrackDeleted broadcasts, got %v", broadcaster.Broadcasts)
 		}
 	})

--- a/backend/internal/usecase/visit.go
+++ b/backend/internal/usecase/visit.go
@@ -150,10 +150,10 @@ func (s *VisitService) StartVisitByQR(
 	}
 
 	s.recordAuditLog(ctx, actor, "VISIT_START", string(visit.ID), true, map[string]any{"method": string(domain.VisitQRScan), "groupID": string(visit.GroupID)})
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventCornersUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventGroupsUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTracksUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTrackUpdated, "track:"+string(session.TrackID))
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventCornersUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventGroupsUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTracksUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTrackUpdated, TrackScope(session.TrackID))
 
 	return visit, nil
 }
@@ -241,10 +241,10 @@ func (s *VisitService) StartVisitManual(
 	}
 
 	s.recordAuditLog(ctx, actor, "VISIT_START", string(visit.ID), true, map[string]any{"method": string(domain.VisitManual), "groupID": string(visit.GroupID)})
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventCornersUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventGroupsUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTracksUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTrackUpdated, "track:"+string(session.TrackID))
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventCornersUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventGroupsUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTracksUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTrackUpdated, TrackScope(session.TrackID))
 
 	return visit, nil
 }
@@ -333,10 +333,10 @@ func (s *VisitService) CompleteVisit(
 	}
 
 	s.recordAuditLog(ctx, actor, "VISIT_COMPLETE", string(visit.ID), true, map[string]any{"groupID": string(visit.GroupID)})
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventCornersUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventGroupsUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTracksUpdated, "camp")
-	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTrackUpdated, "track:"+string(session.TrackID))
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventCornersUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventGroupsUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTracksUpdated, CampScope())
+	_ = s.broadcaster.Broadcast(ctx, groupCampID, EventTrackUpdated, TrackScope(session.TrackID))
 
 	return visit, nil
 }

--- a/backend/internal/usecase/visit_test.go
+++ b/backend/internal/usecase/visit_test.go
@@ -104,7 +104,7 @@ func TestVisitService_StartVisitByQR(t *testing.T) {
 			broadcaster.Broadcasts[1].Event != EventGroupsUpdated ||
 			broadcaster.Broadcasts[2].Event != EventTracksUpdated ||
 			broadcaster.Broadcasts[3].Event != EventTrackUpdated ||
-			broadcaster.Broadcasts[3].Scope != "track:track-1" {
+			broadcaster.Broadcasts[3].Scope != TrackScope("track-1") {
 			t.Errorf("expected corners, groups, tracks, track alerts, got %v", broadcaster.Broadcasts)
 		}
 
@@ -292,7 +292,7 @@ func TestVisitService_CompleteVisit(t *testing.T) {
 			broadcaster.Broadcasts[1].Event != EventGroupsUpdated ||
 			broadcaster.Broadcasts[2].Event != EventTracksUpdated ||
 			broadcaster.Broadcasts[3].Event != EventTrackUpdated ||
-			broadcaster.Broadcasts[3].Scope != "track:track-1" {
+			broadcaster.Broadcasts[3].Scope != TrackScope("track-1") {
 			t.Errorf("expected corners, groups, tracks, track alerts, got %v", broadcaster.Broadcasts)
 		}
 	})


### PR DESCRIPTION
## 변경 사항
- 문자열 scope를 ScopeCamp/ScopeTrack 구조화 값으로 바꾸고 모든 호출부를 마이그레이션했습니다.
- admin/track 구독을 campID로 격리하고, 버퍼가 찬 구독은 제거·close해 재연결을 유도합니다.
- 캠프 간 누수, track target, admin/track 버퍼 full 제거 테스트를 추가했습니다.

## 변경 이유
기존 broadcaster가 campID를 무시해 다른 캠프 구독자에게 이벤트를 전송했습니다.

## 종료 조건 증명
- go test ./... 통과
- go test -race ./internal/infrastructure/sse ./internal/infrastructure/web ./internal/usecase 통과
- go vet ./... 통과
- PR diff: 308 additions / 97 deletions