### PR TITLE
fix: 브로드캐스트 메시지 캠프 범위 적용

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -801,6 +801,99 @@ const docTemplate = `{
                 }
             }
         },
+        "/camps/{campId}/messages/broadcast": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "관리자가 보낸 BROADCAST 메시지들의 목록을 조회한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "E. Message"
+                ],
+                "summary": "발송된 공지사항 목록",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MessageResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "모든 활성 트랙에 BROADCAST 메시지를 보낸다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "E. Message"
+                ],
+                "summary": "전체 공지 발송",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "메시지 내용",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/BroadcastMessageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/MessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/camps/{campId}/reports/current": {
             "get": {
                 "security": [
@@ -1648,71 +1741,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/messages/broadcast": {
-            "get": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "관리자가 보낸 BROADCAST 메시지들의 목록을 조회한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "E. Message"
-                ],
-                "summary": "발송된 공지사항 목록",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/MessageResponse"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "모든 활성 트랙에 BROADCAST 메시지를 보낸다.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "E. Message"
-                ],
-                "summary": "전체 공지 발송",
-                "parameters": [
-                    {
-                        "description": "메시지 내용",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/BroadcastMessageRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/MessageResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/messages/broadcast/{id}/read": {
             "post": {
                 "security": [
@@ -2506,9 +2534,6 @@ const docTemplate = `{
         "BroadcastMessageRequest": {
             "type": "object",
             "properties": {
-                "campId": {
-                    "type": "string"
-                },
                 "content": {
                     "type": "string"
                 }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -794,6 +794,99 @@
                 }
             }
         },
+        "/camps/{campId}/messages/broadcast": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "관리자가 보낸 BROADCAST 메시지들의 목록을 조회한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "E. Message"
+                ],
+                "summary": "발송된 공지사항 목록",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/MessageResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "모든 활성 트랙에 BROADCAST 메시지를 보낸다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "E. Message"
+                ],
+                "summary": "전체 공지 발송",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "메시지 내용",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/BroadcastMessageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/MessageResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/camps/{campId}/reports/current": {
             "get": {
                 "security": [
@@ -1641,71 +1734,6 @@
                 }
             }
         },
-        "/messages/broadcast": {
-            "get": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "관리자가 보낸 BROADCAST 메시지들의 목록을 조회한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "E. Message"
-                ],
-                "summary": "발송된 공지사항 목록",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/MessageResponse"
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "모든 활성 트랙에 BROADCAST 메시지를 보낸다.",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "E. Message"
-                ],
-                "summary": "전체 공지 발송",
-                "parameters": [
-                    {
-                        "description": "메시지 내용",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/BroadcastMessageRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "201": {
-                        "description": "Created",
-                        "schema": {
-                            "$ref": "#/definitions/MessageResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/messages/broadcast/{id}/read": {
             "post": {
                 "security": [
@@ -2499,9 +2527,6 @@
         "BroadcastMessageRequest": {
             "type": "object",
             "properties": {
-                "campId": {
-                    "type": "string"
-                },
                 "content": {
                     "type": "string"
                 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -104,8 +104,6 @@ definitions:
     type: object
   BroadcastMessageRequest:
     properties:
-      campId:
-        type: string
       content:
         type: string
     type: object
@@ -1137,6 +1135,65 @@ paths:
       summary: 전체 조 목록 조회
       tags:
       - B. Resource Management (Admin)
+  /camps/{campId}/messages/broadcast:
+    get:
+      description: 관리자가 보낸 BROADCAST 메시지들의 목록을 조회한다.
+      parameters:
+      - description: 캠프 ID
+        in: path
+        name: campId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/MessageResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: 발송된 공지사항 목록
+      tags:
+      - E. Message
+    post:
+      consumes:
+      - application/json
+      description: 모든 활성 트랙에 BROADCAST 메시지를 보낸다.
+      parameters:
+      - description: 캠프 ID
+        in: path
+        name: campId
+        required: true
+        type: string
+      - description: 메시지 내용
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/BroadcastMessageRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/MessageResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: 전체 공지 발송
+      tags:
+      - E. Message
   /camps/{campId}/reports/current:
     get:
       description: 현재 활성화된 캠프의 상세 통계(CampReport)를 반환한다.
@@ -1668,46 +1725,6 @@ paths:
       summary: 조별 방문 기록 조회
       tags:
       - B. Resource Management (Admin)
-  /messages/broadcast:
-    get:
-      description: 관리자가 보낸 BROADCAST 메시지들의 목록을 조회한다.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/MessageResponse'
-            type: array
-      security:
-      - AdminAuth: []
-      summary: 발송된 공지사항 목록
-      tags:
-      - E. Message
-    post:
-      consumes:
-      - application/json
-      description: 모든 활성 트랙에 BROADCAST 메시지를 보낸다.
-      parameters:
-      - description: 메시지 내용
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/BroadcastMessageRequest'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/MessageResponse'
-      security:
-      - AdminAuth: []
-      summary: 전체 공지 발송
-      tags:
-      - E. Message
   /messages/broadcast/{id}/read:
     post:
       description: 트랙 진행자가 공지사항을 확인(읽음) 처리한다.

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -153,14 +153,14 @@ ON CONFLICT (id) DO UPDATE SET
     revoked_at = EXCLUDED.revoked_at;
 
 -- name: SaveMessage :exec
-INSERT INTO messages (id, channel_type, track_id, sender_role, content, sent_at)
-VALUES ($1, $2, $3, $4, $5, $6);
+INSERT INTO messages (id, channel_type, camp_id, track_id, sender_role, content, sent_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7);
 
 -- name: ListBroadcastMessagesByCamp :many
-SELECT * FROM messages WHERE channel_type = 'BROADCAST';
+SELECT * FROM messages WHERE channel_type = 'BROADCAST' AND camp_id = $1 ORDER BY sent_at;
 
 -- name: ListDirectMessagesByTrack :many
-SELECT * FROM messages WHERE track_id = $1 AND channel_type = 'DIRECT';
+SELECT * FROM messages WHERE track_id = $1 AND channel_type = 'DIRECT' ORDER BY sent_at;
 
 -- name: SaveBroadcastReceipt :exec
 INSERT INTO broadcast_receipts (message_id, track_id, read_at)

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -178,6 +178,7 @@ COMMENT ON COLUMN admin_sessions.revoked_at IS '세션이 무효화된 시간';
 CREATE TABLE messages (
     id VARCHAR(50) PRIMARY KEY,
     channel_type VARCHAR(50) NOT NULL,
+    camp_id VARCHAR(50) REFERENCES camps(id) ON DELETE CASCADE,
     track_id VARCHAR(50),
     sender_role VARCHAR(50) NOT NULL,
     content TEXT NOT NULL,
@@ -186,6 +187,7 @@ CREATE TABLE messages (
 COMMENT ON TABLE messages IS '전체 공지사항 및 트랙별 메시지 발송 내역을 저장하는 테이블';
 COMMENT ON COLUMN messages.id IS '메시지 고유 식별자';
 COMMENT ON COLUMN messages.channel_type IS '전송 채널 (BROADCAST, DIRECT 등)';
+COMMENT ON COLUMN messages.camp_id IS 'BROADCAST 채널인 경우 소속 캠프 식별자 (DIRECT면 NULL)';
 COMMENT ON COLUMN messages.track_id IS 'DIRECT 채널인 경우 대상 트랙 식별자 (BROADCAST면 NULL)';
 COMMENT ON COLUMN messages.sender_role IS '발신자 역할 (ADMIN 등)';
 COMMENT ON COLUMN messages.content IS '메시지 본문';

--- a/backend/internal/domain/message.go
+++ b/backend/internal/domain/message.go
@@ -21,6 +21,7 @@ const (
 type Message struct {
 	ID          MessageID
 	ChannelType MessageChannelType
+	CampID      Optional[CampID]
 	TrackID     Optional[TrackID]
 	SenderRole  SenderRole
 	Content     string

--- a/backend/internal/infrastructure/postgres/db/models.go
+++ b/backend/internal/infrastructure/postgres/db/models.go
@@ -170,6 +170,8 @@ type Message struct {
 	ID string `json:"id"`
 	// 전송 채널 (BROADCAST, DIRECT 등)
 	ChannelType string `json:"channel_type"`
+	// BROADCAST 채널인 경우 소속 캠프 식별자 (DIRECT면 NULL)
+	CampID pgtype.Text `json:"camp_id"`
 	// DIRECT 채널인 경우 대상 트랙 식별자 (BROADCAST면 NULL)
 	TrackID pgtype.Text `json:"track_id"`
 	// 발신자 역할 (ADMIN 등)

--- a/backend/internal/infrastructure/postgres/db/querier.go
+++ b/backend/internal/infrastructure/postgres/db/querier.go
@@ -38,7 +38,7 @@ type Querier interface {
 	ListAdminSessionsByAdmin(ctx context.Context, adminID string) ([]AdminSession, error)
 	ListAllBadges(ctx context.Context) ([]Badge, error)
 	ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([]AuditLog, error)
-	ListBroadcastMessagesByCamp(ctx context.Context) ([]Message, error)
+	ListBroadcastMessagesByCamp(ctx context.Context, campID pgtype.Text) ([]Message, error)
 	ListBroadcastReceiptsByMessage(ctx context.Context, messageID string) ([]BroadcastReceipt, error)
 	ListCamps(ctx context.Context) ([]Camp, error)
 	ListCornersByCamp(ctx context.Context, campID string) ([]Corner, error)

--- a/backend/internal/infrastructure/postgres/db/query.sql.go
+++ b/backend/internal/infrastructure/postgres/db/query.sql.go
@@ -606,11 +606,11 @@ func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([
 }
 
 const listBroadcastMessagesByCamp = `-- name: ListBroadcastMessagesByCamp :many
-SELECT id, channel_type, track_id, sender_role, content, sent_at FROM messages WHERE channel_type = 'BROADCAST'
+SELECT id, channel_type, camp_id, track_id, sender_role, content, sent_at FROM messages WHERE channel_type = 'BROADCAST' AND camp_id = $1 ORDER BY sent_at
 `
 
-func (q *Queries) ListBroadcastMessagesByCamp(ctx context.Context) ([]Message, error) {
-	rows, err := q.db.Query(ctx, listBroadcastMessagesByCamp)
+func (q *Queries) ListBroadcastMessagesByCamp(ctx context.Context, campID pgtype.Text) ([]Message, error) {
+	rows, err := q.db.Query(ctx, listBroadcastMessagesByCamp, campID)
 	if err != nil {
 		return nil, err
 	}
@@ -621,6 +621,7 @@ func (q *Queries) ListBroadcastMessagesByCamp(ctx context.Context) ([]Message, e
 		if err := rows.Scan(
 			&i.ID,
 			&i.ChannelType,
+			&i.CampID,
 			&i.TrackID,
 			&i.SenderRole,
 			&i.Content,
@@ -764,7 +765,7 @@ func (q *Queries) ListDeviceRegistrationsByCampAndStatus(ctx context.Context, ar
 }
 
 const listDirectMessagesByTrack = `-- name: ListDirectMessagesByTrack :many
-SELECT id, channel_type, track_id, sender_role, content, sent_at FROM messages WHERE track_id = $1 AND channel_type = 'DIRECT'
+SELECT id, channel_type, camp_id, track_id, sender_role, content, sent_at FROM messages WHERE track_id = $1 AND channel_type = 'DIRECT' ORDER BY sent_at
 `
 
 func (q *Queries) ListDirectMessagesByTrack(ctx context.Context, trackID pgtype.Text) ([]Message, error) {
@@ -779,6 +780,7 @@ func (q *Queries) ListDirectMessagesByTrack(ctx context.Context, trackID pgtype.
 		if err := rows.Scan(
 			&i.ID,
 			&i.ChannelType,
+			&i.CampID,
 			&i.TrackID,
 			&i.SenderRole,
 			&i.Content,
@@ -1272,13 +1274,14 @@ func (q *Queries) SaveGroup(ctx context.Context, arg SaveGroupParams) error {
 }
 
 const saveMessage = `-- name: SaveMessage :exec
-INSERT INTO messages (id, channel_type, track_id, sender_role, content, sent_at)
-VALUES ($1, $2, $3, $4, $5, $6)
+INSERT INTO messages (id, channel_type, camp_id, track_id, sender_role, content, sent_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 `
 
 type SaveMessageParams struct {
 	ID          string             `json:"id"`
 	ChannelType string             `json:"channel_type"`
+	CampID      pgtype.Text        `json:"camp_id"`
 	TrackID     pgtype.Text        `json:"track_id"`
 	SenderRole  string             `json:"sender_role"`
 	Content     string             `json:"content"`
@@ -1289,6 +1292,7 @@ func (q *Queries) SaveMessage(ctx context.Context, arg SaveMessageParams) error 
 	_, err := q.db.Exec(ctx, saveMessage,
 		arg.ID,
 		arg.ChannelType,
+		arg.CampID,
 		arg.TrackID,
 		arg.SenderRole,
 		arg.Content,

--- a/backend/internal/infrastructure/postgres/message_repo.go
+++ b/backend/internal/infrastructure/postgres/message_repo.go
@@ -39,6 +39,11 @@ func mapMessage(row db.Message) *domain.Message {
 	} else {
 		m.TrackID = domain.None[domain.TrackID]()
 	}
+	if row.CampID.Valid {
+		m.CampID = domain.Some(domain.CampID(row.CampID.String))
+	} else {
+		m.CampID = domain.None[domain.CampID]()
+	}
 
 	return m
 }
@@ -55,6 +60,9 @@ func (r *pgMessageRepository) Save(ctx context.Context, msg *domain.Message) err
 	if val, ok := msg.TrackID.Value(); ok {
 		params.TrackID = pgtype.Text{String: string(val), Valid: true}
 	}
+	if val, ok := msg.CampID.Value(); ok {
+		params.CampID = pgtype.Text{String: string(val), Valid: true}
+	}
 
 	err := r.queries(ctx).SaveMessage(ctx, params)
 	if err != nil {
@@ -64,7 +72,7 @@ func (r *pgMessageRepository) Save(ctx context.Context, msg *domain.Message) err
 }
 
 func (r *pgMessageRepository) ListBroadcastsByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Message, error) {
-	rows, err := r.queries(ctx).ListBroadcastMessagesByCamp(ctx)
+	rows, err := r.queries(ctx).ListBroadcastMessagesByCamp(ctx, pgtype.Text{String: string(campID), Valid: true})
 	if err != nil {
 		return nil, errs.Wrap(ctx, err)
 	}

--- a/backend/internal/infrastructure/web/message_handler.go
+++ b/backend/internal/infrastructure/web/message_handler.go
@@ -50,7 +50,6 @@ func NewMessageHandler(message MessageUsecase) *MessageHandler {
 }
 
 type BroadcastMessageRequest struct {
-	CampID  string `json:"campId"`
 	Content string `json:"content"`
 } // @name BroadcastMessageRequest
 
@@ -60,13 +59,19 @@ type BroadcastMessageRequest struct {
 // @Security     AdminAuth
 // @Accept       json
 // @Produce      json
+// @Param        campId path string true "캠프 ID"
 // @Param        request body BroadcastMessageRequest true "메시지 내용"
 // @Success      201 {object} MessageResponse
-// @Router       /messages/broadcast [post]
+// @Failure      400 {object} ErrorResponse
+// @Router       /camps/{campId}/messages/broadcast [post]
 func (h *MessageHandler) SendBroadcast(c echo.Context) error {
 	session, ok := c.Get("adminSession").(*domain.AdminSession)
 	if !ok {
 		return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "unauthorized"})
+	}
+	campID := domain.CampID(c.Param("campId"))
+	if campID == "" {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "campId is required"})
 	}
 
 	var req BroadcastMessageRequest
@@ -74,7 +79,7 @@ func (h *MessageHandler) SendBroadcast(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "invalid request"})
 	}
 
-	msg, err := h.message.SendBroadcast(c.Request().Context(), domain.CampID(req.CampID), req.Content, session.AdminID)
+	msg, err := h.message.SendBroadcast(c.Request().Context(), campID, req.Content, session.AdminID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
 	}
@@ -93,15 +98,17 @@ func (h *MessageHandler) SendBroadcast(c echo.Context) error {
 // @Tags         E. Message
 // @Security     AdminAuth
 // @Produce      json
+// @Param        campId path string true "캠프 ID"
 // @Success      200 {array} MessageResponse
-// @Router       /messages/broadcast [get]
+// @Failure      400 {object} ErrorResponse
+// @Router       /camps/{campId}/messages/broadcast [get]
 func (h *MessageHandler) ListBroadcasts(c echo.Context) error {
-	campID := c.QueryParam("campId")
+	campID := domain.CampID(c.Param("campId"))
 	if campID == "" {
-		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "missing campId"})
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "campId is required"})
 	}
 
-	msgs, err := h.message.ListBroadcastsByCamp(c.Request().Context(), domain.CampID(campID))
+	msgs, err := h.message.ListBroadcastsByCamp(c.Request().Context(), campID)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
 	}

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -106,8 +106,8 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 
 	// ── E. Message (Admin) ──
 	if h.Message != nil {
-		admin.POST("/messages/broadcast", h.Message.SendBroadcast)
-		admin.GET("/messages/broadcast", h.Message.ListBroadcasts)
+		admin.POST("/camps/:campId/messages/broadcast", h.Message.SendBroadcast)
+		admin.GET("/camps/:campId/messages/broadcast", h.Message.ListBroadcasts)
 		admin.GET("/messages/broadcast/:id/receipts", h.Message.GetBroadcastReceipts)
 		admin.POST("/tracks/:trackId/messages", h.Message.SendDirect)
 		admin.GET("/tracks/:trackId/messages", h.Message.ListDirectMessages)

--- a/backend/internal/usecase/message.go
+++ b/backend/internal/usecase/message.go
@@ -70,6 +70,7 @@ func (s *MessageService) SendBroadcast(
 	msg := &domain.Message{
 		ID:          msgID,
 		ChannelType: domain.MessageBroadcast,
+		CampID:      domain.Some(campID),
 		TrackID:     domain.None[domain.TrackID](),
 		SenderRole:  domain.RoleAdmin,
 		Content:     content,
@@ -131,6 +132,7 @@ func (s *MessageService) SendDirect(
 	msg := &domain.Message{
 		ID:          msgID,
 		ChannelType: domain.MessageDirect,
+		CampID:      domain.None[domain.CampID](),
 		TrackID:     domain.Some(trackID),
 		SenderRole:  senderRole,
 		Content:     content,

--- a/backend/internal/usecase/message_test.go
+++ b/backend/internal/usecase/message_test.go
@@ -47,6 +47,9 @@ func TestMessageService_SendBroadcast(t *testing.T) {
 		if msg.ID != "msg-uuid" {
 			t.Errorf("expected message ID 'msg-uuid', got '%s'", msg.ID)
 		}
+		if campID, ok := msg.CampID.Value(); !ok || campID != "camp-1" {
+			t.Errorf("expected broadcast CampID 'camp-1', got %q (set=%t)", campID, ok)
+		}
 
 		if len(receipts.Receipts) != 2 {
 			t.Errorf("expected 2 receipts to be saved, got %d", len(receipts.Receipts))
@@ -57,6 +60,50 @@ func TestMessageService_SendBroadcast(t *testing.T) {
 			broadcaster.Broadcasts[0].Event != EventMessagesChanged ||
 			broadcaster.Broadcasts[0].Scope != CampScope() {
 			t.Errorf("expected EventMessagesChanged broadcast with scope 'broadcast', got %v", broadcaster.Broadcasts)
+		}
+	})
+}
+
+func TestMessageService_ListBroadcastsByCamp(t *testing.T) {
+	t.Run("ShouldReturnOnlyMessagesForRequestedCampInSentAtOrder", func(t *testing.T) {
+		// Arrange
+		messages := NewMockMessageRepository()
+		messages.Save(context.Background(), &domain.Message{
+			ID:          "message-camp-b",
+			ChannelType: domain.MessageBroadcast,
+			CampID:      domain.Some(domain.CampID("camp-b")),
+			TrackID:     domain.None[domain.TrackID](),
+			SentAt:      time.Date(2026, 7, 14, 9, 0, 0, 0, time.UTC),
+		})
+		messages.Save(context.Background(), &domain.Message{
+			ID:          "message-camp-a-later",
+			ChannelType: domain.MessageBroadcast,
+			CampID:      domain.Some(domain.CampID("camp-a")),
+			TrackID:     domain.None[domain.TrackID](),
+			SentAt:      time.Date(2026, 7, 14, 11, 0, 0, 0, time.UTC),
+		})
+		messages.Save(context.Background(), &domain.Message{
+			ID:          "message-camp-a-earlier",
+			ChannelType: domain.MessageBroadcast,
+			CampID:      domain.Some(domain.CampID("camp-a")),
+			TrackID:     domain.None[domain.TrackID](),
+			SentAt:      time.Date(2026, 7, 14, 10, 0, 0, 0, time.UTC),
+		})
+
+		s := &MessageService{messages: messages}
+
+		// Act
+		result, err := s.ListBroadcastsByCamp(context.Background(), "camp-a")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(result) != 2 {
+			t.Fatalf("expected 2 camp-a messages, got %d", len(result))
+		}
+		if result[0].ID != "message-camp-a-earlier" || result[1].ID != "message-camp-a-later" {
+			t.Errorf("expected camp-a messages in sent_at order, got %q then %q", result[0].ID, result[1].ID)
 		}
 	})
 }

--- a/backend/internal/usecase/mock_test.go
+++ b/backend/internal/usecase/mock_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"sort"
 
 	"cornermon/backend/internal/domain"
 )
@@ -467,10 +468,14 @@ func (r *MockMessageRepository) Save(ctx context.Context, msg *domain.Message) e
 func (r *MockMessageRepository) ListBroadcastsByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Message, error) {
 	var list []*domain.Message
 	for _, m := range r.Messages {
-		if m.ChannelType == domain.MessageBroadcast {
+		messageCampID, ok := m.CampID.Value()
+		if m.ChannelType == domain.MessageBroadcast && ok && messageCampID == campID {
 			list = append(list, m)
 		}
 	}
+	sort.Slice(list, func(i, j int) bool {
+		return list[i].SentAt.Before(list[j].SentAt)
+	})
 	return list, nil
 }
 


### PR DESCRIPTION
## 변경 사항

- BROADCAST 메시지에 camp_id를 저장하고 캠프별 조회 SQL에 필터를 적용했습니다.
- 브로드캐스트·다이렉트 메시지 목록을 sent_at 오름차순으로 정렬합니다.
- 공지 발송·목록 API를 GET/POST /camps/{campId}/messages/broadcast로 통일하고, 본문의 중복 campId를 제거했습니다.
- sqlc 및 Swagger 생성 산출물을 갱신하고 캠프 간 메시지 격리 회귀 테스트를 추가했습니다.

## 변경 이유

기존 브로드캐스트 조회 SQL이 전달받은 campId를 사용하지 않아 여러 캠프의 공지가 한 목록에 섞여 반환됐습니다.

## 종료 조건 증명

- sqlc generate 완료
- make -C backend swag 완료
- go test ./... 통과
- go vet ./... 통과
- git diff --check 통과
- PR 변경량: 345 additions / 200 deletions

## 운영 참고

개발 DB가 아직 초기화 전이므로 별도 마이그레이션은 추가하지 않았습니다. 초기화 시 backend/db/schema.sql의 messages.camp_id 정의가 적용됩니다.
