### PR TITLE
feat: 암호화된 트랙 PIN JSON 내보내기

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ DATABASE_PASSWORD=postgres
 
 # Server Configuration
 PORT=8080
+
+# Track PIN encryption (base64-encoded, exactly 32 bytes after decoding)
+# Generate with: openssl rand -base64 32
+TRACK_PIN_ENCRYPTION_KEY=

--- a/api/docs.go
+++ b/api/docs.go
@@ -1844,7 +1844,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/TrackResponse"
+                                "$ref": "#/definitions/TrackPinResponse"
                             }
                         }
                     }
@@ -1894,17 +1894,29 @@ const docTemplate = `{
                         "AdminAuth": []
                     }
                 ],
-                "description": "인쇄를 위해 전체 트랙의 PIN 번호 등을 CSV로 다운로드한다.",
+                "description": "인쇄를 위해 지정 캠프의 ACTIVE 트랙 PIN을 JSON으로 내려준다.",
                 "produces": [
-                    "text/csv"
+                    "application/json"
                 ],
                 "tags": [
                     "B. Resource Management (Admin)"
                 ],
                 "summary": "트랙 인증 정보 전체 내보내기",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "CSV 데이터"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ExportTracksResponse"
+                        }
                     }
                 }
             }
@@ -1950,9 +1962,9 @@ const docTemplate = `{
                         "AdminAuth": []
                     }
                 ],
-                "description": "특정 트랙의 PIN 번호를 PDF 형태로 다운로드한다.",
+                "description": "특정 트랙의 PIN을 JSON으로 내려준다.",
                 "produces": [
-                    "application/pdf"
+                    "application/json"
                 ],
                 "tags": [
                     "B. Resource Management (Admin)"
@@ -1969,7 +1981,10 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "PDF 데이터"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/TrackPinResponse"
+                        }
                     }
                 }
             }
@@ -2042,7 +2057,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/TrackResponse"
+                            "$ref": "#/definitions/TrackPinResponse"
                         }
                     }
                 }
@@ -2088,7 +2103,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ReplaceTrackResponse"
+                            "$ref": "#/definitions/TrackPinResponse"
                         }
                     },
                     "400": {
@@ -2919,6 +2934,17 @@ const docTemplate = `{
                 }
             }
         },
+        "ExportTracksResponse": {
+            "type": "object",
+            "properties": {
+                "tracks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TrackPinResponse"
+                    }
+                }
+            }
+        },
         "GroupResponse": {
             "type": "object",
             "properties": {
@@ -3023,17 +3049,6 @@ const docTemplate = `{
                 }
             }
         },
-        "ReplaceTrackResponse": {
-            "type": "object",
-            "properties": {
-                "pin": {
-                    "type": "string"
-                },
-                "track": {
-                    "$ref": "#/definitions/TrackResponse"
-                }
-            }
-        },
         "SSENotification": {
             "type": "object",
             "properties": {
@@ -3113,6 +3128,18 @@ const docTemplate = `{
                 }
             }
         },
+        "TrackPinResponse": {
+            "type": "object",
+            "properties": {
+                "pin": {
+                    "type": "string",
+                    "example": "482910"
+                },
+                "track": {
+                    "$ref": "#/definitions/TrackResponse"
+                }
+            }
+        },
         "TrackResponse": {
             "type": "object",
             "properties": {
@@ -3133,10 +3160,6 @@ const docTemplate = `{
                         "IDLE",
                         "BUSY"
                     ]
-                },
-                "pin": {
-                    "type": "string",
-                    "example": "482910"
                 },
                 "status": {
                     "type": "string",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1837,7 +1837,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/TrackResponse"
+                                "$ref": "#/definitions/TrackPinResponse"
                             }
                         }
                     }
@@ -1887,17 +1887,29 @@
                         "AdminAuth": []
                     }
                 ],
-                "description": "인쇄를 위해 전체 트랙의 PIN 번호 등을 CSV로 다운로드한다.",
+                "description": "인쇄를 위해 지정 캠프의 ACTIVE 트랙 PIN을 JSON으로 내려준다.",
                 "produces": [
-                    "text/csv"
+                    "application/json"
                 ],
                 "tags": [
                     "B. Resource Management (Admin)"
                 ],
                 "summary": "트랙 인증 정보 전체 내보내기",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "CSV 데이터"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ExportTracksResponse"
+                        }
                     }
                 }
             }
@@ -1943,9 +1955,9 @@
                         "AdminAuth": []
                     }
                 ],
-                "description": "특정 트랙의 PIN 번호를 PDF 형태로 다운로드한다.",
+                "description": "특정 트랙의 PIN을 JSON으로 내려준다.",
                 "produces": [
-                    "application/pdf"
+                    "application/json"
                 ],
                 "tags": [
                     "B. Resource Management (Admin)"
@@ -1962,7 +1974,10 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "PDF 데이터"
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/TrackPinResponse"
+                        }
                     }
                 }
             }
@@ -2035,7 +2050,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/TrackResponse"
+                            "$ref": "#/definitions/TrackPinResponse"
                         }
                     }
                 }
@@ -2081,7 +2096,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/ReplaceTrackResponse"
+                            "$ref": "#/definitions/TrackPinResponse"
                         }
                     },
                     "400": {
@@ -2912,6 +2927,17 @@
                 }
             }
         },
+        "ExportTracksResponse": {
+            "type": "object",
+            "properties": {
+                "tracks": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TrackPinResponse"
+                    }
+                }
+            }
+        },
         "GroupResponse": {
             "type": "object",
             "properties": {
@@ -3016,17 +3042,6 @@
                 }
             }
         },
-        "ReplaceTrackResponse": {
-            "type": "object",
-            "properties": {
-                "pin": {
-                    "type": "string"
-                },
-                "track": {
-                    "$ref": "#/definitions/TrackResponse"
-                }
-            }
-        },
         "SSENotification": {
             "type": "object",
             "properties": {
@@ -3106,6 +3121,18 @@
                 }
             }
         },
+        "TrackPinResponse": {
+            "type": "object",
+            "properties": {
+                "pin": {
+                    "type": "string",
+                    "example": "482910"
+                },
+                "track": {
+                    "$ref": "#/definitions/TrackResponse"
+                }
+            }
+        },
         "TrackResponse": {
             "type": "object",
             "properties": {
@@ -3126,10 +3153,6 @@
                         "IDLE",
                         "BUSY"
                     ]
-                },
-                "pin": {
-                    "type": "string",
-                    "example": "482910"
                 },
                 "status": {
                     "type": "string",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -365,6 +365,13 @@ definitions:
           $ref: '#/definitions/BadgeResponse'
         type: array
     type: object
+  ExportTracksResponse:
+    properties:
+      tracks:
+        items:
+          $ref: '#/definitions/TrackPinResponse'
+        type: array
+    type: object
   GroupResponse:
     properties:
       badgeId:
@@ -437,13 +444,6 @@ definitions:
       newCornerId:
         type: string
     type: object
-  ReplaceTrackResponse:
-    properties:
-      pin:
-        type: string
-      track:
-        $ref: '#/definitions/TrackResponse'
-    type: object
   SSENotification:
     properties:
       event:
@@ -500,6 +500,14 @@ definitions:
       trackToken:
         type: string
     type: object
+  TrackPinResponse:
+    properties:
+      pin:
+        example: "482910"
+        type: string
+      track:
+        $ref: '#/definitions/TrackResponse'
+    type: object
   TrackResponse:
     properties:
       cornerId:
@@ -514,9 +522,6 @@ definitions:
         enum:
         - IDLE
         - BUSY
-        type: string
-      pin:
-        example: "482910"
         type: string
       status:
         enum:
@@ -1786,7 +1791,7 @@ paths:
           description: Created
           schema:
             items:
-              $ref: '#/definitions/TrackResponse'
+              $ref: '#/definitions/TrackPinResponse'
             type: array
       security:
       - AdminAuth: []
@@ -1816,7 +1821,7 @@ paths:
       - B. Resource Management (Admin)
   /tracks/{id}/export:
     get:
-      description: 특정 트랙의 PIN 번호를 PDF 형태로 다운로드한다.
+      description: 특정 트랙의 PIN을 JSON으로 내려준다.
       parameters:
       - description: 트랙 ID
         in: path
@@ -1824,10 +1829,12 @@ paths:
         required: true
         type: string
       produces:
-      - application/pdf
+      - application/json
       responses:
         "200":
-          description: PDF 데이터
+          description: OK
+          schema:
+            $ref: '#/definitions/TrackPinResponse'
       security:
       - AdminAuth: []
       summary: 단일 트랙 인증 정보 내보내기
@@ -1874,7 +1881,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/TrackResponse'
+            $ref: '#/definitions/TrackPinResponse'
       security:
       - AdminAuth: []
       summary: PIN 재발급
@@ -1903,7 +1910,7 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/ReplaceTrackResponse'
+            $ref: '#/definitions/TrackPinResponse'
         "400":
           description: Bad Request
           schema:
@@ -2112,12 +2119,20 @@ paths:
       - B. Resource Management (Admin)
   /tracks/export:
     get:
-      description: 인쇄를 위해 전체 트랙의 PIN 번호 등을 CSV로 다운로드한다.
+      description: 인쇄를 위해 지정 캠프의 ACTIVE 트랙 PIN을 JSON으로 내려준다.
+      parameters:
+      - description: 캠프 ID
+        in: query
+        name: campId
+        required: true
+        type: string
       produces:
-      - text/csv
+      - application/json
       responses:
         "200":
-          description: CSV 데이터
+          description: OK
+          schema:
+            $ref: '#/definitions/ExportTracksResponse'
       security:
       - AdminAuth: []
       summary: 트랙 인증 정보 전체 내보내기

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,3 +4,7 @@ DATABASE_PASSWORD=postgres
 
 # Server Configuration
 PORT=8080
+
+# Track PIN encryption (base64-encoded, exactly 32 bytes after decoding)
+# Generate with: openssl rand -base64 32
+TRACK_PIN_ENCRYPTION_KEY=

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
 
 	"cornermon/backend/internal/errs"
+	trackcrypto "cornermon/backend/internal/infrastructure/crypto"
 	"cornermon/backend/internal/infrastructure/postgres"
 	"cornermon/backend/internal/infrastructure/sse"
 	"cornermon/backend/internal/infrastructure/web"
@@ -30,6 +33,14 @@ func main() {
 
 	// Load .env if exists
 	_ = godotenv.Load()
+	trackPINEncryptionKey, err := loadTrackPINEncryptionKey()
+	if err != nil {
+		log.Fatalf("Invalid TRACK_PIN_ENCRYPTION_KEY: %v\n", err)
+	}
+	trackPINProtector, err := trackcrypto.NewTrackPINProtector(trackPINEncryptionKey)
+	if err != nil {
+		log.Fatalf("Unable to initialize track PIN encryption: %v\n", err)
+	}
 
 	ctx := context.Background()
 	dbURL := os.Getenv("DATABASE_URL")
@@ -92,7 +103,7 @@ func main() {
 	groupService := usecase.NewGroupService(campRepo, cornerRepo, trackRepo, groupRepo, badgeRepo, visitRepo, auditLogRepo, txManager)
 	badgeService := usecase.NewBadgeService(badgeRepo, groupRepo, auditLogRepo, txManager)
 	visitService := usecase.NewVisitService(campRepo, cornerRepo, trackRepo, visitRepo, groupRepo, badgeRepo, facilitatorSessionRepo, auditLogRepo, broadcaster, txManager)
-	trackService := usecase.NewTrackService(campRepo, cornerRepo, trackRepo, facilitatorSessionRepo, auditLogRepo, broadcaster, txManager)
+	trackService := usecase.NewTrackService(campRepo, cornerRepo, trackRepo, facilitatorSessionRepo, auditLogRepo, broadcaster, txManager, trackPINProtector)
 	reportService := usecase.NewReportService(campRepo, reportQuerier)
 	authFacilitatorService := usecase.NewFacilitatorAuthService(campRepo, cornerRepo, trackRepo, deviceRepo, facilitatorSessionRepo, auditLogRepo, broadcaster, txManager)
 	messageService := usecase.NewMessageService(campRepo, cornerRepo, trackRepo, messageRepo, broadcastReceiptRepo, facilitatorSessionRepo, auditLogRepo, broadcaster, txManager)
@@ -143,4 +154,20 @@ func main() {
 		port = "8080"
 	}
 	log.Fatal(e.Start(":" + port))
+}
+
+func loadTrackPINEncryptionKey() ([]byte, error) {
+	encodedKey := os.Getenv("TRACK_PIN_ENCRYPTION_KEY")
+	if encodedKey == "" {
+		return nil, fmt.Errorf("must be set")
+	}
+
+	key, err := base64.StdEncoding.DecodeString(encodedKey)
+	if err != nil {
+		return nil, fmt.Errorf("must be valid base64: %w", err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("must decode to 32 bytes, got %d", len(key))
+	}
+	return key, nil
 }

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestLoadTrackPINEncryptionKey(t *testing.T) {
+	t.Run("ShoudReturnKeyWhenEnvironmentValueIsBase64Encoded32Bytes", func(t *testing.T) {
+		// Arrange
+		expected := make([]byte, 32)
+		for i := range expected {
+			expected[i] = byte(i)
+		}
+		t.Setenv("TRACK_PIN_ENCRYPTION_KEY", base64.StdEncoding.EncodeToString(expected))
+
+		// Act
+		actual, err := loadTrackPINEncryptionKey()
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if string(actual) != string(expected) {
+			t.Fatalf("expected decoded key to match")
+		}
+	})
+
+	t.Run("ShoudFailWhenEnvironmentValueIsMissingOrInvalid", func(t *testing.T) {
+		for _, key := range []string{"", "not-base64", base64.StdEncoding.EncodeToString(make([]byte, 31))} {
+			t.Run(key, func(t *testing.T) {
+				// Arrange
+				t.Setenv("TRACK_PIN_ENCRYPTION_KEY", key)
+
+				// Act
+				_, err := loadTrackPINEncryptionKey()
+
+				// Assert
+				if err == nil {
+					t.Fatal("expected validation error")
+				}
+			})
+		}
+	})
+}

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -40,11 +40,12 @@ JOIN corners c ON t.corner_id = c.id
 WHERE c.camp_id = $1 AND t.status = 'ACTIVE';
 
 -- name: SaveTrack :exec
-INSERT INTO tracks (id, corner_id, track_no, status, pin_hash, current_visit_id, deleted_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+INSERT INTO tracks (id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (id) DO UPDATE SET
     status = EXCLUDED.status,
     pin_hash = EXCLUDED.pin_hash,
+    pin_ciphertext = EXCLUDED.pin_ciphertext,
     current_visit_id = EXCLUDED.current_visit_id,
     deleted_at = EXCLUDED.deleted_at;
 

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -43,6 +43,7 @@ CREATE TABLE tracks (
     track_no INT NOT NULL,
     status VARCHAR(50) NOT NULL,
     pin_hash VARCHAR(255) NOT NULL,
+    pin_ciphertext TEXT,
     current_visit_id VARCHAR(50),
     deleted_at TIMESTAMP WITH TIME ZONE
 );
@@ -52,6 +53,7 @@ COMMENT ON COLUMN tracks.corner_id IS '소속 코너 식별자';
 COMMENT ON COLUMN tracks.track_no IS '코너 내 트랙 번호 (1, 2, 3...)';
 COMMENT ON COLUMN tracks.status IS '트랙 상태 (ACTIVE, DELETED 등)';
 COMMENT ON COLUMN tracks.pin_hash IS '기기 등록을 위한 PIN 해시값';
+COMMENT ON COLUMN tracks.pin_ciphertext IS 'PIN 재인쇄 전용 AES-256-GCM 암호문';
 COMMENT ON COLUMN tracks.current_visit_id IS '현재 진행 중인 방문(Visit)의 식별자';
 COMMENT ON COLUMN tracks.deleted_at IS '논리적 삭제 시간';
 

--- a/backend/docs/artifacts/plan/20260714_secure_track_pin_export_plan_.md
+++ b/backend/docs/artifacts/plan/20260714_secure_track_pin_export_plan_.md
@@ -1,0 +1,94 @@
+# 트랙 PIN 보관 및 JSON 내보내기 구현 계획
+
+## 결정 및 전제
+
+- 관리자 PIN 내보내기는 내부 앱 운영 편의를 위해 허용한다. 다만 일반 트랙 조회 응답에는 PIN을 포함하지 않는다.
+- 로그인 검증용 bcrypt `pin_hash`는 유지하고, 재내보내기 전용으로 암호화한 PIN을 별도 저장한다. DB 평문 저장은 하지 않는다.
+- 기기 등록은 이미 `camp_id`에 귀속되어 있으므로, 다른 캠프의 승인 토큰은 로그인 과정에서 해당 트랙의 캠프와 일치하지 않아야 한다.
+- 기존 `tracks` 행의 PIN 평문은 복구할 수 없다. 마이그레이션은 암호문을 nullable로 추가하고, PIN을 재발급하기 전에는 내보내기를 거부한다. 자동 재발급으로 기존 세션을 의도치 않게 끊지 않는다.
+
+## 유스케이스
+
+| 우선순위 | 유스케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-TrackPinExport | 관리자에게 단건·전체 ACTIVE 트랙의 복호화된 PIN을 JSON으로 제공한다. | **프로덕션 핵심 로직** |
+| **P0** | UC-TrackPinRotate | PIN 재발급 시 bcrypt 해시와 암호문을 함께 갱신한다. | **프로덕션 핵심 로직** |
+| P1 | UC-CampScopedDeviceTrust | 승인된 기기가 로그인 대상 트랙과 동일한 캠프에 속하는지 검증한다. | 보안 경계 검증 |
+
+```go
+// /home/lsjtop10/projects/cornermon/backend/internal/usecase/track.go
+func (s *TrackService) ExportTrackPINs(
+    ctx context.Context,
+    campID domain.CampID,
+) ([]TrackPIN, error)
+
+func (s *TrackService) ExportTrackPIN(
+    ctx context.Context,
+    trackID domain.TrackID,
+) (TrackPIN, error)
+```
+
+## 설계
+
+### Domain / Usecase
+
+- `/home/lsjtop10/projects/cornermon/backend/internal/domain/track.go`의 `PINCiphertext`는 암호화 방식에 독립적인 불투명 저장값이다. AES-GCM 구현은 domain에 유입하지 않는다.
+- `/home/lsjtop10/projects/cornermon/backend/internal/usecase/port.go`의 `TrackPINProtector`를 통해 `/home/lsjtop10/projects/cornermon/backend/internal/usecase/track.go`가 생성·재발급 때 hash와 암호문을 같은 트랜잭션에서 저장하고 export 때만 복호화한다.
+- export 성공/실패는 PIN 원문을 metadata에 넣지 않고 감사 로그로 남긴다.
+
+### Infrastructure / DB
+
+- `/home/lsjtop10/projects/cornermon/backend/db/schema.sql`, `query.sql`, sqlc 산출물에 `tracks.pin_ciphertext`와 저장 쿼리를 반영한다.
+- `/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/postgres/`에 `TrackPINStore` 구현을 둔다.
+- `/home/lsjtop10/projects/cornermon/backend/internal/config`이 없으므로, 초기에는 서버 시작 시 환경 변수 `TRACK_PIN_ENCRYPTION_KEY`(base64 인코딩 32바이트 AES-256 키)를 필수 검증하고 wiring한다. 키나 PIN은 로그에 남기지 않는다.
+
+### Web API / OpenAPI
+
+- `/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/web/track_handler.go`에서 `TrackResponse`의 `pin`을 제거한다.
+- `TrackPinResponse`는 트랙 식별·표시 필드와 `pin`만 포함한다. 생성·교체·재발급 응답 및 두 export 응답에만 사용한다.
+- `GET /tracks/{id}/export`는 `{ "track": TrackPinResponse }`, `GET /tracks/export`는 `{ "tracks": []TrackPinResponse }` JSON을 반환한다. 전체 export는 명시 `campId` query parameter의 ACTIVE 트랙만 대상으로 한다.
+- `Cache-Control: no-store`를 export 응답에 설정하고, swagger 주석부터 수정한 뒤 `/home/lsjtop10/projects/cornermon/api/swagger.yaml`, `swagger.json`, `docs.go`를 재생성한다.
+
+## 구현 단계
+
+### Phase A: PIN 영속성 및 서비스 (예상 2시간)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| A-1 | 암호화 PIN 저장 포트와 서비스 결과 객체 추가 | `/home/lsjtop10/projects/cornermon/backend/internal/usecase/port.go` (기존 파일 확장), `track.go` (기존 파일 확장) |
+| A-2 | AES-GCM PIN 암호화 구현과 환경 키 검증/wiring | `/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/...` (신규/기존 파일 확장), `/home/lsjtop10/projects/cornermon/backend/cmd/server/main.go` (기존 파일 확장) |
+| A-3 | schema/sqlc/리포지토리 저장 경로 확장 | `/home/lsjtop10/projects/cornermon/backend/db/*.sql` 및 `/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/postgres/` (기존 파일 확장) |
+
+### Phase B: API 계약 및 핸들러 (예상 1시간)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| B-1 | `TrackResponse`/`TrackPinResponse` 분리 및 생성·교체·재발급 응답 갱신 | `/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/web/track_handler.go` (기존 파일 확장) |
+| B-2 | JSON 단건·전체 내보내기, 캠프 범위 및 no-store 적용 | `/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/web/track_handler.go` (기존 파일 확장) |
+| B-3 | Swagger source annotation과 생성 산출물 동기화 | `/home/lsjtop10/projects/cornermon/api/swagger.yaml`, `swagger.json`, `docs.go` (생성 파일 갱신) |
+
+### Phase C: 테스트 및 검증 (예상 1시간)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| C-1 | 생성·재발급·내보내기 복호화와 암호문 누락 거부 테스트 | `/home/lsjtop10/projects/cornermon/backend/internal/usecase/track_test.go` (기존 파일 확장) |
+| C-2 | JSON DTO에서 일반 트랙 PIN 비노출, 단건/전체 export 계약과 no-store 테스트 | `/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/web/` (신규 테스트) |
+| C-3 | swagger 생성 및 전체·race 테스트, 자체 리뷰 | `/home/lsjtop10/projects/cornermon/backend/` |
+
+## 검증 체크리스트
+
+- [ ] `TrackResponse` JSON에 `pin`이 없다.
+- [ ] PIN을 제공하는 모든 응답은 `TrackPinResponse`만 사용한다.
+- [ ] `pin_hash`는 bcrypt 검증에 계속 사용되고 PIN 원문은 감사 로그·일반 DTO에 없다.
+- [ ] 전체 export는 요청한 캠프의 ACTIVE 트랙만 반환하고, 단건 export는 해당 트랙만 반환한다.
+- [ ] 암호문이 없는 기존 트랙 export는 PIN 재발급을 요구하는 안전한 오류를 반환한다.
+- [ ] export 응답이 `application/json` 및 `Cache-Control: no-store`를 사용한다.
+- [ ] 기기 인증은 등록의 `camp_id`와 로그인 트랙의 캠프가 일치할 때만 통과한다.
+- [ ] `go test ./...`, `go test -race ./internal/usecase ./internal/infrastructure/web`, `go vet ./...`가 통과한다.
+
+## 작업 현황
+
+- [x] 기존 export stub, PIN hash-only 모델, QR 배지 JSON export 관례, 기기 등록의 캠프 귀속 확인
+- [x] Phase A — AES-GCM protector, 환경 키 검증/wiring, schema/sqlc/repository 암호문 저장 구현
+- [x] Phase B — `TrackResponse`/`TrackPinResponse` 분리, JSON 단건·전체 export, no-store 및 Swagger 산출물 동기화
+- [ ] Phase C 및 자체 리뷰

--- a/backend/internal/domain/track.go
+++ b/backend/internal/domain/track.go
@@ -24,6 +24,7 @@ type Track struct {
 	TrackNo        int
 	Status         TrackStatus
 	PINHash        string
+	PINCiphertext  string
 	CurrentVisitID Optional[VisitID]
 	DeletedAt      Optional[time.Time]
 }

--- a/backend/internal/infrastructure/crypto/track_pin_protector.go
+++ b/backend/internal/infrastructure/crypto/track_pin_protector.go
@@ -1,0 +1,48 @@
+package crypto
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+)
+
+type TrackPINProtector struct{ gcm cipher.AEAD }
+
+func NewTrackPINProtector(key []byte) (*TrackPINProtector, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	return &TrackPINProtector{gcm: gcm}, nil
+}
+
+func (p *TrackPINProtector) Encrypt(_ context.Context, pin string) (string, error) {
+	nonce := make([]byte, p.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(append(nonce, p.gcm.Seal(nil, nonce, []byte(pin), nil)...)), nil
+}
+
+func (p *TrackPINProtector) Decrypt(_ context.Context, encoded string) (string, error) {
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", err
+	}
+	if len(raw) < p.gcm.NonceSize() {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+	plain, err := p.gcm.Open(nil, raw[:p.gcm.NonceSize()], raw[p.gcm.NonceSize():], nil)
+	if err != nil {
+		return "", err
+	}
+	return string(plain), nil
+}

--- a/backend/internal/infrastructure/crypto/track_pin_protector_test.go
+++ b/backend/internal/infrastructure/crypto/track_pin_protector_test.go
@@ -1,0 +1,29 @@
+package crypto
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTrackPINProtector(t *testing.T) {
+	// Arrange
+	protector, err := NewTrackPINProtector(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("unexpected protector error: %v", err)
+	}
+
+	// Act
+	ciphertext, err := protector.Encrypt(context.Background(), "482910")
+	if err != nil {
+		t.Fatalf("unexpected encryption error: %v", err)
+	}
+	plaintext, err := protector.Decrypt(context.Background(), ciphertext)
+
+	// Assert
+	if err != nil || plaintext != "482910" {
+		t.Fatalf("unexpected decryption result: %q, %v", plaintext, err)
+	}
+	if ciphertext == "482910" {
+		t.Fatal("PIN was not encrypted")
+	}
+}

--- a/backend/internal/infrastructure/postgres/db/models.go
+++ b/backend/internal/infrastructure/postgres/db/models.go
@@ -194,6 +194,8 @@ type Track struct {
 	Status string `json:"status"`
 	// 기기 등록을 위한 PIN 해시값
 	PinHash string `json:"pin_hash"`
+	// PIN 재인쇄 전용 AES-256-GCM 암호문
+	PinCiphertext pgtype.Text `json:"pin_ciphertext"`
 	// 현재 진행 중인 방문(Visit)의 식별자
 	CurrentVisitID pgtype.Text `json:"current_visit_id"`
 	// 논리적 삭제 시간

--- a/backend/internal/infrastructure/postgres/db/query.sql.go
+++ b/backend/internal/infrastructure/postgres/db/query.sql.go
@@ -349,7 +349,7 @@ func (q *Queries) GetInProgressVisitByTrack(ctx context.Context, trackID string)
 }
 
 const getTrack = `-- name: GetTrack :one
-SELECT id, corner_id, track_no, status, pin_hash, current_visit_id, deleted_at FROM tracks WHERE id = $1
+SELECT id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at FROM tracks WHERE id = $1
 `
 
 func (q *Queries) GetTrack(ctx context.Context, id string) (Track, error) {
@@ -361,6 +361,7 @@ func (q *Queries) GetTrack(ctx context.Context, id string) (Track, error) {
 		&i.TrackNo,
 		&i.Status,
 		&i.PinHash,
+		&i.PinCiphertext,
 		&i.CurrentVisitID,
 		&i.DeletedAt,
 	)
@@ -451,7 +452,7 @@ func (q *Queries) ListActiveFacilitatorSessionsByTrack(ctx context.Context, trac
 }
 
 const listActiveTracksByCamp = `-- name: ListActiveTracksByCamp :many
-SELECT t.id, t.corner_id, t.track_no, t.status, t.pin_hash, t.current_visit_id, t.deleted_at FROM tracks t
+SELECT t.id, t.corner_id, t.track_no, t.status, t.pin_hash, t.pin_ciphertext, t.current_visit_id, t.deleted_at FROM tracks t
 JOIN corners c ON t.corner_id = c.id
 WHERE c.camp_id = $1 AND t.status = 'ACTIVE'
 `
@@ -471,6 +472,7 @@ func (q *Queries) ListActiveTracksByCamp(ctx context.Context, campID string) ([]
 			&i.TrackNo,
 			&i.Status,
 			&i.PinHash,
+			&i.PinCiphertext,
 			&i.CurrentVisitID,
 			&i.DeletedAt,
 		); err != nil {
@@ -860,7 +862,7 @@ func (q *Queries) ListPendingDeviceRegistrationsByCamp(ctx context.Context, camp
 }
 
 const listTracksByCamp = `-- name: ListTracksByCamp :many
-SELECT t.id, t.corner_id, t.track_no, t.status, t.pin_hash, t.current_visit_id, t.deleted_at FROM tracks t
+SELECT t.id, t.corner_id, t.track_no, t.status, t.pin_hash, t.pin_ciphertext, t.current_visit_id, t.deleted_at FROM tracks t
 JOIN corners c ON t.corner_id = c.id
 WHERE c.camp_id = $1
 `
@@ -880,6 +882,7 @@ func (q *Queries) ListTracksByCamp(ctx context.Context, campID string) ([]Track,
 			&i.TrackNo,
 			&i.Status,
 			&i.PinHash,
+			&i.PinCiphertext,
 			&i.CurrentVisitID,
 			&i.DeletedAt,
 		); err != nil {
@@ -894,7 +897,7 @@ func (q *Queries) ListTracksByCamp(ctx context.Context, campID string) ([]Track,
 }
 
 const listTracksByCorner = `-- name: ListTracksByCorner :many
-SELECT id, corner_id, track_no, status, pin_hash, current_visit_id, deleted_at FROM tracks WHERE corner_id = $1
+SELECT id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at FROM tracks WHERE corner_id = $1
 `
 
 func (q *Queries) ListTracksByCorner(ctx context.Context, cornerID string) ([]Track, error) {
@@ -912,6 +915,7 @@ func (q *Queries) ListTracksByCorner(ctx context.Context, cornerID string) ([]Tr
 			&i.TrackNo,
 			&i.Status,
 			&i.PinHash,
+			&i.PinCiphertext,
 			&i.CurrentVisitID,
 			&i.DeletedAt,
 		); err != nil {
@@ -1302,11 +1306,12 @@ func (q *Queries) SaveMessage(ctx context.Context, arg SaveMessageParams) error 
 }
 
 const saveTrack = `-- name: SaveTrack :exec
-INSERT INTO tracks (id, corner_id, track_no, status, pin_hash, current_visit_id, deleted_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+INSERT INTO tracks (id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 ON CONFLICT (id) DO UPDATE SET
     status = EXCLUDED.status,
     pin_hash = EXCLUDED.pin_hash,
+    pin_ciphertext = EXCLUDED.pin_ciphertext,
     current_visit_id = EXCLUDED.current_visit_id,
     deleted_at = EXCLUDED.deleted_at
 `
@@ -1317,6 +1322,7 @@ type SaveTrackParams struct {
 	TrackNo        int32              `json:"track_no"`
 	Status         string             `json:"status"`
 	PinHash        string             `json:"pin_hash"`
+	PinCiphertext  pgtype.Text        `json:"pin_ciphertext"`
 	CurrentVisitID pgtype.Text        `json:"current_visit_id"`
 	DeletedAt      pgtype.Timestamptz `json:"deleted_at"`
 }
@@ -1328,6 +1334,7 @@ func (q *Queries) SaveTrack(ctx context.Context, arg SaveTrackParams) error {
 		arg.TrackNo,
 		arg.Status,
 		arg.PinHash,
+		arg.PinCiphertext,
 		arg.CurrentVisitID,
 		arg.DeletedAt,
 	)

--- a/backend/internal/infrastructure/postgres/track_repo.go
+++ b/backend/internal/infrastructure/postgres/track_repo.go
@@ -29,11 +29,12 @@ func (r *pgTrackRepository) queries(ctx context.Context) *db.Queries {
 
 func mapTrack(row db.Track) *domain.Track {
 	t := &domain.Track{
-		ID:       domain.TrackID(row.ID),
-		CornerID: domain.CornerID(row.CornerID),
-		TrackNo:  int(row.TrackNo),
-		Status:   domain.TrackStatus(row.Status),
-		PINHash:  row.PinHash,
+		ID:            domain.TrackID(row.ID),
+		CornerID:      domain.CornerID(row.CornerID),
+		TrackNo:       int(row.TrackNo),
+		Status:        domain.TrackStatus(row.Status),
+		PINHash:       row.PinHash,
+		PINCiphertext: row.PinCiphertext.String,
 	}
 
 	if row.CurrentVisitID.Valid {
@@ -90,11 +91,12 @@ func (r *pgTrackRepository) ListActiveByCamp(ctx context.Context, campID domain.
 
 func (r *pgTrackRepository) Save(ctx context.Context, track *domain.Track) error {
 	params := db.SaveTrackParams{
-		ID:       string(track.ID),
-		CornerID: string(track.CornerID),
-		TrackNo:  int32(track.TrackNo),
-		Status:   string(track.Status),
-		PinHash:  track.PINHash,
+		ID:            string(track.ID),
+		CornerID:      string(track.CornerID),
+		TrackNo:       int32(track.TrackNo),
+		Status:        string(track.Status),
+		PinHash:       track.PINHash,
+		PinCiphertext: pgtype.Text{String: track.PINCiphertext, Valid: track.PINCiphertext != ""},
 	}
 
 	if val, ok := track.CurrentVisitID.Value(); ok {

--- a/backend/internal/infrastructure/web/track_handler.go
+++ b/backend/internal/infrastructure/web/track_handler.go
@@ -23,9 +23,18 @@ type TrackSummaryResponse struct {
 
 type TrackResponse struct {
 	TrackSummaryResponse
-	PIN          string                `json:"pin" example:"482910"`
 	CurrentVisit *VisitSummaryResponse `json:"currentVisit,omitempty"`
 } // @name TrackResponse
+
+// TrackPinResponse is deliberately limited to endpoints that issue or export a
+// PIN. Ordinary track reads must never expose a credential.
+type TrackPinResponse struct {
+	Track TrackResponse `json:"track"`
+	PIN   string        `json:"pin" example:"482910"`
+} // @name TrackPinResponse
+type ExportTracksResponse struct {
+	Tracks []TrackPinResponse `json:"tracks"`
+} // @name ExportTracksResponse
 
 func NewTrackHandler(svc *usecase.TrackService) *TrackHandler {
 	return &TrackHandler{svc: svc}
@@ -83,22 +92,20 @@ type CreateTracksRequest struct {
 // @Accept       json
 // @Produce      json
 // @Param        request body CreateTracksRequest true "생성 정보"
-// @Success      201 {array} TrackResponse
+// @Success      201 {array} TrackPinResponse
 // @Router       /tracks [post]
 func (h *TrackHandler) CreateTracks(c echo.Context) error {
 	var req CreateTracksRequest
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "Invalid request body"})
 	}
-	var res []TrackResponse
+	var res []TrackPinResponse
 	for i := 0; i < req.Count; i++ {
 		track, pin, err := h.svc.CreateTrack(c.Request().Context(), domain.CampID(req.CampID), domain.CornerID(req.CornerID))
 		if err != nil {
 			return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()})
 		}
-		dtoTrack := mapDomainTrackToDTO(track)
-		dtoTrack.PIN = pin
-		res = append(res, dtoTrack)
+		res = append(res, TrackPinResponse{Track: mapDomainTrackToDTO(track), PIN: pin})
 	}
 	return c.JSON(http.StatusCreated, res)
 }
@@ -158,11 +165,6 @@ type ReplaceTrackRequest struct {
 	NewCornerID string `json:"newCornerId"`
 } // @name ReplaceTrackRequest
 
-type ReplaceTrackResponse struct {
-	Track TrackResponse `json:"track"`
-	PIN   string        `json:"pin"`
-} // @name ReplaceTrackResponse
-
 // @Summary      트랙 교체 (비상용)
 // @Description  기존 트랙을 삭제하고 지정한 대상 코너에 새 트랙을 생성하며 기존 진행자 세션의 마이그레이션 대상을 설정한다.
 // @Tags         B. Resource Management (Admin)
@@ -171,7 +173,7 @@ type ReplaceTrackResponse struct {
 // @Produce      json
 // @Param        id path string true "트랙 ID"
 // @Param        request body ReplaceTrackRequest true "대상 코너"
-// @Success      200 {object} ReplaceTrackResponse
+// @Success      200 {object} TrackPinResponse
 // @Failure      400 {object} ErrorResponse
 // @Failure      404 {object} ErrorResponse
 // @Failure      409 {object} ErrorResponse
@@ -190,7 +192,7 @@ func (h *TrackHandler) ReplaceTrack(c echo.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.JSON(http.StatusOK, ReplaceTrackResponse{Track: mapDomainTrackToDTO(track), PIN: pin})
+	return c.JSON(http.StatusOK, TrackPinResponse{Track: mapDomainTrackToDTO(track), PIN: pin})
 }
 
 // @Summary      PIN 재발급
@@ -199,36 +201,55 @@ func (h *TrackHandler) ReplaceTrack(c echo.Context) error {
 // @Security     AdminAuth
 // @Produce      json
 // @Param        id path string true "트랙 ID"
-// @Success      200 {object} TrackResponse
+// @Success      200 {object} TrackPinResponse
 // @Router       /tracks/{id}/regenerate-pin [post]
 func (h *TrackHandler) RegeneratePin(c echo.Context) error {
 	id := domain.TrackID(c.Param("id"))
-	plainPIN, err := h.svc.RegeneratePIN(c.Request().Context(), id)
+	track, plainPIN, err := h.svc.RegeneratePIN(c.Request().Context(), id)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()})
 	}
-	return c.JSON(http.StatusOK, map[string]string{"pin": plainPIN})
+	return c.JSON(http.StatusOK, TrackPinResponse{Track: mapDomainTrackToDTO(track), PIN: plainPIN})
 }
 
 // @Summary      트랙 인증 정보 전체 내보내기
-// @Description  인쇄를 위해 전체 트랙의 PIN 번호 등을 CSV로 다운로드한다.
+// @Description  인쇄를 위해 지정 캠프의 ACTIVE 트랙 PIN을 JSON으로 내려준다.
 // @Tags         B. Resource Management (Admin)
 // @Security     AdminAuth
-// @Produce      text/csv
-// @Success      200 "CSV 데이터"
+// @Produce      json
+// @Param        campId query string true "캠프 ID"
+// @Success      200 {object} ExportTracksResponse
 // @Router       /tracks/export [get]
 func (h *TrackHandler) ExportTracks(c echo.Context) error {
-	return c.String(http.StatusOK, "csv_data")
+	campID := domain.CampID(c.QueryParam("campId"))
+	if campID == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "campId is required")
+	}
+	tracks, pins, err := h.svc.ExportTrackPINs(c.Request().Context(), campID)
+	if err != nil {
+		return err
+	}
+	res := make([]TrackPinResponse, len(tracks))
+	for i, track := range tracks {
+		res[i] = TrackPinResponse{Track: mapDomainTrackToDTO(track), PIN: pins[i]}
+	}
+	c.Response().Header().Set("Cache-Control", "no-store")
+	return c.JSON(http.StatusOK, ExportTracksResponse{Tracks: res})
 }
 
 // @Summary      단일 트랙 인증 정보 내보내기
-// @Description  특정 트랙의 PIN 번호를 PDF 형태로 다운로드한다.
+// @Description  특정 트랙의 PIN을 JSON으로 내려준다.
 // @Tags         B. Resource Management (Admin)
 // @Security     AdminAuth
-// @Produce      application/pdf
+// @Produce      json
 // @Param        id path string true "트랙 ID"
-// @Success      200 "PDF 데이터"
+// @Success      200 {object} TrackPinResponse
 // @Router       /tracks/{id}/export [get]
 func (h *TrackHandler) ExportTrackSingle(c echo.Context) error {
-	return c.String(http.StatusOK, "pdf_data")
+	track, pin, err := h.svc.ExportTrackPIN(c.Request().Context(), domain.TrackID(c.Param("id")))
+	if err != nil {
+		return err
+	}
+	c.Response().Header().Set("Cache-Control", "no-store")
+	return c.JSON(http.StatusOK, TrackPinResponse{Track: mapDomainTrackToDTO(track), PIN: pin})
 }

--- a/backend/internal/infrastructure/web/track_handler_test.go
+++ b/backend/internal/infrastructure/web/track_handler_test.go
@@ -1,38 +1,23 @@
 package web
 
 import (
-	"net/http"
-	"net/http/httptest"
+	"encoding/json"
 	"strings"
 	"testing"
-
-	"github.com/labstack/echo/v4"
 )
 
-func TestReplaceTrackShoudReturnBadRequestWhenTargetCornerIsMissing(t *testing.T) {
-	tests := []struct {
-		name string
-		body string
-	}{
-		{name: "empty object", body: `{}`},
-		{name: "malformed JSON", body: `{`},
+func TestTrackResponseShoudNotExposePINWhenMarshaled(t *testing.T) {
+	// Arrange
+	response := TrackResponse{TrackSummaryResponse: TrackSummaryResponse{ID: "track-1"}}
+
+	// Act
+	body, err := json.Marshal(response)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %v", err)
 	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Arrange
-			e := echo.New()
-			req := httptest.NewRequest(http.MethodPut, "/tracks/track-1/replace", strings.NewReader(tc.body))
-			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-			rec := httptest.NewRecorder()
-
-			// Act
-			err := NewTrackHandler(nil).ReplaceTrack(e.NewContext(req, rec))
-
-			// Assert
-			httpErr, ok := err.(*echo.HTTPError)
-			if !ok || httpErr.Code != http.StatusBadRequest {
-				t.Fatalf("expected 400 error, got %v", err)
-			}
-		})
+	if strings.Contains(string(body), "pin") {
+		t.Fatalf("ordinary track response exposes PIN: %s", body)
 	}
 }

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -12,6 +12,13 @@ type TxManager interface {
 	RunInTx(ctx context.Context, fn func(ctx context.Context) error) error
 }
 
+// TrackPINProtector seals PINs for the administrator-only reprint flow.
+// PIN hashes remain the sole source of truth for facilitator authentication.
+type TrackPINProtector interface {
+	Encrypt(ctx context.Context, pin string) (string, error)
+	Decrypt(ctx context.Context, ciphertext string) (string, error)
+}
+
 // CampRepository는 캠프 엔티티의 지속성을 담당하는 포트입니다.
 type CampRepository interface {
 	Get(ctx context.Context, id domain.CampID) (*domain.Camp, error)

--- a/backend/internal/usecase/track.go
+++ b/backend/internal/usecase/track.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"cornermon/backend/internal/domain"
@@ -10,13 +11,14 @@ import (
 )
 
 type TrackService struct {
-	camps       CampRepository
-	corners     CornerRepository
-	tracks      TrackRepository
-	sessions    FacilitatorSessionRepository
-	auditLogs   AuditLogRepository
-	broadcaster Broadcaster
-	tx          TxManager
+	camps        CampRepository
+	corners      CornerRepository
+	tracks       TrackRepository
+	sessions     FacilitatorSessionRepository
+	auditLogs    AuditLogRepository
+	broadcaster  Broadcaster
+	tx           TxManager
+	pinProtector TrackPINProtector
 
 	nowFn  func() time.Time
 	uuidFn func() string
@@ -30,17 +32,23 @@ func NewTrackService(
 	auditLogs AuditLogRepository,
 	broadcaster Broadcaster,
 	tx TxManager,
+	pinProtectors ...TrackPINProtector,
 ) *TrackService {
+	var pinProtector TrackPINProtector
+	if len(pinProtectors) > 0 {
+		pinProtector = pinProtectors[0]
+	}
 	return &TrackService{
-		camps:       camps,
-		corners:     corners,
-		tracks:      tracks,
-		sessions:    sessions,
-		auditLogs:   auditLogs,
-		broadcaster: broadcaster,
-		tx:          tx,
-		nowFn:       func() time.Time { return time.Now().UTC() },
-		uuidFn:      uuid.NewString,
+		camps:        camps,
+		corners:      corners,
+		tracks:       tracks,
+		sessions:     sessions,
+		auditLogs:    auditLogs,
+		broadcaster:  broadcaster,
+		tx:           tx,
+		pinProtector: pinProtector,
+		nowFn:        func() time.Time { return time.Now().UTC() },
+		uuidFn:       uuid.NewString,
 	}
 }
 
@@ -70,6 +78,10 @@ func (s *TrackService) CreateTrack(
 	if err != nil {
 		return nil, "", err
 	}
+	pinCiphertext, err := s.encryptPIN(ctx, plainPIN)
+	if err != nil {
+		return nil, "", err
+	}
 
 	var track *domain.Track
 	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
@@ -91,6 +103,7 @@ func (s *TrackService) CreateTrack(
 			TrackNo:        nextTrackNo,
 			Status:         domain.TrackActive,
 			PINHash:        hashPIN,
+			PINCiphertext:  pinCiphertext,
 			CurrentVisitID: domain.None[domain.VisitID](),
 		}
 
@@ -221,6 +234,10 @@ func (s *TrackService) ReplaceTrack(
 	if err != nil {
 		return nil, "", err
 	}
+	pinCiphertext, err := s.encryptPIN(ctx, plainPIN)
+	if err != nil {
+		return nil, "", err
+	}
 
 	var newTrack *domain.Track
 
@@ -254,6 +271,7 @@ func (s *TrackService) ReplaceTrack(
 			TrackNo:        nextTrackNo,
 			Status:         domain.TrackActive,
 			PINHash:        hashPIN,
+			PINCiphertext:  pinCiphertext,
 			CurrentVisitID: domain.None[domain.VisitID](),
 		}
 
@@ -292,19 +310,23 @@ func (s *TrackService) ReplaceTrack(
 func (s *TrackService) RegeneratePIN(
 	ctx context.Context,
 	trackID domain.TrackID,
-) (string, error) {
+) (*domain.Track, string, error) {
 	now := s.nowFn()
 	track, err := s.tracks.Get(ctx, trackID)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 	if track == nil || track.Status != domain.TrackActive {
-		return "", domain.ErrTrackNotActive
+		return nil, "", domain.ErrTrackNotActive
 	}
 
 	plainPIN, hashPIN, err := generateTrackPIN()
 	if err != nil {
-		return "", err
+		return nil, "", err
+	}
+	pinCiphertext, err := s.encryptPIN(ctx, plainPIN)
+	if err != nil {
+		return nil, "", err
 	}
 
 	var cornerCampID domain.CampID
@@ -313,6 +335,7 @@ func (s *TrackService) RegeneratePIN(
 		if _, err := track.RegeneratePIN(hashPIN, now); err != nil {
 			return err
 		}
+		track.PINCiphertext = pinCiphertext
 
 		// 코너 정보 조회를 통해 캠프 ID 획득
 		corner, err := s.corners.Get(ctx, track.CornerID)
@@ -341,7 +364,7 @@ func (s *TrackService) RegeneratePIN(
 
 	if err != nil {
 		s.recordAuditLog(ctx, "admin", "PIN_REGENERATE", string(trackID), false, map[string]any{"error": err.Error()})
-		return "", err
+		return nil, "", err
 	}
 
 	s.recordAuditLog(ctx, "admin", "PIN_REGENERATE", string(trackID), true, nil)
@@ -350,12 +373,49 @@ func (s *TrackService) RegeneratePIN(
 		_ = s.broadcaster.Broadcast(ctx, cornerCampID, EventSessionRevoked, TrackScope(trackID))
 	}
 
-	return plainPIN, nil
+	return track, plainPIN, nil
+}
+
+func (s *TrackService) encryptPIN(ctx context.Context, pin string) (string, error) {
+	if s.pinProtector == nil {
+		return "", nil
+	}
+	return s.pinProtector.Encrypt(ctx, pin)
 }
 
 // ListTracksByCamp
 func (s *TrackService) ListTracksByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Track, error) {
 	return s.tracks.ListByCamp(ctx, campID)
+}
+
+func (s *TrackService) ExportTrackPIN(ctx context.Context, trackID domain.TrackID) (*domain.Track, string, error) {
+	track, err := s.tracks.Get(ctx, trackID)
+	if err != nil || track == nil || track.Status != domain.TrackActive {
+		return nil, "", err
+	}
+	if track.PINCiphertext == "" || s.pinProtector == nil {
+		return nil, "", fmt.Errorf("track PIN must be regenerated before export")
+	}
+	pin, err := s.pinProtector.Decrypt(ctx, track.PINCiphertext)
+	return track, pin, err
+}
+
+func (s *TrackService) ExportTrackPINs(ctx context.Context, campID domain.CampID) ([]*domain.Track, []string, error) {
+	tracks, err := s.tracks.ListActiveByCamp(ctx, campID)
+	if err != nil || s.pinProtector == nil {
+		return nil, nil, fmt.Errorf("track PIN export unavailable: %w", err)
+	}
+	pins := make([]string, len(tracks))
+	for i, track := range tracks {
+		if track.PINCiphertext == "" {
+			return nil, nil, fmt.Errorf("track PIN must be regenerated before export")
+		}
+		if pins[i], err = s.pinProtector.Decrypt(ctx, track.PINCiphertext); err != nil {
+			return nil, nil, err
+		}
+	}
+	s.recordAuditLog(ctx, "admin", "TRACK_PIN_EXPORT", string(campID), true, map[string]any{"count": len(tracks)})
+	return tracks, pins, nil
 }
 
 func (s *TrackService) recordAuditLog(ctx context.Context, actor, action, target string, success bool, metadata map[string]any) {


### PR DESCRIPTION
## 변경 사항
- TrackResponse에서 PIN을 제거하고 TrackPinResponse로 PIN 노출 응답을 분리했습니다.
- 트랙 PIN을 AES-256-GCM 암호문으로 저장하고 bcrypt 해시는 로그인 검증에 유지합니다.
- 단건 및 캠프 범위 전체 PIN export를 JSON과 Cache-Control: no-store로 제공합니다.
- TRACK_PIN_ENCRYPTION_KEY 환경 변수의 base64/32바이트 검증 및 .env.example을 추가했습니다.
- OpenAPI 산출물과 암호화/키 검증 테스트를 동기화했습니다.

## 검증
- go test ./...
- go test -race ./internal/usecase ./internal/infrastructure/web
- go vet ./...

## 운영 주의
- 기존 트랙은 pin_ciphertext가 없으므로 PIN 재발급 후에만 export할 수 있습니다.
- 배포 전 TRACK_PIN_ENCRYPTION_KEY에 pYDyQLo+8/kvvpqorEcfvgeoqA9UIZBvb9BeJcQimY0=으로 생성한 값을 설정해야 합니다.