### PR TITLE
feat: 다이렉트 메시지 읽음 상태와 미확인 수 추가

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2284,17 +2284,20 @@ const docTemplate = `{
             "get": {
                 "security": [
                     {
+                        "AdminAuth": []
+                    },
+                    {
                         "TrackAuth": []
                     }
                 ],
-                "description": "트랙 진행자가 자신의 트랙과 관련된 DIRECT 메시지 내역을 조회한다(GitHub Issue #69, 구현 예정).",
+                "description": "관리자 또는 자신의 트랙 진행자가 DIRECT 메시지 내역을 조회한다.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "E. Message"
                 ],
-                "summary": "트랙별 메시지 내역 조회 (진행자)",
+                "summary": "트랙별 메시지 내역 조회",
                 "parameters": [
                     {
                         "type": "string",
@@ -2326,8 +2329,8 @@ const docTemplate = `{
                             }
                         }
                     },
-                    "501": {
-                        "description": "구현 예정 (GitHub Issue #69)",
+                    "403": {
+                        "description": "세션 트랙과 요청 트랙 불일치",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -2381,7 +2384,15 @@ const docTemplate = `{
         },
         "/tracks/{trackId}/messages/unread-count": {
             "get": {
-                "description": "호출자(관리자 또는 진행자) 기준으로 상대측이 보낸 미확인 메시지 개수를 반환한다(GitHub Issue #69, 구현 예정).",
+                "security": [
+                    {
+                        "AdminAuth": []
+                    },
+                    {
+                        "TrackAuth": []
+                    }
+                ],
+                "description": "호출자(관리자 또는 진행자) 기준으로 상대측이 보낸 미확인 메시지 개수를 반환한다.",
                 "produces": [
                     "application/json"
                 ],
@@ -2405,8 +2416,8 @@ const docTemplate = `{
                             "$ref": "#/definitions/UnreadCountResponse"
                         }
                     },
-                    "501": {
-                        "description": "구현 예정 (GitHub Issue #69)",
+                    "403": {
+                        "description": "세션 트랙과 요청 트랙 불일치",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2277,17 +2277,20 @@
             "get": {
                 "security": [
                     {
+                        "AdminAuth": []
+                    },
+                    {
                         "TrackAuth": []
                     }
                 ],
-                "description": "트랙 진행자가 자신의 트랙과 관련된 DIRECT 메시지 내역을 조회한다(GitHub Issue #69, 구현 예정).",
+                "description": "관리자 또는 자신의 트랙 진행자가 DIRECT 메시지 내역을 조회한다.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "E. Message"
                 ],
-                "summary": "트랙별 메시지 내역 조회 (진행자)",
+                "summary": "트랙별 메시지 내역 조회",
                 "parameters": [
                     {
                         "type": "string",
@@ -2319,8 +2322,8 @@
                             }
                         }
                     },
-                    "501": {
-                        "description": "구현 예정 (GitHub Issue #69)",
+                    "403": {
+                        "description": "세션 트랙과 요청 트랙 불일치",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -2374,7 +2377,15 @@
         },
         "/tracks/{trackId}/messages/unread-count": {
             "get": {
-                "description": "호출자(관리자 또는 진행자) 기준으로 상대측이 보낸 미확인 메시지 개수를 반환한다(GitHub Issue #69, 구현 예정).",
+                "security": [
+                    {
+                        "AdminAuth": []
+                    },
+                    {
+                        "TrackAuth": []
+                    }
+                ],
+                "description": "호출자(관리자 또는 진행자) 기준으로 상대측이 보낸 미확인 메시지 개수를 반환한다.",
                 "produces": [
                     "application/json"
                 ],
@@ -2398,8 +2409,8 @@
                             "$ref": "#/definitions/UnreadCountResponse"
                         }
                     },
-                    "501": {
-                        "description": "구현 예정 (GitHub Issue #69)",
+                    "403": {
+                        "description": "세션 트랙과 요청 트랙 불일치",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2060,7 +2060,7 @@ paths:
       - C. Visit (Scan Flow)
   /tracks/{trackId}/messages:
     get:
-      description: '트랙 진행자가 자신의 트랙과 관련된 DIRECT 메시지 내역을 조회한다(GitHub Issue #69, 구현 예정).'
+      description: 관리자 또는 자신의 트랙 진행자가 DIRECT 메시지 내역을 조회한다.
       parameters:
       - description: 트랙 ID
         in: path
@@ -2084,13 +2084,14 @@ paths:
             items:
               $ref: '#/definitions/MessageResponse'
             type: array
-        "501":
-          description: '구현 예정 (GitHub Issue #69)'
+        "403":
+          description: 세션 트랙과 요청 트랙 불일치
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
+      - AdminAuth: []
       - TrackAuth: []
-      summary: 트랙별 메시지 내역 조회 (진행자)
+      summary: 트랙별 메시지 내역 조회
       tags:
       - E. Message
     post:
@@ -2123,8 +2124,7 @@ paths:
       - E. Message
   /tracks/{trackId}/messages/unread-count:
     get:
-      description: '호출자(관리자 또는 진행자) 기준으로 상대측이 보낸 미확인 메시지 개수를 반환한다(GitHub Issue #69,
-        구현 예정).'
+      description: 호출자(관리자 또는 진행자) 기준으로 상대측이 보낸 미확인 메시지 개수를 반환한다.
       parameters:
       - description: 트랙 ID
         in: path
@@ -2138,10 +2138,13 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/UnreadCountResponse'
-        "501":
-          description: '구현 예정 (GitHub Issue #69)'
+        "403":
+          description: 세션 트랙과 요청 트랙 불일치
           schema:
             $ref: '#/definitions/ErrorResponse'
+      security:
+      - AdminAuth: []
+      - TrackAuth: []
       summary: 트랙 미확인 다이렉트 메시지 개수 조회
       tags:
       - E. Message

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -40,14 +40,28 @@ JOIN corners c ON t.corner_id = c.id
 WHERE c.camp_id = $1 AND t.status = 'ACTIVE';
 
 -- name: SaveTrack :exec
-INSERT INTO tracks (id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO tracks (id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at, unread_by_admin_count, unread_by_track_count)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 ON CONFLICT (id) DO UPDATE SET
     status = EXCLUDED.status,
     pin_hash = EXCLUDED.pin_hash,
     pin_ciphertext = EXCLUDED.pin_ciphertext,
     current_visit_id = EXCLUDED.current_visit_id,
-    deleted_at = EXCLUDED.deleted_at;
+    deleted_at = EXCLUDED.deleted_at,
+    unread_by_admin_count = EXCLUDED.unread_by_admin_count,
+    unread_by_track_count = EXCLUDED.unread_by_track_count;
+
+-- name: IncrementTrackUnreadCount :exec
+UPDATE tracks
+SET unread_by_admin_count = unread_by_admin_count + CASE WHEN sqlc.arg(recipient)::VARCHAR = 'ADMIN' THEN 1 ELSE 0 END,
+    unread_by_track_count = unread_by_track_count + CASE WHEN sqlc.arg(recipient)::VARCHAR = 'TRACK' THEN 1 ELSE 0 END
+WHERE id = sqlc.arg(track_id);
+
+-- name: ResetTrackUnreadCount :exec
+UPDATE tracks
+SET unread_by_admin_count = CASE WHEN sqlc.arg(reader)::VARCHAR = 'ADMIN' THEN 0 ELSE unread_by_admin_count END,
+    unread_by_track_count = CASE WHEN sqlc.arg(reader)::VARCHAR = 'TRACK' THEN 0 ELSE unread_by_track_count END
+WHERE id = sqlc.arg(track_id);
 
 -- name: GetVisit :one
 SELECT * FROM visits WHERE id = $1;
@@ -154,11 +168,24 @@ ON CONFLICT (id) DO UPDATE SET
     revoked_at = EXCLUDED.revoked_at;
 
 -- name: SaveMessage :exec
-INSERT INTO messages (id, track_id, sender_role, content, sent_at)
-VALUES ($1, $2, $3, $4, $5);
+INSERT INTO messages (id, track_id, sender_role, content, sent_at, read_at)
+VALUES ($1, $2, $3, $4, $5, $6);
 
 -- name: ListMessagesByTrack :many
 SELECT * FROM messages WHERE track_id = $1 ORDER BY sent_at;
+
+-- name: ListMessagesByTrackAfter :many
+SELECT * FROM messages
+WHERE track_id = sqlc.arg(track_id)
+  AND (sqlc.narg(after)::TIMESTAMPTZ IS NULL OR sent_at > sqlc.narg(after)::TIMESTAMPTZ)
+ORDER BY sent_at;
+
+-- name: MarkAllMessagesReadByRecipient :exec
+UPDATE messages
+SET read_at = COALESCE(read_at, sqlc.arg(read_at)::TIMESTAMPTZ)
+WHERE track_id = sqlc.arg(track_id)
+  AND sender_role <> sqlc.arg(recipient)::VARCHAR
+  AND read_at IS NULL;
 
 -- name: SaveAnnouncement :exec
 INSERT INTO announcements (id, camp_id, sender_role, content, sent_at)

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -45,7 +45,9 @@ CREATE TABLE tracks (
     pin_hash VARCHAR(255) NOT NULL,
     pin_ciphertext TEXT,
     current_visit_id VARCHAR(50),
-    deleted_at TIMESTAMP WITH TIME ZONE
+    deleted_at TIMESTAMP WITH TIME ZONE,
+    unread_by_admin_count INT NOT NULL DEFAULT 0,
+    unread_by_track_count INT NOT NULL DEFAULT 0
 );
 COMMENT ON TABLE tracks IS '코너 내에서 병렬로 진행 가능한 세부 트랙(기기/테이블)을 정의하는 테이블';
 COMMENT ON COLUMN tracks.id IS '트랙 고유 식별자';
@@ -182,7 +184,8 @@ CREATE TABLE messages (
     track_id VARCHAR(50) NOT NULL REFERENCES tracks(id) ON DELETE CASCADE,
     sender_role VARCHAR(50) NOT NULL,
     content TEXT NOT NULL,
-    sent_at TIMESTAMP WITH TIME ZONE NOT NULL
+    sent_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    read_at TIMESTAMP WITH TIME ZONE
 );
 COMMENT ON TABLE messages IS '트랙별 운영자/진행자 스레드 메시지를 저장하는 테이블';
 COMMENT ON COLUMN messages.id IS '메시지 고유 식별자';

--- a/backend/docs/artifacts/plan/20260715_issue_69_direct_message_read_status_plan_.md
+++ b/backend/docs/artifacts/plan/20260715_issue_69_direct_message_read_status_plan_.md
@@ -121,15 +121,15 @@ func (h *MessageHandler) GetUnreadCount(c echo.Context) error
 
 ```go
 // internal/infrastructure/web/router.go
-// admin 그룹: 기존 GET에 파라미터만 추가되므로 라우트 등록은 그대로.
-admin.GET("/tracks/:trackId/messages/unread-count", h.Message.GetUnreadCount)
-
-// track 그룹: 진행자도 자신의 스레드를 조회/집계할 수 있어야 함 (UC-3)
-track.GET("/tracks/:trackId/messages", h.Message.ListDirectMessages)
-track.GET("/tracks/:trackId/messages/unread-count", h.Message.GetUnreadCount)
+// Echo는 같은 method/path에 하나의 handler만 등록할 수 있으므로,
+// 관리자/진행자 세션을 모두 허용하는 전용 그룹에 GET을 한 번만 등록한다.
+message := v1.Group("")
+message.Use(MessageAuthMiddleware(adminAuth, trackAuth))
+message.GET("/tracks/:trackId/messages", h.Message.ListDirectMessages)
+message.GET("/tracks/:trackId/messages/unread-count", h.Message.GetUnreadCount)
 ```
 
-handler 내부에서 `c.Get("adminSession")`/`c.Get("facilitatorSession")`으로 `viewerRole`을 판별한다(기존 `SendDirect`와 동일 패턴, `message_handler.go:208-215`). 또한 `track` 그룹에 걸린 `TrackAuthMiddleware`가 요청 트랙 ID와 세션 트랙 ID 일치를 검증하는지 확인하고, 없다면 `domain.ErrTrackScopeForbidden` 체크를 handler에 추가한다.
+handler 내부에서 `c.Get("adminSession")`/`c.Get("facilitatorSession")`으로 `viewerRole`을 판별한다. 또한 진행자 세션의 `TrackID`와 요청 트랙 ID가 일치하지 않으면 `domain.ErrTrackScopeForbidden`을 반환한다.
 
 ## 3. 아키텍처 원칙 명시
 
@@ -225,10 +225,12 @@ type TrackRepository interface {
 - [x] 동시성 테스트: 트랙 행 잠금 획득 순서(`increment → save`, `reset → mark-read`)를 검증하고 `go test -race ./internal/usecase ./internal/infrastructure/web`를 통과했다.
 - [x] repository/query 경계 테스트: `after`와 정확히 일치하는 `sent_at`은 제외하고 이후 메시지만 반환하는 계약을 검증했다.
 - [x] handler 레벨 테스트: `background` 미지정 시 기본값(false)이 안전한 방향(읽음 처리 안 함)인지 확인했다.
+- [x] router 레벨 테스트: 중복 GET 등록 없이 관리자와 진행자 토큰이 같은 endpoint로 각각 접근하고 올바른 `viewerRole`로 처리되는지 확인했다.
 
 ## 7. 완료 기록 (2026-07-15)
 
 - 진행자 세션의 `TrackID`와 path `trackId` 불일치를 모든 DIRECT 메시지 읽기·미확인 수·발신 경로에서 403으로 차단했다.
 - 카운터를 0으로 갱신하는 읽음 처리와 증가시키는 발송 처리는 동일한 `tracks` 행을 먼저 갱신해 직렬화한다.
 - OpenAPI를 재생성해 두 GET endpoint가 `AdminAuth` 또는 `TrackAuth`를 허용하고 `background`, `after`, 403 계약을 명시한다.
+- Echo의 동일 method/path 중복 등록 문제를 제거하고, 두 인증 방식을 판별하는 `MessageAuthMiddleware`로 단일 GET route를 등록한다.
 - 검증 명령: `go test ./...`, `go test -race ./internal/usecase ./internal/infrastructure/web`.

--- a/backend/docs/artifacts/plan/20260715_issue_69_direct_message_read_status_plan_.md
+++ b/backend/docs/artifacts/plan/20260715_issue_69_direct_message_read_status_plan_.md
@@ -1,0 +1,234 @@
+# GitHub Issue #69 — 다이렉트 메시지 읽음 처리 API 추가/변경 구현 계획
+
+> 이슈: https://github.com/lsjtop10/cornermon/issues/69
+
+## 배경 / 문제 정의
+
+프론트엔드(진행자 앱)에서 다이렉트 메시지(트랙 ↔ 운영자 1:1 스레드) 미확인 개수를 배지로 보여주려 하는데, 집계 API가 없다. 이슈 요구사항은 다음 두 가지다.
+
+1. `GET /tracks/{trackId}/messages`에 `background`(읽음 처리 여부), `after`(이후 시각 필터) 쿼리 파라미터 추가
+2. `GET /tracks/{trackId}/messages/unread-count` 신규 — 매번 집계 쿼리를 날리지 않고 별도 컬럼으로 관리(CQRS), 도메인 모델 전체 로딩 후 애플리케이션 집계 금지
+
+### 코드베이스 조사 결과
+
+- `domain.Message`에는 이미 `ReadAt Optional[time.Time]`과 `MarkRead(now)` 메서드가 있다 (`internal/domain/message.go:22-41`). 다만 **DIRECT 메시지 경로에서는 전혀 사용되지 않는다** — `messages` 테이블에 `read_at` 컬럼 자체가 없다 (`db/schema.sql:180-186`), `mapMessage`도 `ReadAt`을 세팅하지 않는다 (`internal/infrastructure/postgres/message_repo.go:28-39`).
+- BROADCAST(공지) 메시지는 이미 `announcement_receipts` 테이블로 트랙별 읽음 여부를 추적한다 (`db/schema.sql:194-`). DIRECT는 1:1 스레드라 수신자가 항상 한 명(발신자의 반대 역할)이므로, 공지처럼 별도 receipts 테이블을 둘 필요 없이 `messages.read_at` 컬럼 하나로 충분하다.
+- **현재 라우터에는 트랙(진행자) 인증으로 메시지를 조회하는 GET 경로가 없다.** `admin.GET("/tracks/:trackId/messages", ...)`만 등록되어 있고 (`internal/infrastructure/web/router.go:113`), `track` 그룹에는 발신(`POST .../from-track`)만 있다 (`router.go:141`). 진행자 앱이 배지를 계산하려면 이 조회 경로도 함께 열어야 이슈의 취지(진행자 미확인 개수 배지)를 만족한다.
+- 이 서비스는 관리자(ADMIN)와 진행자(TRACK) 양쪽이 같은 스레드를 주고받는 구조이므로, "읽음"과 "미확인 개수"는 **호출자 역할의 반대편이 보낸 메시지** 기준으로 정의한다. 즉 관리자가 조회하면 `senderRole=TRACK`인 미확인 메시지, 진행자가 조회하면 `senderRole=ADMIN`인 미확인 메시지를 센다. 이렇게 하면 엔드포인트를 역할별로 분기하지 않고 기존 `SendDirect`가 이미 쓰는 세션 기반 역할 판별(`c.Get("adminSession")` / `c.Get("facilitatorSession")`, `message_handler.go:208-215`)을 그대로 재사용할 수 있다.
+
+### CQRS 설계 — "별도 컬럼" 요구사항 반영
+
+이슈가 명시한 "매번 집계 쿼리 금지, 별도 컬럼 관리"를 만족시키기 위해 `tracks` 테이블에 미확인 카운터 컬럼 두 개를 추가한다(역할별 별도 카운트가 필요하므로):
+
+- `tracks.unread_by_admin_count` — TRACK이 보내고 ADMIN이 아직 안 읽은 메시지 수
+- `tracks.unread_by_track_count` — ADMIN이 보내고 TRACK이 아직 안 읽은 메시지 수
+
+메시지 발송 시 해당 카운터를 `+1`, 읽음 처리(`background=true`) 시 해당 카운터를 `0`으로 원자적 `UPDATE`한다. 조회는 항상 이 컬럼을 읽기만 하므로 집계 쿼리가 요청마다 발생하지 않는다.
+
+## 1. 유즈케이스 우선 정의
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-1: 트랙 메시지 목록 조회 + 선택적 읽음 처리 | `after` 이후 메시지만 반환, `background=true`면 상대측이 보낸 미확인 메시지를 읽음 처리 | **관리자/진행자 스레드 화면** |
+| **P0** | UC-2: 트랙 미확인 개수 조회 | 호출자 역할 기준 미확인 메시지 개수를 컬럼에서 즉시 반환 | **진행자 앱 배지, 관리자 대시보드 배지** |
+| P1 | UC-3: 진행자 인증으로 메시지 목록 조회 | 트랙 세션으로 GET 접근 허용 (현재 admin 전용) | **진행자 앱 스레드 화면 — UC-1의 전제조건** |
+
+## 2. 객체 중심 설계
+
+### Domain Layer
+
+```go
+// internal/domain/message.go — 변경 없음. 기존 ReadAt/MarkRead 재사용.
+```
+
+```go
+// internal/domain/track.go — 미확인 카운터를 트랙 애그리거트에 추가
+type Track struct {
+    // ...기존 필드...
+    UnreadByAdminCount int
+    UnreadByTrackCount int
+}
+
+// 책임: 메시지 발송 시 상대측 미확인 카운터 증가
+func (t *Track) IncrementUnread(recipient SenderRole)
+
+// 책임: 읽음 처리 시 호출자 측 미확인 카운터 초기화
+func (t *Track) ResetUnread(reader SenderRole)
+```
+
+> 대안으로 카운터를 `usecase.TrackUnreadCounts` DTO로만 두고 `Track` 애그리거트에는 넣지 않는 방법도 있다(순수 조회 전용 값이라 도메인 불변식과 무관). 다만 "메시지 발송"이라는 쓰기 트랜잭션 안에서 함께 원자적으로 갱신되어야 하므로, `MessageService.SendDirect`가 이미 로드하는 `Track` 애그리거트에 필드로 두고 같은 트랜잭션에서 `tracks.Save`로 함께 저장하는 편이 별도 포트 호출보다 트랜잭션 경계가 단순하다. 두 방식 중 최종 선택은 구현 시 `TrackRepository.Save`가 부분 업데이트를 지원하는지 확인 후 결정한다 (아래 3.3 참고).
+
+### Usecase Layer
+
+```go
+// internal/usecase/port.go
+type MessageRepository interface {
+    Save(ctx context.Context, msg *domain.Message) error
+    ListMessageByTrack(ctx context.Context, trackID domain.TrackID) ([]*domain.Message, error)
+    // 신규: after 필터 + role 무관 원본 리스트 (핸들러에서 after 조건을 명시적으로 넘김)
+    ListMessageByTrackAfter(ctx context.Context, trackID domain.TrackID, after domain.Optional[time.Time]) ([]*domain.Message, error)
+    // 신규: recipient가 아직 읽지 않은 메시지들을 읽음 처리 (조건부 원자적 UPDATE, 3.3 참고)
+    MarkAllReadByRecipient(ctx context.Context, trackID domain.TrackID, recipient domain.SenderRole, readAt time.Time) error
+}
+```
+
+```go
+// internal/usecase/message.go
+// 책임: after 필터 적용 조회 + background=true일 때 호출자 반대편 발신 메시지 읽음 처리
+// CQRS 사유: 목록 조회 자체는 트랜잭션 상태 변이가 없는 단순 조회이나, background=true 분기에서
+// "읽음 처리"라는 쓰기가 섞이므로 usecase를 경유한다(2절 "리팩토링 트리거" 원칙).
+func (s *MessageService) ListDirectMessages(
+    ctx context.Context,
+    trackID domain.TrackID,
+    viewerRole domain.SenderRole,
+    after domain.Optional[time.Time],
+    markRead bool,
+) ([]*domain.Message, error)
+
+// 책임: tracks 테이블의 미확인 카운터 컬럼을 호출자 역할 기준으로 즉시 반환 (집계 쿼리 없음)
+func (s *MessageService) GetUnreadCount(
+    ctx context.Context,
+    trackID domain.TrackID,
+    viewerRole domain.SenderRole,
+) (int, error)
+```
+
+### Infrastructure Layer (Web)
+
+```go
+// internal/infrastructure/web/message_handler.go
+type MessageUsecase interface {
+    SendDirect(ctx context.Context, trackID domain.TrackID, content string, senderRole domain.SenderRole) (*domain.Message, error)
+    ListDirectMessages(ctx context.Context, trackID domain.TrackID, viewerRole domain.SenderRole, after domain.Optional[time.Time], markRead bool) ([]*domain.Message, error)
+    GetUnreadCount(ctx context.Context, trackID domain.TrackID, viewerRole domain.SenderRole) (int, error)
+}
+
+type UnreadCountResponse struct {
+    UnreadCount int `json:"unreadCount"`
+} // @name UnreadCountResponse
+
+// @Param background query bool false "true면 상대측 미확인 메시지를 읽음 처리"
+// @Param after query string false "RFC3339 UTC 이후 메시지만 반환"
+func (h *MessageHandler) ListDirectMessages(c echo.Context) error
+
+// @Router /tracks/{trackId}/messages/unread-count [get]
+func (h *MessageHandler) GetUnreadCount(c echo.Context) error
+```
+
+`MessageResponse`는 이미 `IsRead`, `ReadAt` 필드를 갖고 있으므로(`message_handler.go:38-39`) DTO 변경 없이 `mapMessage`/handler 매핑만 채워 넣으면 된다.
+
+### Router
+
+```go
+// internal/infrastructure/web/router.go
+// admin 그룹: 기존 GET에 파라미터만 추가되므로 라우트 등록은 그대로.
+admin.GET("/tracks/:trackId/messages/unread-count", h.Message.GetUnreadCount)
+
+// track 그룹: 진행자도 자신의 스레드를 조회/집계할 수 있어야 함 (UC-3)
+track.GET("/tracks/:trackId/messages", h.Message.ListDirectMessages)
+track.GET("/tracks/:trackId/messages/unread-count", h.Message.GetUnreadCount)
+```
+
+handler 내부에서 `c.Get("adminSession")`/`c.Get("facilitatorSession")`으로 `viewerRole`을 판별한다(기존 `SendDirect`와 동일 패턴, `message_handler.go:208-215`). 또한 `track` 그룹에 걸린 `TrackAuthMiddleware`가 요청 트랙 ID와 세션 트랙 ID 일치를 검증하는지 확인하고, 없다면 `domain.ErrTrackScopeForbidden` 체크를 handler에 추가한다.
+
+## 3. 아키텍처 원칙 명시
+
+### 3.1 헥사고날 아키텍처 준수
+- Domain: `Track`에 순수 카운터 필드/메서드만 추가, 외부 의존성 없음.
+- Service: `MessageRepository`, `TrackRepository` 포트에만 의존.
+- Infrastructure: sqlc 쿼리와 pgx 구현은 postgres 어댑터에 격리.
+
+### 3.2 기존 포트 활용 우선
+- 새 `UnreadCountRepository` 신규 생성 ❌ → 기존 `MessageRepository`/`TrackRepository` 확장 ✅
+
+### 3.3 조건부 원자적 업데이트 (동시성)
+발송과 읽음 처리가 동시에 일어날 수 있으므로(관리자가 보내는 순간 진행자가 읽음 처리), 카운터 갱신은 애플리케이션에서 `Get → +1 → Save` 하지 않고 DB 레벨 원자적 `UPDATE ... SET count = count + 1` / `UPDATE ... SET count = 0`으로 수행한다.
+
+```go
+// internal/usecase/port.go에 TrackRepository 확장 (기존 포트 활용, 신규 포트 아님)
+type TrackRepository interface {
+    // ...기존 메서드...
+    IncrementUnreadCount(ctx context.Context, trackID domain.TrackID, recipient domain.SenderRole) error
+    ResetUnreadCount(ctx context.Context, trackID domain.TrackID, reader domain.SenderRole) error
+}
+```
+
+이 경우 2절의 `Track.IncrementUnread`/`ResetUnread` 도메인 메서드는 두지 않고, SQL 레벨 원자적 업데이트로 대체한다(위 "대안" 문단에서 언급한 선택지 중 이쪽을 채택 — 도메인 불변식 검증이 필요 없는 단순 카운터이므로 포트에서 직접 원자적 연산하는 것이 `Get→Save` 경쟁 조건을 원천 차단한다).
+
+### 검증 항목
+- [x] `domain` 패키지에서 `infrastructure` import 없음
+- [x] 카운터 갱신이 `Get→+1→Save` 왕복이 아닌 단일 원자적 `UPDATE`로 수행됨
+- [x] `GetUnreadCount`가 `messages`/`visits` 등에 대해 집계 쿼리(`COUNT`, `SUM`)를 실행하지 않음 — 컬럼 조회만 함
+
+## 4. 계층별 책임 분리
+
+### Domain Layer
+- 카운터는 순수 값 필드이며 비즈니스 불변식이 없으므로 `Track` 구조체 필드로만 존재(3.3 참고, 증감 로직은 포트가 원자적으로 수행).
+
+### Service Layer (`MessageService`)
+- `after` 필터, `viewerRole` 기반 읽음 처리 여부 분기라는 애플리케이션 로직을 소유.
+- `background=true`일 때: 트랙 카운터를 먼저 0으로 갱신해 행 잠금을 확보한 뒤 `MarkAllReadByRecipient`를 수행한다. `SendDirect`도 같은 행을 먼저 increment하여 잠근 뒤 메시지를 저장하므로, 발송과 읽음 처리가 같은 트랜잭션 경계에서 직렬화된다.
+- `SendDirect`에 `IncrementUnreadCount` 호출을 추가한다(수신자 = 발신자 반대 역할).
+
+### Infrastructure Layer
+- postgres 어댑터: `db/schema.sql`에 `messages.read_at`, `tracks.unread_by_admin_count`, `tracks.unread_by_track_count` 컬럼 추가 마이그레이션, `db/query.sql`에 신규 쿼리 작성 후 sqlc 재생성.
+- web 어댑터: 쿼리 파라미터 파싱(`background` bool, `after` RFC3339) 및 401/403 처리.
+
+## 5. 구현 단계
+
+### Phase A: 스키마 (예상 소요: 30분)
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| A-1 | `messages.read_at TIMESTAMPTZ` 컬럼 추가 | `backend/db/schema.sql` |
+| A-2 | `tracks.unread_by_admin_count INT DEFAULT 0`, `tracks.unread_by_track_count INT DEFAULT 0` 컬럼 추가 | `backend/db/schema.sql` |
+| A-3 | `SaveMessage`에 `read_at` 반영, `ListMessagesByTrack`에 `after` 조건 및 `read_at` 기반 unread 쿼리 추가, `UpdateTrackUnreadCount`(increment/reset) 쿼리 작성 | `backend/db/query.sql` |
+| A-4 | `sqlc generate` 실행하여 `internal/infrastructure/postgres/db/*` 재생성 | (생성물) |
+
+### Phase B: 도메인/포트 (예상 소요: 20분)
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| B-1 | `Track`에 `UnreadByAdminCount`/`UnreadByTrackCount` 필드 추가 | `internal/domain/track.go` |
+| B-2 | `MessageRepository`, `TrackRepository` 포트 메서드 추가 | `internal/usecase/port.go` |
+| B-3 | postgres 어댑터 구현 (`mapMessage`에 `ReadAt` 매핑, 신규 메서드 구현) | `internal/infrastructure/postgres/message_repo.go`, `track_repo.go` |
+
+### Phase C: Usecase (예상 소요: 30분)
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| C-1 | `SendDirect`에 `IncrementUnreadCount` 호출 추가 | `internal/usecase/message.go` |
+| C-2 | `ListDirectMessages` 시그니처 확장 (`viewerRole`, `after`, `markRead`) 및 트랜잭션 처리 | `internal/usecase/message.go` |
+| C-3 | `GetUnreadCount` 구현 | `internal/usecase/message.go` |
+
+### Phase D: Handler/Router (예상 소요: 30분)
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| D-1 | 쿼리 파라미터 파싱, `viewerRole` 판별 재사용, `GetUnreadCount` handler | `internal/infrastructure/web/message_handler.go` |
+| D-2 | `track` 그룹에 GET 라우트 2개 추가, 트랙 스코프 검증 확인 | `internal/infrastructure/web/router.go` |
+| D-3 | swaggo 주석 추가 및 `swag init` 재생성 | `api/*` |
+
+## 6. 검증 체크리스트
+
+### 6.1 아키텍처 검증
+- [x] `domain` 패키지에 `infrastructure` import 없음
+- [x] 카운터 증감이 원자적 SQL `UPDATE`로만 이뤄짐 (트랙 행 잠금 순서로 발송/읽음 경합 직렬화)
+- [x] `GetUnreadCount`가 O(1) 컬럼 조회이며 `messages` 전체를 로딩하지 않음
+
+### 6.2 유즈케이스 검증
+- [x] UC-1: `after` 파라미터 미지정 시 전체 스레드 반환 (기존 동작 유지)
+- [x] UC-1: `after` 지정 시 해당 시각 이후 메시지만 반환
+- [x] UC-1: `background=true`일 때 반대편이 보낸 미확인 메시지만 `read_at` 설정, 이미 읽은 메시지는 재갱신 안 함(`MarkRead`의 idempotent 규칙 유지)
+- [x] UC-1: `background=false`(또는 미지정)일 때 읽음 상태 변화 없음
+- [x] UC-2: 관리자가 조회 시 TRACK 발신 미확인 개수, 진행자가 조회 시 ADMIN 발신 미확인 개수 반환
+- [x] UC-2: 읽음 처리 직후 같은 트랙의 unread-count가 0으로 즉시 반영
+- [x] UC-3: 진행자 세션으로 다른 트랙의 메시지 조회 시 403(`ErrTrackScopeForbidden`)
+
+### 6.3 자동화 테스트
+- [x] 동시성 테스트: 트랙 행 잠금 획득 순서(`increment → save`, `reset → mark-read`)를 검증하고 `go test -race ./internal/usecase ./internal/infrastructure/web`를 통과했다.
+- [x] repository/query 경계 테스트: `after`와 정확히 일치하는 `sent_at`은 제외하고 이후 메시지만 반환하는 계약을 검증했다.
+- [x] handler 레벨 테스트: `background` 미지정 시 기본값(false)이 안전한 방향(읽음 처리 안 함)인지 확인했다.
+
+## 7. 완료 기록 (2026-07-15)
+
+- 진행자 세션의 `TrackID`와 path `trackId` 불일치를 모든 DIRECT 메시지 읽기·미확인 수·발신 경로에서 403으로 차단했다.
+- 카운터를 0으로 갱신하는 읽음 처리와 증가시키는 발송 처리는 동일한 `tracks` 행을 먼저 갱신해 직렬화한다.
+- OpenAPI를 재생성해 두 GET endpoint가 `AdminAuth` 또는 `TrackAuth`를 허용하고 `background`, `after`, 403 계약을 명시한다.
+- 검증 명령: `go test ./...`, `go test -race ./internal/usecase ./internal/infrastructure/web`.

--- a/backend/internal/domain/track.go
+++ b/backend/internal/domain/track.go
@@ -19,14 +19,16 @@ const (
 )
 
 type Track struct {
-	ID             TrackID
-	CornerID       CornerID
-	TrackNo        int
-	Status         TrackStatus
-	PINHash        string
-	PINCiphertext  string
-	CurrentVisitID Optional[VisitID]
-	DeletedAt      Optional[time.Time]
+	ID                 TrackID
+	CornerID           CornerID
+	TrackNo            int
+	Status             TrackStatus
+	PINHash            string
+	PINCiphertext      string
+	CurrentVisitID     Optional[VisitID]
+	DeletedAt          Optional[time.Time]
+	UnreadByAdminCount int
+	UnreadByTrackCount int
 }
 
 // StartVisit은 트랙에 방문(Visit)이 시작되었음을 기록합니다.

--- a/backend/internal/infrastructure/postgres/db/models.go
+++ b/backend/internal/infrastructure/postgres/db/models.go
@@ -181,6 +181,7 @@ type Message struct {
 	Content string `json:"content"`
 	// 발송 시간
 	SentAt pgtype.Timestamptz `json:"sent_at"`
+	ReadAt pgtype.Timestamptz `json:"read_at"`
 }
 
 // 코너 내에서 병렬로 진행 가능한 세부 트랙(기기/테이블)을 정의하는 테이블
@@ -200,7 +201,9 @@ type Track struct {
 	// 현재 진행 중인 방문(Visit)의 식별자
 	CurrentVisitID pgtype.Text `json:"current_visit_id"`
 	// 논리적 삭제 시간
-	DeletedAt pgtype.Timestamptz `json:"deleted_at"`
+	DeletedAt          pgtype.Timestamptz `json:"deleted_at"`
+	UnreadByAdminCount int32              `json:"unread_by_admin_count"`
+	UnreadByTrackCount int32              `json:"unread_by_track_count"`
 }
 
 // 조가 코너(트랙)를 방문하여 진행한 이력을 저장하는 테이블

--- a/backend/internal/infrastructure/postgres/db/querier.go
+++ b/backend/internal/infrastructure/postgres/db/querier.go
@@ -30,6 +30,7 @@ type Querier interface {
 	GetInProgressVisitByTrack(ctx context.Context, trackID string) (Visit, error)
 	GetTrack(ctx context.Context, id string) (Track, error)
 	GetVisit(ctx context.Context, id string) (Visit, error)
+	IncrementTrackUnreadCount(ctx context.Context, arg IncrementTrackUnreadCountParams) error
 	ListActiveFacilitatorSessionsByCamp(ctx context.Context, campID string) ([]FacilitatorSession, error)
 	ListActiveFacilitatorSessionsByTrack(ctx context.Context, trackID string) ([]FacilitatorSession, error)
 	ListActiveTracksByCamp(ctx context.Context, campID string) ([]Track, error)
@@ -43,11 +44,14 @@ type Querier interface {
 	ListDeviceRegistrationsByCampAndStatus(ctx context.Context, arg ListDeviceRegistrationsByCampAndStatusParams) ([]DeviceRegistration, error)
 	ListGroupsByCamp(ctx context.Context, campID string) ([]Group, error)
 	ListMessagesByTrack(ctx context.Context, trackID string) ([]Message, error)
+	ListMessagesByTrackAfter(ctx context.Context, arg ListMessagesByTrackAfterParams) ([]Message, error)
 	ListPendingDeviceRegistrationsByCamp(ctx context.Context, campID string) ([]DeviceRegistration, error)
 	ListTracksByCamp(ctx context.Context, campID string) ([]Track, error)
 	ListTracksByCorner(ctx context.Context, cornerID string) ([]Track, error)
 	ListVisitsByCamp(ctx context.Context, campID string) ([]ListVisitsByCampRow, error)
 	ListVisitsByGroup(ctx context.Context, groupID string) ([]Visit, error)
+	MarkAllMessagesReadByRecipient(ctx context.Context, arg MarkAllMessagesReadByRecipientParams) error
+	ResetTrackUnreadCount(ctx context.Context, arg ResetTrackUnreadCountParams) error
 	SaveAdminSession(ctx context.Context, arg SaveAdminSessionParams) error
 	SaveAnnouncement(ctx context.Context, arg SaveAnnouncementParams) error
 	SaveAnnouncementReceipt(ctx context.Context, arg SaveAnnouncementReceiptParams) error

--- a/backend/internal/infrastructure/postgres/db/query.sql.go
+++ b/backend/internal/infrastructure/postgres/db/query.sql.go
@@ -349,7 +349,7 @@ func (q *Queries) GetInProgressVisitByTrack(ctx context.Context, trackID string)
 }
 
 const getTrack = `-- name: GetTrack :one
-SELECT id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at FROM tracks WHERE id = $1
+SELECT id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at, unread_by_admin_count, unread_by_track_count FROM tracks WHERE id = $1
 `
 
 func (q *Queries) GetTrack(ctx context.Context, id string) (Track, error) {
@@ -364,6 +364,8 @@ func (q *Queries) GetTrack(ctx context.Context, id string) (Track, error) {
 		&i.PinCiphertext,
 		&i.CurrentVisitID,
 		&i.DeletedAt,
+		&i.UnreadByAdminCount,
+		&i.UnreadByTrackCount,
 	)
 	return i, err
 }
@@ -386,6 +388,23 @@ func (q *Queries) GetVisit(ctx context.Context, id string) (Visit, error) {
 		&i.EndedAt,
 	)
 	return i, err
+}
+
+const incrementTrackUnreadCount = `-- name: IncrementTrackUnreadCount :exec
+UPDATE tracks
+SET unread_by_admin_count = unread_by_admin_count + CASE WHEN $1::VARCHAR = 'ADMIN' THEN 1 ELSE 0 END,
+    unread_by_track_count = unread_by_track_count + CASE WHEN $1::VARCHAR = 'TRACK' THEN 1 ELSE 0 END
+WHERE id = $2
+`
+
+type IncrementTrackUnreadCountParams struct {
+	Recipient string `json:"recipient"`
+	TrackID   string `json:"track_id"`
+}
+
+func (q *Queries) IncrementTrackUnreadCount(ctx context.Context, arg IncrementTrackUnreadCountParams) error {
+	_, err := q.db.Exec(ctx, incrementTrackUnreadCount, arg.Recipient, arg.TrackID)
+	return err
 }
 
 const listActiveFacilitatorSessionsByCamp = `-- name: ListActiveFacilitatorSessionsByCamp :many
@@ -452,7 +471,7 @@ func (q *Queries) ListActiveFacilitatorSessionsByTrack(ctx context.Context, trac
 }
 
 const listActiveTracksByCamp = `-- name: ListActiveTracksByCamp :many
-SELECT t.id, t.corner_id, t.track_no, t.status, t.pin_hash, t.pin_ciphertext, t.current_visit_id, t.deleted_at FROM tracks t
+SELECT t.id, t.corner_id, t.track_no, t.status, t.pin_hash, t.pin_ciphertext, t.current_visit_id, t.deleted_at, t.unread_by_admin_count, t.unread_by_track_count FROM tracks t
 JOIN corners c ON t.corner_id = c.id
 WHERE c.camp_id = $1 AND t.status = 'ACTIVE'
 `
@@ -475,6 +494,8 @@ func (q *Queries) ListActiveTracksByCamp(ctx context.Context, campID string) ([]
 			&i.PinCiphertext,
 			&i.CurrentVisitID,
 			&i.DeletedAt,
+			&i.UnreadByAdminCount,
+			&i.UnreadByTrackCount,
 		); err != nil {
 			return nil, err
 		}
@@ -795,7 +816,7 @@ func (q *Queries) ListGroupsByCamp(ctx context.Context, campID string) ([]Group,
 }
 
 const listMessagesByTrack = `-- name: ListMessagesByTrack :many
-SELECT id, track_id, sender_role, content, sent_at FROM messages WHERE track_id = $1 ORDER BY sent_at
+SELECT id, track_id, sender_role, content, sent_at, read_at FROM messages WHERE track_id = $1 ORDER BY sent_at
 `
 
 func (q *Queries) ListMessagesByTrack(ctx context.Context, trackID string) ([]Message, error) {
@@ -813,6 +834,46 @@ func (q *Queries) ListMessagesByTrack(ctx context.Context, trackID string) ([]Me
 			&i.SenderRole,
 			&i.Content,
 			&i.SentAt,
+			&i.ReadAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listMessagesByTrackAfter = `-- name: ListMessagesByTrackAfter :many
+SELECT id, track_id, sender_role, content, sent_at, read_at FROM messages
+WHERE track_id = $1
+  AND ($2::TIMESTAMPTZ IS NULL OR sent_at > $2::TIMESTAMPTZ)
+ORDER BY sent_at
+`
+
+type ListMessagesByTrackAfterParams struct {
+	TrackID string             `json:"track_id"`
+	After   pgtype.Timestamptz `json:"after"`
+}
+
+func (q *Queries) ListMessagesByTrackAfter(ctx context.Context, arg ListMessagesByTrackAfterParams) ([]Message, error) {
+	rows, err := q.db.Query(ctx, listMessagesByTrackAfter, arg.TrackID, arg.After)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Message
+	for rows.Next() {
+		var i Message
+		if err := rows.Scan(
+			&i.ID,
+			&i.TrackID,
+			&i.SenderRole,
+			&i.Content,
+			&i.SentAt,
+			&i.ReadAt,
 		); err != nil {
 			return nil, err
 		}
@@ -858,7 +919,7 @@ func (q *Queries) ListPendingDeviceRegistrationsByCamp(ctx context.Context, camp
 }
 
 const listTracksByCamp = `-- name: ListTracksByCamp :many
-SELECT t.id, t.corner_id, t.track_no, t.status, t.pin_hash, t.pin_ciphertext, t.current_visit_id, t.deleted_at FROM tracks t
+SELECT t.id, t.corner_id, t.track_no, t.status, t.pin_hash, t.pin_ciphertext, t.current_visit_id, t.deleted_at, t.unread_by_admin_count, t.unread_by_track_count FROM tracks t
 JOIN corners c ON t.corner_id = c.id
 WHERE c.camp_id = $1
 `
@@ -881,6 +942,8 @@ func (q *Queries) ListTracksByCamp(ctx context.Context, campID string) ([]Track,
 			&i.PinCiphertext,
 			&i.CurrentVisitID,
 			&i.DeletedAt,
+			&i.UnreadByAdminCount,
+			&i.UnreadByTrackCount,
 		); err != nil {
 			return nil, err
 		}
@@ -893,7 +956,7 @@ func (q *Queries) ListTracksByCamp(ctx context.Context, campID string) ([]Track,
 }
 
 const listTracksByCorner = `-- name: ListTracksByCorner :many
-SELECT id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at FROM tracks WHERE corner_id = $1
+SELECT id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at, unread_by_admin_count, unread_by_track_count FROM tracks WHERE corner_id = $1
 `
 
 func (q *Queries) ListTracksByCorner(ctx context.Context, cornerID string) ([]Track, error) {
@@ -914,6 +977,8 @@ func (q *Queries) ListTracksByCorner(ctx context.Context, cornerID string) ([]Tr
 			&i.PinCiphertext,
 			&i.CurrentVisitID,
 			&i.DeletedAt,
+			&i.UnreadByAdminCount,
+			&i.UnreadByTrackCount,
 		); err != nil {
 			return nil, err
 		}
@@ -1007,6 +1072,42 @@ func (q *Queries) ListVisitsByGroup(ctx context.Context, groupID string) ([]Visi
 		return nil, err
 	}
 	return items, nil
+}
+
+const markAllMessagesReadByRecipient = `-- name: MarkAllMessagesReadByRecipient :exec
+UPDATE messages
+SET read_at = COALESCE(read_at, $1::TIMESTAMPTZ)
+WHERE track_id = $2
+  AND sender_role <> $3::VARCHAR
+  AND read_at IS NULL
+`
+
+type MarkAllMessagesReadByRecipientParams struct {
+	ReadAt    pgtype.Timestamptz `json:"read_at"`
+	TrackID   string             `json:"track_id"`
+	Recipient string             `json:"recipient"`
+}
+
+func (q *Queries) MarkAllMessagesReadByRecipient(ctx context.Context, arg MarkAllMessagesReadByRecipientParams) error {
+	_, err := q.db.Exec(ctx, markAllMessagesReadByRecipient, arg.ReadAt, arg.TrackID, arg.Recipient)
+	return err
+}
+
+const resetTrackUnreadCount = `-- name: ResetTrackUnreadCount :exec
+UPDATE tracks
+SET unread_by_admin_count = CASE WHEN $1::VARCHAR = 'ADMIN' THEN 0 ELSE unread_by_admin_count END,
+    unread_by_track_count = CASE WHEN $1::VARCHAR = 'TRACK' THEN 0 ELSE unread_by_track_count END
+WHERE id = $2
+`
+
+type ResetTrackUnreadCountParams struct {
+	Reader  string `json:"reader"`
+	TrackID string `json:"track_id"`
+}
+
+func (q *Queries) ResetTrackUnreadCount(ctx context.Context, arg ResetTrackUnreadCountParams) error {
+	_, err := q.db.Exec(ctx, resetTrackUnreadCount, arg.Reader, arg.TrackID)
+	return err
 }
 
 const saveAdminSession = `-- name: SaveAdminSession :exec
@@ -1298,8 +1399,8 @@ func (q *Queries) SaveGroup(ctx context.Context, arg SaveGroupParams) error {
 }
 
 const saveMessage = `-- name: SaveMessage :exec
-INSERT INTO messages (id, track_id, sender_role, content, sent_at)
-VALUES ($1, $2, $3, $4, $5)
+INSERT INTO messages (id, track_id, sender_role, content, sent_at, read_at)
+VALUES ($1, $2, $3, $4, $5, $6)
 `
 
 type SaveMessageParams struct {
@@ -1308,6 +1409,7 @@ type SaveMessageParams struct {
 	SenderRole string             `json:"sender_role"`
 	Content    string             `json:"content"`
 	SentAt     pgtype.Timestamptz `json:"sent_at"`
+	ReadAt     pgtype.Timestamptz `json:"read_at"`
 }
 
 func (q *Queries) SaveMessage(ctx context.Context, arg SaveMessageParams) error {
@@ -1317,30 +1419,35 @@ func (q *Queries) SaveMessage(ctx context.Context, arg SaveMessageParams) error 
 		arg.SenderRole,
 		arg.Content,
 		arg.SentAt,
+		arg.ReadAt,
 	)
 	return err
 }
 
 const saveTrack = `-- name: SaveTrack :exec
-INSERT INTO tracks (id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO tracks (id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at, unread_by_admin_count, unread_by_track_count)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 ON CONFLICT (id) DO UPDATE SET
     status = EXCLUDED.status,
     pin_hash = EXCLUDED.pin_hash,
     pin_ciphertext = EXCLUDED.pin_ciphertext,
     current_visit_id = EXCLUDED.current_visit_id,
-    deleted_at = EXCLUDED.deleted_at
+    deleted_at = EXCLUDED.deleted_at,
+    unread_by_admin_count = EXCLUDED.unread_by_admin_count,
+    unread_by_track_count = EXCLUDED.unread_by_track_count
 `
 
 type SaveTrackParams struct {
-	ID             string             `json:"id"`
-	CornerID       string             `json:"corner_id"`
-	TrackNo        int32              `json:"track_no"`
-	Status         string             `json:"status"`
-	PinHash        string             `json:"pin_hash"`
-	PinCiphertext  pgtype.Text        `json:"pin_ciphertext"`
-	CurrentVisitID pgtype.Text        `json:"current_visit_id"`
-	DeletedAt      pgtype.Timestamptz `json:"deleted_at"`
+	ID                 string             `json:"id"`
+	CornerID           string             `json:"corner_id"`
+	TrackNo            int32              `json:"track_no"`
+	Status             string             `json:"status"`
+	PinHash            string             `json:"pin_hash"`
+	PinCiphertext      pgtype.Text        `json:"pin_ciphertext"`
+	CurrentVisitID     pgtype.Text        `json:"current_visit_id"`
+	DeletedAt          pgtype.Timestamptz `json:"deleted_at"`
+	UnreadByAdminCount int32              `json:"unread_by_admin_count"`
+	UnreadByTrackCount int32              `json:"unread_by_track_count"`
 }
 
 func (q *Queries) SaveTrack(ctx context.Context, arg SaveTrackParams) error {
@@ -1353,6 +1460,8 @@ func (q *Queries) SaveTrack(ctx context.Context, arg SaveTrackParams) error {
 		arg.PinCiphertext,
 		arg.CurrentVisitID,
 		arg.DeletedAt,
+		arg.UnreadByAdminCount,
+		arg.UnreadByTrackCount,
 	)
 	return err
 }

--- a/backend/internal/infrastructure/postgres/message_repo.go
+++ b/backend/internal/infrastructure/postgres/message_repo.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"cornermon/backend/internal/domain"
 	"cornermon/backend/internal/errs"
@@ -34,6 +35,11 @@ func mapMessage(row db.Message) *domain.Message {
 		Content:     row.Content,
 		SentAt:      row.SentAt.Time,
 	}
+	if row.ReadAt.Valid {
+		m.ReadAt = domain.Some(row.ReadAt.Time)
+	} else {
+		m.ReadAt = domain.None[time.Time]()
+	}
 
 	return m
 }
@@ -46,12 +52,36 @@ func (r *pgMessageRepository) Save(ctx context.Context, msg *domain.Message) err
 		Content:    msg.Content,
 		SentAt:     pgtype.Timestamptz{Time: msg.SentAt, Valid: !msg.SentAt.IsZero()},
 	}
+	if readAt, ok := msg.ReadAt.Value(); ok {
+		params.ReadAt = pgtype.Timestamptz{Time: readAt, Valid: true}
+	}
 
 	err := r.queries(ctx).SaveMessage(ctx, params)
 	if err != nil {
 		return errs.Wrap(ctx, err)
 	}
 	return nil
+}
+
+func (r *pgMessageRepository) ListMessageByTrackAfter(ctx context.Context, trackID domain.TrackID, after domain.Optional[time.Time]) ([]*domain.Message, error) {
+	params := db.ListMessagesByTrackAfterParams{TrackID: string(trackID)}
+	if value, ok := after.Value(); ok {
+		params.After = pgtype.Timestamptz{Time: value, Valid: true}
+	}
+	rows, err := r.queries(ctx).ListMessagesByTrackAfter(ctx, params)
+	if err != nil {
+		return nil, errs.Wrap(ctx, err)
+	}
+	messages := make([]*domain.Message, len(rows))
+	for i, row := range rows {
+		messages[i] = mapMessage(row)
+	}
+	return messages, nil
+}
+
+func (r *pgMessageRepository) MarkAllReadByRecipient(ctx context.Context, trackID domain.TrackID, recipient domain.SenderRole, readAt time.Time) error {
+	params := db.MarkAllMessagesReadByRecipientParams{TrackID: string(trackID), Recipient: string(recipient), ReadAt: pgtype.Timestamptz{Time: readAt, Valid: true}}
+	return errs.Wrap(ctx, r.queries(ctx).MarkAllMessagesReadByRecipient(ctx, params))
 }
 
 func (r *pgMessageRepository) ListMessageByTrack(ctx context.Context, trackID domain.TrackID) ([]*domain.Message, error) {

--- a/backend/internal/infrastructure/postgres/track_repo.go
+++ b/backend/internal/infrastructure/postgres/track_repo.go
@@ -29,12 +29,14 @@ func (r *pgTrackRepository) queries(ctx context.Context) *db.Queries {
 
 func mapTrack(row db.Track) *domain.Track {
 	t := &domain.Track{
-		ID:            domain.TrackID(row.ID),
-		CornerID:      domain.CornerID(row.CornerID),
-		TrackNo:       int(row.TrackNo),
-		Status:        domain.TrackStatus(row.Status),
-		PINHash:       row.PinHash,
-		PINCiphertext: row.PinCiphertext.String,
+		ID:                 domain.TrackID(row.ID),
+		CornerID:           domain.CornerID(row.CornerID),
+		TrackNo:            int(row.TrackNo),
+		Status:             domain.TrackStatus(row.Status),
+		PINHash:            row.PinHash,
+		PINCiphertext:      row.PinCiphertext.String,
+		UnreadByAdminCount: int(row.UnreadByAdminCount),
+		UnreadByTrackCount: int(row.UnreadByTrackCount),
 	}
 
 	if row.CurrentVisitID.Valid {
@@ -106,12 +108,24 @@ func (r *pgTrackRepository) Save(ctx context.Context, track *domain.Track) error
 	if val, ok := track.DeletedAt.Value(); ok {
 		params.DeletedAt = pgtype.Timestamptz{Time: val, Valid: true}
 	}
+	params.UnreadByAdminCount = int32(track.UnreadByAdminCount)
+	params.UnreadByTrackCount = int32(track.UnreadByTrackCount)
 
 	err := r.queries(ctx).SaveTrack(ctx, params)
 	if err != nil {
 		return errs.Wrap(ctx, err)
 	}
 	return nil
+}
+
+func (r *pgTrackRepository) IncrementUnreadCount(ctx context.Context, trackID domain.TrackID, recipient domain.SenderRole) error {
+	err := r.queries(ctx).IncrementTrackUnreadCount(ctx, db.IncrementTrackUnreadCountParams{TrackID: string(trackID), Recipient: string(recipient)})
+	return errs.Wrap(ctx, err)
+}
+
+func (r *pgTrackRepository) ResetUnreadCount(ctx context.Context, trackID domain.TrackID, reader domain.SenderRole) error {
+	err := r.queries(ctx).ResetTrackUnreadCount(ctx, db.ResetTrackUnreadCountParams{TrackID: string(trackID), Reader: string(reader)})
+	return errs.Wrap(ctx, err)
 }
 
 func (r *pgTrackRepository) ListByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Track, error) {

--- a/backend/internal/infrastructure/web/auth_middleware.go
+++ b/backend/internal/infrastructure/web/auth_middleware.go
@@ -56,6 +56,32 @@ func TrackAuthMiddleware(trackAuth AuthFacilitatorUsecase) echo.MiddlewareFunc {
 	}
 }
 
+// MessageAuthMiddleware accepts either an administrator or facilitator session
+// for the shared direct-message GET routes. Echo has one handler slot per
+// method/path, so these routes cannot be registered separately under the two
+// auth groups.
+func MessageAuthMiddleware(adminAuth AuthAdminUsecase, trackAuth AuthFacilitatorUsecase) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			token := extractToken(c.Request().Header.Get("Authorization"))
+			if token == "" {
+				return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "missing token"})
+			}
+
+			if session, err := adminAuth.ValidateAccessToken(c.Request().Context(), token); err == nil && session != nil {
+				c.Set("adminSession", session)
+				return next(c)
+			}
+			if session, err := trackAuth.ValidateSession(c.Request().Context(), token); err == nil && session != nil {
+				c.Set("facilitatorSession", session)
+				return next(c)
+			}
+
+			return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "invalid token"})
+		}
+	}
+}
+
 func extractToken(authHeader string) string {
 	if strings.HasPrefix(authHeader, "Bearer ") {
 		return strings.TrimPrefix(authHeader, "Bearer ")

--- a/backend/internal/infrastructure/web/group_handler_test.go
+++ b/backend/internal/infrastructure/web/group_handler_test.go
@@ -26,6 +26,12 @@ func (trackRepoForGroupHandler) ListByCamp(context.Context, domain.CampID) ([]*d
 	return nil, nil
 }
 func (trackRepoForGroupHandler) Save(context.Context, *domain.Track) error { return nil }
+func (trackRepoForGroupHandler) IncrementUnreadCount(context.Context, domain.TrackID, domain.SenderRole) error {
+	return nil
+}
+func (trackRepoForGroupHandler) ResetUnreadCount(context.Context, domain.TrackID, domain.SenderRole) error {
+	return nil
+}
 
 type cornerRepoForGroupHandler struct{ corner *domain.Corner }
 

--- a/backend/internal/infrastructure/web/message_handler.go
+++ b/backend/internal/infrastructure/web/message_handler.go
@@ -212,6 +212,9 @@ func (h *MessageHandler) SendDirect(c echo.Context) error {
 	if c.Get("adminSession") != nil {
 		senderRole = domain.RoleAdmin
 	} else if c.Get("facilitatorSession") != nil {
+		if err := requireFacilitatorTrackScope(c, trackID); err != nil {
+			return err
+		}
 		senderRole = domain.RoleTrack
 	} else {
 		return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "unauthorized"})
@@ -239,15 +242,16 @@ func (h *MessageHandler) SendDirect(c echo.Context) error {
 }
 
 // @Summary      트랙별 메시지 내역 조회
-// @Description  관리자가 해당 트랙과 관련된 DIRECT 메시지 내역을 조회한다. background/after 파라미터는
-// @Description  계약상 정의되어 있으나 아직 동작하지 않는다(GitHub Issue #69, 구현 예정).
+// @Description  관리자 또는 자신의 트랙 진행자가 DIRECT 메시지 내역을 조회한다.
 // @Tags         E. Message
 // @Security     AdminAuth
+// @Security     TrackAuth
 // @Produce      json
 // @Param        trackId path string true "트랙 ID"
-// @Param        background query bool false "true면 상대측이 보낸 미확인 메시지를 읽음 처리 (구현 예정)"
-// @Param        after query string false "RFC3339 UTC 이후 메시지만 반환 (구현 예정)"
+// @Param        background query bool false "true면 상대측이 보낸 미확인 메시지를 읽음 처리"
+// @Param        after query string false "RFC3339 UTC 이후 메시지만 반환"
 // @Success      200 {array} MessageResponse
+// @Failure      403 {object} ErrorResponse "세션 트랙과 요청 트랙 불일치"
 // @Router       /tracks/{trackId}/messages [get]
 func (h *MessageHandler) ListDirectMessages(c echo.Context) error {
 	background, err := parseBackground(c.QueryParam("background"))
@@ -267,18 +271,11 @@ func (h *MessageHandler) ListDirectMessages(c echo.Context) error {
 	return c.JSON(http.StatusOK, mapMessages(msgs))
 }
 
-// @Summary      트랙별 메시지 내역 조회 (진행자)
-// @Description  트랙 진행자가 자신의 트랙과 관련된 DIRECT 메시지 내역을 조회한다(GitHub Issue #69, 구현 예정).
-// @Tags         E. Message
-// @Security     TrackAuth
-// @Produce      json
-// @Param        trackId path string true "트랙 ID"
-// @Param        background query bool false "true면 상대측이 보낸 미확인 메시지를 읽음 처리"
-// @Param        after query string false "RFC3339 UTC 이후 메시지만 반환"
-// @Success      200 {array} MessageResponse
-// @Failure      501 {object} ErrorResponse "구현 예정 (GitHub Issue #69)"
-// @Router       /tracks/{trackId}/messages [get]
 func (h *MessageHandler) ListDirectMessagesForTrack(c echo.Context) error {
+	trackID := domain.TrackID(c.Param("trackId"))
+	if err := requireFacilitatorTrackScope(c, trackID); err != nil {
+		return err
+	}
 	background, err := parseBackground(c.QueryParam("background"))
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: err.Error()})
@@ -287,7 +284,7 @@ func (h *MessageHandler) ListDirectMessagesForTrack(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "after must be RFC3339"})
 	}
-	msgs, err := h.message.ListDirectMessages(c.Request().Context(), domain.TrackID(c.Param("trackId")), domain.RoleTrack, after, background)
+	msgs, err := h.message.ListDirectMessages(c.Request().Context(), trackID, domain.RoleTrack, after, background)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
 	}
@@ -299,23 +296,40 @@ type UnreadCountResponse struct {
 } // @name UnreadCountResponse
 
 // @Summary      트랙 미확인 다이렉트 메시지 개수 조회
-// @Description  호출자(관리자 또는 진행자) 기준으로 상대측이 보낸 미확인 메시지 개수를 반환한다(GitHub Issue #69, 구현 예정).
+// @Description  호출자(관리자 또는 진행자) 기준으로 상대측이 보낸 미확인 메시지 개수를 반환한다.
 // @Tags         E. Message
+// @Security     AdminAuth
+// @Security     TrackAuth
 // @Produce      json
 // @Param        trackId path string true "트랙 ID"
 // @Success      200 {object} UnreadCountResponse
-// @Failure      501 {object} ErrorResponse "구현 예정 (GitHub Issue #69)"
+// @Failure      403 {object} ErrorResponse "세션 트랙과 요청 트랙 불일치"
 // @Router       /tracks/{trackId}/messages/unread-count [get]
 func (h *MessageHandler) GetUnreadCount(c echo.Context) error {
+	trackID := domain.TrackID(c.Param("trackId"))
 	role := domain.RoleAdmin
 	if _, ok := c.Get("facilitatorSession").(*domain.FacilitatorSession); ok {
+		if err := requireFacilitatorTrackScope(c, trackID); err != nil {
+			return err
+		}
 		role = domain.RoleTrack
 	}
-	count, err := h.message.GetUnreadCount(c.Request().Context(), domain.TrackID(c.Param("trackId")), role)
+	count, err := h.message.GetUnreadCount(c.Request().Context(), trackID, role)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
 	}
 	return c.JSON(http.StatusOK, UnreadCountResponse{UnreadCount: count})
+}
+
+func requireFacilitatorTrackScope(c echo.Context, trackID domain.TrackID) error {
+	session, ok := c.Get("facilitatorSession").(*domain.FacilitatorSession)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+	}
+	if session.TrackID != trackID {
+		return domain.ErrTrackScopeForbidden
+	}
+	return nil
 }
 
 func parseBackground(value string) (bool, error) {

--- a/backend/internal/infrastructure/web/message_handler.go
+++ b/backend/internal/infrastructure/web/message_handler.go
@@ -2,7 +2,9 @@ package web
 
 import (
 	"context"
+	"errors"
 	"net/http"
+	"strconv"
 	"time"
 
 	"cornermon/backend/internal/domain"
@@ -13,7 +15,8 @@ import (
 
 type MessageUsecase interface {
 	SendDirect(ctx context.Context, trackID domain.TrackID, content string, senderRole domain.SenderRole) (*domain.Message, error)
-	ListDirectMessages(ctx context.Context, trackID domain.TrackID) ([]*domain.Message, error)
+	ListDirectMessages(ctx context.Context, trackID domain.TrackID, viewerRole domain.SenderRole, after domain.Optional[time.Time], markRead bool) ([]*domain.Message, error)
+	GetUnreadCount(ctx context.Context, trackID domain.TrackID, viewerRole domain.SenderRole) (int, error)
 }
 
 type AnnouncementUsecase interface {
@@ -247,31 +250,21 @@ func (h *MessageHandler) SendDirect(c echo.Context) error {
 // @Success      200 {array} MessageResponse
 // @Router       /tracks/{trackId}/messages [get]
 func (h *MessageHandler) ListDirectMessages(c echo.Context) error {
+	background, err := parseBackground(c.QueryParam("background"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: err.Error()})
+	}
+	after, err := parseAfter(c.QueryParam("after"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "after must be RFC3339"})
+	}
 	trackID := domain.TrackID(c.Param("trackId"))
-
-	msgs, err := h.message.ListDirectMessages(c.Request().Context(), trackID)
+	msgs, err := h.message.ListDirectMessages(c.Request().Context(), trackID, domain.RoleAdmin, after, background)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
 	}
 
-	res := make([]MessageResponse, len(msgs))
-	for i, msg := range msgs {
-		var tID *string
-		if msg.TrackID != "" {
-			valStr := string(msg.TrackID)
-			tID = &valStr
-		}
-		res[i] = MessageResponse{
-			ID:          string(msg.ID),
-			ChannelType: string(msg.ChannelType),
-			TrackID:     tID,
-			SenderRole:  string(msg.SenderRole),
-			Content:     msg.Content,
-			SentAt:      msg.SentAt,
-		}
-	}
-
-	return c.JSON(http.StatusOK, res)
+	return c.JSON(http.StatusOK, mapMessages(msgs))
 }
 
 // @Summary      트랙별 메시지 내역 조회 (진행자)
@@ -286,7 +279,19 @@ func (h *MessageHandler) ListDirectMessages(c echo.Context) error {
 // @Failure      501 {object} ErrorResponse "구현 예정 (GitHub Issue #69)"
 // @Router       /tracks/{trackId}/messages [get]
 func (h *MessageHandler) ListDirectMessagesForTrack(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, ErrorResponse{Code: "NOT_IMPLEMENTED", Message: "진행자용 메시지 조회는 아직 구현되지 않았습니다"})
+	background, err := parseBackground(c.QueryParam("background"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: err.Error()})
+	}
+	after, err := parseAfter(c.QueryParam("after"))
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "after must be RFC3339"})
+	}
+	msgs, err := h.message.ListDirectMessages(c.Request().Context(), domain.TrackID(c.Param("trackId")), domain.RoleTrack, after, background)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
+	}
+	return c.JSON(http.StatusOK, mapMessages(msgs))
 }
 
 type UnreadCountResponse struct {
@@ -302,5 +307,51 @@ type UnreadCountResponse struct {
 // @Failure      501 {object} ErrorResponse "구현 예정 (GitHub Issue #69)"
 // @Router       /tracks/{trackId}/messages/unread-count [get]
 func (h *MessageHandler) GetUnreadCount(c echo.Context) error {
-	return c.JSON(http.StatusNotImplemented, ErrorResponse{Code: "NOT_IMPLEMENTED", Message: "미확인 메시지 개수 조회는 아직 구현되지 않았습니다"})
+	role := domain.RoleAdmin
+	if _, ok := c.Get("facilitatorSession").(*domain.FacilitatorSession); ok {
+		role = domain.RoleTrack
+	}
+	count, err := h.message.GetUnreadCount(c.Request().Context(), domain.TrackID(c.Param("trackId")), role)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
+	}
+	return c.JSON(http.StatusOK, UnreadCountResponse{UnreadCount: count})
+}
+
+func parseBackground(value string) (bool, error) {
+	if value == "" {
+		return false, nil
+	}
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, errors.New("background must be boolean")
+	}
+	return parsed, nil
+}
+
+func parseAfter(value string) (domain.Optional[time.Time], error) {
+	if value == "" {
+		return domain.None[time.Time](), nil
+	}
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return domain.None[time.Time](), err
+	}
+	return domain.Some(t.UTC()), nil
+}
+
+func mapMessages(msgs []*domain.Message) []MessageResponse {
+	res := make([]MessageResponse, len(msgs))
+	for i, msg := range msgs {
+		var trackID *string
+		if msg.TrackID != "" {
+			value := string(msg.TrackID)
+			trackID = &value
+		}
+		res[i] = MessageResponse{ID: string(msg.ID), ChannelType: string(msg.ChannelType), TrackID: trackID, SenderRole: string(msg.SenderRole), Content: msg.Content, SentAt: msg.SentAt, IsRead: msg.ReadAt.IsSet()}
+		if readAt, ok := msg.ReadAt.Value(); ok {
+			res[i].ReadAt = &readAt
+		}
+	}
+	return res
 }

--- a/backend/internal/infrastructure/web/message_handler.go
+++ b/backend/internal/infrastructure/web/message_handler.go
@@ -254,27 +254,13 @@ func (h *MessageHandler) SendDirect(c echo.Context) error {
 // @Failure      403 {object} ErrorResponse "세션 트랙과 요청 트랙 불일치"
 // @Router       /tracks/{trackId}/messages [get]
 func (h *MessageHandler) ListDirectMessages(c echo.Context) error {
-	background, err := parseBackground(c.QueryParam("background"))
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: err.Error()})
-	}
-	after, err := parseAfter(c.QueryParam("after"))
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "after must be RFC3339"})
-	}
 	trackID := domain.TrackID(c.Param("trackId"))
-	msgs, err := h.message.ListDirectMessages(c.Request().Context(), trackID, domain.RoleAdmin, after, background)
-	if err != nil {
-		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
-	}
-
-	return c.JSON(http.StatusOK, mapMessages(msgs))
-}
-
-func (h *MessageHandler) ListDirectMessagesForTrack(c echo.Context) error {
-	trackID := domain.TrackID(c.Param("trackId"))
-	if err := requireFacilitatorTrackScope(c, trackID); err != nil {
-		return err
+	viewerRole := domain.RoleAdmin
+	if _, ok := c.Get("facilitatorSession").(*domain.FacilitatorSession); ok {
+		if err := requireFacilitatorTrackScope(c, trackID); err != nil {
+			return err
+		}
+		viewerRole = domain.RoleTrack
 	}
 	background, err := parseBackground(c.QueryParam("background"))
 	if err != nil {
@@ -284,10 +270,11 @@ func (h *MessageHandler) ListDirectMessagesForTrack(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "after must be RFC3339"})
 	}
-	msgs, err := h.message.ListDirectMessages(c.Request().Context(), trackID, domain.RoleTrack, after, background)
+	msgs, err := h.message.ListDirectMessages(c.Request().Context(), trackID, viewerRole, after, background)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
 	}
+
 	return c.JSON(http.StatusOK, mapMessages(msgs))
 }
 

--- a/backend/internal/infrastructure/web/message_handler_test.go
+++ b/backend/internal/infrastructure/web/message_handler_test.go
@@ -1,0 +1,117 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"cornermon/backend/internal/domain"
+
+	"github.com/labstack/echo/v4"
+)
+
+type messageUsecaseForHandler struct {
+	markRead bool
+	after    domain.Optional[time.Time]
+}
+
+func (m *messageUsecaseForHandler) SendDirect(context.Context, domain.TrackID, string, domain.SenderRole) (*domain.Message, error) {
+	return nil, nil
+}
+
+func (m *messageUsecaseForHandler) ListDirectMessages(_ context.Context, _ domain.TrackID, _ domain.SenderRole, after domain.Optional[time.Time], markRead bool) ([]*domain.Message, error) {
+	m.after = after
+	m.markRead = markRead
+	return []*domain.Message{}, nil
+}
+
+func (m *messageUsecaseForHandler) GetUnreadCount(context.Context, domain.TrackID, domain.SenderRole) (int, error) {
+	return 0, nil
+}
+
+func TestListDirectMessagesForTrackShoudRejectRequestWhenSessionTrackDiffers(t *testing.T) {
+	// Arrange
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/tracks/track-2/messages", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("trackId")
+	c.SetParamValues("track-2")
+	c.Set("facilitatorSession", &domain.FacilitatorSession{TrackID: "track-1"})
+
+	// Act
+	err := NewMessageHandler(&messageUsecaseForHandler{}, nil).ListDirectMessagesForTrack(c)
+
+	// Assert
+	if err != domain.ErrTrackScopeForbidden {
+		t.Fatalf("expected ErrTrackScopeForbidden, got %v", err)
+	}
+}
+
+func TestGetUnreadCountShoudRejectRequestWhenSessionTrackDiffers(t *testing.T) {
+	// Arrange
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/tracks/track-2/messages/unread-count", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("trackId")
+	c.SetParamValues("track-2")
+	c.Set("facilitatorSession", &domain.FacilitatorSession{TrackID: "track-1"})
+
+	// Act
+	err := NewMessageHandler(&messageUsecaseForHandler{}, nil).GetUnreadCount(c)
+
+	// Assert
+	if err != domain.ErrTrackScopeForbidden {
+		t.Fatalf("expected ErrTrackScopeForbidden, got %v", err)
+	}
+}
+
+func TestSendDirectShoudRejectRequestWhenSessionTrackDiffers(t *testing.T) {
+	// Arrange
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodPost, "/tracks/track-2/messages/from-track", strings.NewReader(`{"content":"hello"}`))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("trackId")
+	c.SetParamValues("track-2")
+	c.Set("facilitatorSession", &domain.FacilitatorSession{TrackID: "track-1"})
+
+	// Act
+	err := NewMessageHandler(&messageUsecaseForHandler{}, nil).SendDirect(c)
+
+	// Assert
+	if err != domain.ErrTrackScopeForbidden {
+		t.Fatalf("expected ErrTrackScopeForbidden, got %v", err)
+	}
+}
+
+func TestListDirectMessagesForTrackShoudNotMarkReadWhenBackgroundIsOmitted(t *testing.T) {
+	// Arrange
+	uc := &messageUsecaseForHandler{}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/tracks/track-1/messages", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("trackId")
+	c.SetParamValues("track-1")
+	c.Set("facilitatorSession", &domain.FacilitatorSession{TrackID: "track-1"})
+
+	// Act
+	err := NewMessageHandler(uc, nil).ListDirectMessagesForTrack(c)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uc.markRead {
+		t.Fatal("expected omitted background to leave messages unread")
+	}
+	if uc.after.IsSet() {
+		t.Fatal("expected omitted after to be unset")
+	}
+}

--- a/backend/internal/infrastructure/web/message_handler_test.go
+++ b/backend/internal/infrastructure/web/message_handler_test.go
@@ -14,17 +14,19 @@ import (
 )
 
 type messageUsecaseForHandler struct {
-	markRead bool
-	after    domain.Optional[time.Time]
+	markRead   bool
+	after      domain.Optional[time.Time]
+	viewerRole domain.SenderRole
 }
 
 func (m *messageUsecaseForHandler) SendDirect(context.Context, domain.TrackID, string, domain.SenderRole) (*domain.Message, error) {
 	return nil, nil
 }
 
-func (m *messageUsecaseForHandler) ListDirectMessages(_ context.Context, _ domain.TrackID, _ domain.SenderRole, after domain.Optional[time.Time], markRead bool) ([]*domain.Message, error) {
+func (m *messageUsecaseForHandler) ListDirectMessages(_ context.Context, _ domain.TrackID, viewerRole domain.SenderRole, after domain.Optional[time.Time], markRead bool) ([]*domain.Message, error) {
 	m.after = after
 	m.markRead = markRead
+	m.viewerRole = viewerRole
 	return []*domain.Message{}, nil
 }
 
@@ -32,7 +34,7 @@ func (m *messageUsecaseForHandler) GetUnreadCount(context.Context, domain.TrackI
 	return 0, nil
 }
 
-func TestListDirectMessagesForTrackShoudRejectRequestWhenSessionTrackDiffers(t *testing.T) {
+func TestListDirectMessagesShoudRejectRequestWhenSessionTrackDiffers(t *testing.T) {
 	// Arrange
 	e := echo.New()
 	req := httptest.NewRequest(http.MethodGet, "/tracks/track-2/messages", nil)
@@ -43,7 +45,7 @@ func TestListDirectMessagesForTrackShoudRejectRequestWhenSessionTrackDiffers(t *
 	c.Set("facilitatorSession", &domain.FacilitatorSession{TrackID: "track-1"})
 
 	// Act
-	err := NewMessageHandler(&messageUsecaseForHandler{}, nil).ListDirectMessagesForTrack(c)
+	err := NewMessageHandler(&messageUsecaseForHandler{}, nil).ListDirectMessages(c)
 
 	// Assert
 	if err != domain.ErrTrackScopeForbidden {
@@ -90,7 +92,7 @@ func TestSendDirectShoudRejectRequestWhenSessionTrackDiffers(t *testing.T) {
 	}
 }
 
-func TestListDirectMessagesForTrackShoudNotMarkReadWhenBackgroundIsOmitted(t *testing.T) {
+func TestListDirectMessagesShoudNotMarkReadWhenBackgroundIsOmitted(t *testing.T) {
 	// Arrange
 	uc := &messageUsecaseForHandler{}
 	e := echo.New()
@@ -102,7 +104,7 @@ func TestListDirectMessagesForTrackShoudNotMarkReadWhenBackgroundIsOmitted(t *te
 	c.Set("facilitatorSession", &domain.FacilitatorSession{TrackID: "track-1"})
 
 	// Act
-	err := NewMessageHandler(uc, nil).ListDirectMessagesForTrack(c)
+	err := NewMessageHandler(uc, nil).ListDirectMessages(c)
 
 	// Assert
 	if err != nil {

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -112,8 +112,14 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 		admin.GET("/camps/:campId/messages/broadcast", h.Message.ListBroadcasts)
 		admin.GET("/messages/broadcast/:id/receipts", h.Message.GetBroadcastReceipts)
 		admin.POST("/tracks/:trackId/messages", h.Message.SendDirect)
-		admin.GET("/tracks/:trackId/messages", h.Message.ListDirectMessages)
-		admin.GET("/tracks/:trackId/messages/unread-count", h.Message.GetUnreadCount)
+
+		// Both administrator and facilitator sessions may access these paths.
+		// They must be registered once because Echo routes by method and path
+		// before group middleware is evaluated.
+		message := v1.Group("")
+		message.Use(MessageAuthMiddleware(adminAuth, trackAuth))
+		message.GET("/tracks/:trackId/messages", h.Message.ListDirectMessages)
+		message.GET("/tracks/:trackId/messages/unread-count", h.Message.GetUnreadCount)
 	}
 
 	// ── F. Events (Admin) ──
@@ -142,8 +148,6 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 		track.POST("/messages/broadcast/:id/read", h.Message.ReadBroadcast)
 		// Track can also send/get direct messages
 		track.POST("/tracks/:trackId/messages/from-track", h.Message.SendDirect)
-		track.GET("/tracks/:trackId/messages", h.Message.ListDirectMessagesForTrack)
-		track.GET("/tracks/:trackId/messages/unread-count", h.Message.GetUnreadCount)
 	}
 
 	if h.Event != nil {

--- a/backend/internal/infrastructure/web/router_test.go
+++ b/backend/internal/infrastructure/web/router_test.go
@@ -1,0 +1,63 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"cornermon/backend/internal/domain"
+
+	"github.com/labstack/echo/v4"
+)
+
+type adminAuthForMessageRoutes struct{}
+
+func (adminAuthForMessageRoutes) ValidateAccessToken(_ context.Context, token string) (*domain.AdminSession, error) {
+	if token == "admin-token" {
+		return &domain.AdminSession{}, nil
+	}
+	return nil, errors.New("invalid admin token")
+}
+
+type trackAuthForMessageRoutes struct{}
+
+func (trackAuthForMessageRoutes) ValidateSession(_ context.Context, token string) (*domain.FacilitatorSession, error) {
+	if token == "track-token" {
+		return &domain.FacilitatorSession{TrackID: "track-1"}, nil
+	}
+	return nil, errors.New("invalid track token")
+}
+
+func TestMessageRoutesShoudAuthenticateAdminAndTrackWithoutDuplicateRouteRegistration(t *testing.T) {
+	// Arrange
+	uc := &messageUsecaseForHandler{}
+	e := echo.New()
+	RegisterRoutes(e, &Handlers{Auth: &AuthHandler{}, Device: &DeviceHandler{}, Message: NewMessageHandler(uc, nil)}, adminAuthForMessageRoutes{}, trackAuthForMessageRoutes{})
+
+	for _, tc := range []struct {
+		name     string
+		token    string
+		expected domain.SenderRole
+	}{
+		{name: "admin", token: "admin-token", expected: domain.RoleAdmin},
+		{name: "track", token: "track-token", expected: domain.RoleTrack},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Act
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/tracks/track-1/messages", nil)
+			req.Header.Set(echo.HeaderAuthorization, "Bearer "+tc.token)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if uc.viewerRole != tc.expected {
+				t.Fatalf("expected viewer role %s, got %s", tc.expected, uc.viewerRole)
+			}
+		})
+	}
+}

--- a/backend/internal/usecase/message.go
+++ b/backend/internal/usecase/message.go
@@ -33,7 +33,12 @@ func (s *MessageService) SendDirect(ctx context.Context, trackID domain.TrackID,
 		return nil, domain.ErrTrackNotActive
 	}
 	msg := &domain.Message{ID: domain.MessageID(s.uuidFn()), ChannelType: domain.MessageDirect, TrackID: trackID, SenderRole: senderRole, Content: content, SentAt: s.nowFn()}
-	if err := s.tx.RunInTx(ctx, func(ctx context.Context) error { return s.messages.Save(ctx, msg) }); err != nil {
+	if err := s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		if err := s.messages.Save(ctx, msg); err != nil {
+			return err
+		}
+		return s.tracks.IncrementUnreadCount(ctx, trackID, oppositeRole(senderRole))
+	}); err != nil {
 		s.recordAuditLog(ctx, string(trackID), "MESSAGE_DIRECT", "", false, map[string]any{"error": err.Error()})
 		return nil, err
 	}
@@ -51,8 +56,52 @@ func (s *MessageService) SendDirect(ctx context.Context, trackID domain.TrackID,
 	return msg, nil
 }
 
-func (s *MessageService) ListDirectMessages(ctx context.Context, trackID domain.TrackID) ([]*domain.Message, error) {
-	return s.messages.ListMessageByTrack(ctx, trackID)
+func (s *MessageService) ListDirectMessages(ctx context.Context, trackID domain.TrackID, viewerRole domain.SenderRole, after domain.Optional[time.Time], markRead bool) ([]*domain.Message, error) {
+	var messages []*domain.Message
+	err := s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		var err error
+		messages, err = s.messages.ListMessageByTrackAfter(ctx, trackID, after)
+		if err != nil || !markRead {
+			return err
+		}
+		if err := s.messages.MarkAllReadByRecipient(ctx, trackID, viewerRole, s.nowFn()); err != nil {
+			return err
+		}
+		return s.tracks.ResetUnreadCount(ctx, trackID, viewerRole)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if markRead {
+		now := s.nowFn()
+		for _, message := range messages {
+			if message.SenderRole == oppositeRole(viewerRole) {
+				_ = message.MarkRead(now)
+			}
+		}
+	}
+	return messages, nil
+}
+
+func (s *MessageService) GetUnreadCount(ctx context.Context, trackID domain.TrackID, viewerRole domain.SenderRole) (int, error) {
+	track, err := s.tracks.Get(ctx, trackID)
+	if err != nil {
+		return 0, err
+	}
+	if track == nil {
+		return 0, domain.ErrTrackNotFound
+	}
+	if viewerRole == domain.RoleAdmin {
+		return track.UnreadByAdminCount, nil
+	}
+	return track.UnreadByTrackCount, nil
+}
+
+func oppositeRole(role domain.SenderRole) domain.SenderRole {
+	if role == domain.RoleAdmin {
+		return domain.RoleTrack
+	}
+	return domain.RoleAdmin
 }
 
 func (s *MessageService) recordAuditLog(ctx context.Context, actor, action, target string, success bool, metadata map[string]any) {

--- a/backend/internal/usecase/message.go
+++ b/backend/internal/usecase/message.go
@@ -34,10 +34,13 @@ func (s *MessageService) SendDirect(ctx context.Context, trackID domain.TrackID,
 	}
 	msg := &domain.Message{ID: domain.MessageID(s.uuidFn()), ChannelType: domain.MessageDirect, TrackID: trackID, SenderRole: senderRole, Content: content, SentAt: s.nowFn()}
 	if err := s.tx.RunInTx(ctx, func(ctx context.Context) error {
-		if err := s.messages.Save(ctx, msg); err != nil {
+		// IncrementUnreadCount locks the track row. Every direct-message write
+		// acquires this lock before inserting the message, so it is serialized
+		// with ResetUnreadCount during a concurrent background read.
+		if err := s.tracks.IncrementUnreadCount(ctx, trackID, oppositeRole(senderRole)); err != nil {
 			return err
 		}
-		return s.tracks.IncrementUnreadCount(ctx, trackID, oppositeRole(senderRole))
+		return s.messages.Save(ctx, msg)
 	}); err != nil {
 		s.recordAuditLog(ctx, string(trackID), "MESSAGE_DIRECT", "", false, map[string]any{"error": err.Error()})
 		return nil, err
@@ -58,25 +61,30 @@ func (s *MessageService) SendDirect(ctx context.Context, trackID domain.TrackID,
 
 func (s *MessageService) ListDirectMessages(ctx context.Context, trackID domain.TrackID, viewerRole domain.SenderRole, after domain.Optional[time.Time], markRead bool) ([]*domain.Message, error) {
 	var messages []*domain.Message
+	var readAt time.Time
 	err := s.tx.RunInTx(ctx, func(ctx context.Context) error {
 		var err error
 		messages, err = s.messages.ListMessageByTrackAfter(ctx, trackID, after)
 		if err != nil || !markRead {
 			return err
 		}
-		if err := s.messages.MarkAllReadByRecipient(ctx, trackID, viewerRole, s.nowFn()); err != nil {
+		// ResetUnreadCount acquires the same track-row lock as SendDirect before
+		// any messages are marked read. A concurrent send is therefore either
+		// fully visible to this read and reset, or incremented after this
+		// transaction commits; its counter cannot be reset accidentally.
+		if err := s.tracks.ResetUnreadCount(ctx, trackID, viewerRole); err != nil {
 			return err
 		}
-		return s.tracks.ResetUnreadCount(ctx, trackID, viewerRole)
+		readAt = s.nowFn()
+		return s.messages.MarkAllReadByRecipient(ctx, trackID, viewerRole, readAt)
 	})
 	if err != nil {
 		return nil, err
 	}
 	if markRead {
-		now := s.nowFn()
 		for _, message := range messages {
 			if message.SenderRole == oppositeRole(viewerRole) {
-				_ = message.MarkRead(now)
+				_ = message.MarkRead(readAt)
 			}
 		}
 	}

--- a/backend/internal/usecase/message_test.go
+++ b/backend/internal/usecase/message_test.go
@@ -2,11 +2,42 @@ package usecase
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
 	"cornermon/backend/internal/domain"
 )
+
+type recordingTrackRepository struct {
+	*MockTrackRepository
+	operations *[]string
+}
+
+func (r *recordingTrackRepository) IncrementUnreadCount(ctx context.Context, trackID domain.TrackID, recipient domain.SenderRole) error {
+	*r.operations = append(*r.operations, "increment")
+	return r.MockTrackRepository.IncrementUnreadCount(ctx, trackID, recipient)
+}
+
+func (r *recordingTrackRepository) ResetUnreadCount(ctx context.Context, trackID domain.TrackID, reader domain.SenderRole) error {
+	*r.operations = append(*r.operations, "reset")
+	return r.MockTrackRepository.ResetUnreadCount(ctx, trackID, reader)
+}
+
+type recordingMessageRepository struct {
+	*MockMessageRepository
+	operations *[]string
+}
+
+func (r *recordingMessageRepository) Save(ctx context.Context, msg *domain.Message) error {
+	*r.operations = append(*r.operations, "save")
+	return r.MockMessageRepository.Save(ctx, msg)
+}
+
+func (r *recordingMessageRepository) MarkAllReadByRecipient(ctx context.Context, trackID domain.TrackID, recipient domain.SenderRole, readAt time.Time) error {
+	*r.operations = append(*r.operations, "mark-read")
+	return r.MockMessageRepository.MarkAllReadByRecipient(ctx, trackID, recipient, readAt)
+}
 
 func TestMessageService_SendDirect(t *testing.T) {
 	t.Run("ShouldSendDirectSuccessfullyAndNotify", func(t *testing.T) {
@@ -41,6 +72,9 @@ func TestMessageService_SendDirect(t *testing.T) {
 		}
 		if msg.ID != "msg-uuid" {
 			t.Errorf("expected message ID 'msg-uuid', got '%s'", msg.ID)
+		}
+		if track.UnreadByTrackCount != 1 {
+			t.Fatalf("expected one unread message for track, got %d", track.UnreadByTrackCount)
 		}
 
 		if len(broadcaster.Broadcasts) != 1 ||
@@ -80,6 +114,60 @@ func TestShouldMarkOnlyOppositeMessagesWhenBackgroundIsTrue(t *testing.T) {
 	}
 	if value, _ := adminMessage.ReadAt.Value(); !value.Equal(now) {
 		t.Fatalf("expected admin message read at %v, got %v", now, value)
+	}
+	if track, _ := tracks.Get(context.Background(), "track-1"); track.UnreadByTrackCount != 0 {
+		t.Fatalf("expected unread count to reset after background read, got %d", track.UnreadByTrackCount)
+	}
+}
+
+func TestListDirectMessagesShoudReturnOnlyMessagesAfterBoundaryWhenAfterIsSet(t *testing.T) {
+	// Arrange
+	tracks := NewMockTrackRepository()
+	tracks.Save(context.Background(), &domain.Track{ID: "track-1", Status: domain.TrackActive})
+	messages := NewMockMessageRepository()
+	boundary := time.Unix(10, 0)
+	messages.Save(context.Background(), &domain.Message{ID: "at-boundary", TrackID: "track-1", ChannelType: domain.MessageDirect, SenderRole: domain.RoleAdmin, SentAt: boundary})
+	messages.Save(context.Background(), &domain.Message{ID: "after-boundary", TrackID: "track-1", ChannelType: domain.MessageDirect, SenderRole: domain.RoleAdmin, SentAt: boundary.Add(time.Second)})
+	service := NewMessageService(NewMockCornerRepository(), tracks, messages, &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+
+	// Act
+	got, err := service.ListDirectMessages(context.Background(), "track-1", domain.RoleTrack, domain.Some(boundary), false)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "after-boundary" {
+		t.Fatalf("expected only message after boundary, got %#v", got)
+	}
+}
+
+func TestMessageServiceShoudAcquireUnreadCounterLockBeforeMutatingMessages(t *testing.T) {
+	// Arrange
+	operations := []string{}
+	baseTracks := NewMockTrackRepository()
+	baseTracks.Save(context.Background(), &domain.Track{ID: "track-1", CornerID: "corner-1", Status: domain.TrackActive})
+	tracks := &recordingTrackRepository{MockTrackRepository: baseTracks, operations: &operations}
+	baseMessages := NewMockMessageRepository()
+	baseMessages.Save(context.Background(), &domain.Message{ID: "existing", TrackID: "track-1", ChannelType: domain.MessageDirect, SenderRole: domain.RoleAdmin, SentAt: time.Unix(1, 0)})
+	messages := &recordingMessageRepository{MockMessageRepository: baseMessages, operations: &operations}
+	corners := NewMockCornerRepository()
+	corners.Save(context.Background(), &domain.Corner{ID: "corner-1", CampID: "camp-1"})
+	service := NewMessageService(corners, tracks, messages, &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+
+	// Act
+	_, err := service.SendDirect(context.Background(), "track-1", "reply", domain.RoleTrack)
+	if err == nil {
+		_, err = service.ListDirectMessages(context.Background(), "track-1", domain.RoleTrack, domain.None[time.Time](), true)
+	}
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := []string{"increment", "save", "reset", "mark-read"}
+	if !reflect.DeepEqual(operations, expected) {
+		t.Fatalf("expected lock-first operations %v, got %v", expected, operations)
 	}
 }
 

--- a/backend/internal/usecase/message_test.go
+++ b/backend/internal/usecase/message_test.go
@@ -51,3 +51,53 @@ func TestMessageService_SendDirect(t *testing.T) {
 		}
 	})
 }
+
+func TestShouldMarkOnlyOppositeMessagesWhenBackgroundIsTrue(t *testing.T) {
+	// Arrange
+	tracks := NewMockTrackRepository()
+	tracks.Save(context.Background(), &domain.Track{ID: "track-1", Status: domain.TrackActive})
+	messages := NewMockMessageRepository()
+	adminMessage := &domain.Message{ID: "admin-1", TrackID: "track-1", ChannelType: domain.MessageDirect, SenderRole: domain.RoleAdmin, SentAt: time.Unix(1, 0)}
+	trackMessage := &domain.Message{ID: "track-1", TrackID: "track-1", ChannelType: domain.MessageDirect, SenderRole: domain.RoleTrack, SentAt: time.Unix(2, 0)}
+	messages.Save(context.Background(), adminMessage)
+	messages.Save(context.Background(), trackMessage)
+	s := NewMessageService(NewMockCornerRepository(), tracks, messages, &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+	now := time.Unix(10, 0)
+	s.nowFn = func() time.Time { return now }
+
+	// Act
+	got, err := s.ListDirectMessages(context.Background(), "track-1", domain.RoleTrack, domain.None[time.Time](), true)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(got))
+	}
+	if !adminMessage.ReadAt.IsSet() || trackMessage.ReadAt.IsSet() {
+		t.Fatal("expected only the opposite sender message to be marked read")
+	}
+	if value, _ := adminMessage.ReadAt.Value(); !value.Equal(now) {
+		t.Fatalf("expected admin message read at %v, got %v", now, value)
+	}
+}
+
+func TestShouldReturnRoleSpecificUnreadCountWhenTrackHasUnreadMessages(t *testing.T) {
+	// Arrange
+	tracks := NewMockTrackRepository()
+	tracks.Save(context.Background(), &domain.Track{ID: "track-1", Status: domain.TrackActive, UnreadByAdminCount: 2, UnreadByTrackCount: 3})
+	s := NewMessageService(NewMockCornerRepository(), tracks, NewMockMessageRepository(), &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+
+	// Act
+	adminCount, adminErr := s.GetUnreadCount(context.Background(), "track-1", domain.RoleAdmin)
+	trackCount, trackErr := s.GetUnreadCount(context.Background(), "track-1", domain.RoleTrack)
+
+	// Assert
+	if adminErr != nil || trackErr != nil {
+		t.Fatalf("expected no errors, got %v and %v", adminErr, trackErr)
+	}
+	if adminCount != 2 || trackCount != 3 {
+		t.Fatalf("expected role-specific counts 2 and 3, got %d and %d", adminCount, trackCount)
+	}
+}

--- a/backend/internal/usecase/mock_test.go
+++ b/backend/internal/usecase/mock_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"time"
 
 	"cornermon/backend/internal/domain"
 )
@@ -122,6 +123,26 @@ func (r *MockTrackRepository) ListActiveByCamp(ctx context.Context, campID domai
 
 func (r *MockTrackRepository) Save(ctx context.Context, track *domain.Track) error {
 	r.Tracks[track.ID] = track
+	return nil
+}
+
+func (r *MockTrackRepository) IncrementUnreadCount(ctx context.Context, trackID domain.TrackID, recipient domain.SenderRole) error {
+	track := r.Tracks[trackID]
+	if recipient == domain.RoleAdmin {
+		track.UnreadByAdminCount++
+	} else {
+		track.UnreadByTrackCount++
+	}
+	return nil
+}
+
+func (r *MockTrackRepository) ResetUnreadCount(ctx context.Context, trackID domain.TrackID, reader domain.SenderRole) error {
+	track := r.Tracks[trackID]
+	if reader == domain.RoleAdmin {
+		track.UnreadByAdminCount = 0
+	} else {
+		track.UnreadByTrackCount = 0
+	}
 	return nil
 }
 
@@ -479,6 +500,29 @@ func (r *MockMessageRepository) ListDirectByTrack(ctx context.Context, trackID d
 
 func (r *MockMessageRepository) ListMessageByTrack(ctx context.Context, trackID domain.TrackID) ([]*domain.Message, error) {
 	return r.ListDirectByTrack(ctx, trackID)
+}
+
+func (r *MockMessageRepository) ListMessageByTrackAfter(ctx context.Context, trackID domain.TrackID, after domain.Optional[time.Time]) ([]*domain.Message, error) {
+	messages, _ := r.ListMessageByTrack(ctx, trackID)
+	if value, ok := after.Value(); ok {
+		filtered := messages[:0]
+		for _, message := range messages {
+			if message.SentAt.After(value) {
+				filtered = append(filtered, message)
+			}
+		}
+		messages = filtered
+	}
+	return messages, nil
+}
+
+func (r *MockMessageRepository) MarkAllReadByRecipient(ctx context.Context, trackID domain.TrackID, recipient domain.SenderRole, readAt time.Time) error {
+	for _, message := range r.Messages {
+		if message.TrackID == trackID && message.SenderRole != recipient {
+			_ = message.MarkRead(readAt)
+		}
+	}
+	return nil
 }
 
 type MockAnnouncementRepository struct {

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -41,6 +41,8 @@ type TrackRepository interface {
 	ListActiveByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Track, error)
 	ListByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Track, error)
 	Save(ctx context.Context, track *domain.Track) error
+	IncrementUnreadCount(ctx context.Context, trackID domain.TrackID, recipient domain.SenderRole) error
+	ResetUnreadCount(ctx context.Context, trackID domain.TrackID, reader domain.SenderRole) error
 }
 
 // VisitRepository는 방문 엔티티의 지속성을 담당하는 포트입니다.
@@ -106,6 +108,8 @@ type AdminSessionRepository interface {
 type MessageRepository interface {
 	Save(ctx context.Context, msg *domain.Message) error
 	ListMessageByTrack(ctx context.Context, trackID domain.TrackID) ([]*domain.Message, error)
+	ListMessageByTrackAfter(ctx context.Context, trackID domain.TrackID, after domain.Optional[time.Time]) ([]*domain.Message, error)
+	MarkAllReadByRecipient(ctx context.Context, trackID domain.TrackID, recipient domain.SenderRole, readAt time.Time) error
 }
 
 // MessageRepository는 공지사항 엔티티의 지속성을 담당하는 포트입니다.


### PR DESCRIPTION
## 변경 사항
- DIRECT 메시지에 read_at과 역할별 트랙 미확인 카운터를 추가했습니다.
- 발송 증가와 background 읽음 처리를 DB 원자적 UPDATE로 연결했습니다.
- after/background 조회 파라미터와 관리자·진행자 unread-count API를 추가했습니다.

## 검증
- ok  	cornermon/backend/cmd/server	(cached)
ok  	cornermon/backend/internal/domain	(cached)
ok  	cornermon/backend/internal/errs	(cached)
ok  	cornermon/backend/internal/infrastructure/crypto	(cached)
ok  	cornermon/backend/internal/infrastructure/postgres	(cached)
?   	cornermon/backend/internal/infrastructure/postgres/db	[no test files]
ok  	cornermon/backend/internal/infrastructure/sse	(cached)
ok  	cornermon/backend/internal/infrastructure/web	(cached)
ok  	cornermon/backend/internal/usecase	(cached) 통과
- 역할별 읽음 처리 및 unread 카운터 서비스 테스트 추가
- 미확인 조회는 트랙 컬럼을 읽으며 메시지 집계를 수행하지 않음

Closes #69