### PR TITLE
feat: 관리자 로그인 및 초기 설정 마법사 구현

### DIFF
--- a/frontend/build.yaml
+++ b/frontend/build.yaml
@@ -12,5 +12,6 @@ targets:
             - lib/facilitator/session/*.dart
             - lib/facilitator/features/**/*.dart
             - lib/facilitator/router/*.dart
+            - lib/admin/features/**/*.dart
           exclude:
             - lib/shared/api/gen/**

--- a/frontend/docs/artifacts/plan/관리자_앱_전체_플로우_구현_plan_20260714/03_a0_a0b_login_setup_wizard.md
+++ b/frontend/docs/artifacts/plan/관리자_앱_전체_플로우_구현_plan_20260714/03_a0_a0b_login_setup_wizard.md
@@ -24,7 +24,7 @@
 | **P0** | UC-2: 로그인 성공 후 캠프 유무에 따른 분기 | `GET /camps` 결과가 0개면 `/setup-wizard`, 1개 이상이면 `/camps`로 — 이 라우팅 판단 자체는 `adminRouterProvider`(`02`)가 하고, 이 화면은 판단에 필요한 `campListProvider` 상태를 정확히 채운다 | 프로덕션 핵심 |
 | **P0** | UC-3: 마법사 1단계 — 캠프 정보 입력 | 이름/시작일/종료일 로컬 상태로만 보관(아직 API 호출 없음) | 프로덕션 핵심 |
 | **P0** | UC-4: 마법사 2단계 — 코너 이름 붙여넣기 파싱 + 미리보기 표/개별 조정/삭제 | 줄바꿈 텍스트 → `SetupWizardCornerRow` 리스트, "예시 10개" 템플릿 버튼 | 프로덕션 핵심 |
-| **P0** | UC-5: 코너 0개 상태에서 다음 단계 진행 차단 | "코너를 1개 이상 추가하세요" 소프트 가드(scenarios.md Feature 2-d) | 프로덕션 핵심 |
+| **P0** | UC-5: 코너 없이 캠프만 생성 | 코너가 0개여도 다음 단계와 캠프 생성을 허용하고, 완료 후 코너·트랙 관리 화면에서 추가한다 | 프로덕션 핵심 |
 | **P0** | UC-6: 마법사 3단계 — 검토 및 확정 | `POST /camps` → `PATCH /camps/{id}`(기간) → 코너별 `POST /corners` → 코너별 `POST /tracks` 순차 실행, 진행 상태 표시, 완료 시 `selectedCampIdProvider.select()` 후 `/corner-track-manage`로 이동 | 프로덕션 핵심 |
 | P1 | UC-7: 확정 도중 일부 코너 생성 실패 시 부분 성공 상태를 검토 화면에 남겨 재시도 | §0에서 결정한 부분 실패 처리 | 장애 복구 |
 | P2 | UC-8: 이미 캠프가 있으면 마법사를 건너뛴다 | `adminRouterProvider`가 이미 처리(§UC-2와 동일 메커니즘) — 이 화면 자체는 별도 분기 로직 불필요, 라우터가 애초에 이 화면으로 보내지 않음 | 회귀 방지 |
@@ -167,7 +167,6 @@ class SetupWizardState {
     this.corners = const [],
     this.defaultTargetMinutes = 10,
     this.defaultTrackCountPerCorner = 1,
-    this.blockedMessage,         // "코너를 1개 이상 추가하세요" — 2단계 진행 차단 시 세팅
     this.isSubmitting = false,
     this.createdCampId,          // 3단계 확정 중 POST /camps 성공 직후 채워짐(재시도 시 캠프를 중복 생성하지 않기 위한 가드)
     this.submitError,
@@ -179,12 +178,10 @@ class SetupWizardState {
   final List<SetupWizardCornerRow> corners;
   final int defaultTargetMinutes;
   final int defaultTrackCountPerCorner;
-  final String? blockedMessage;
   final bool isSubmitting;
   final CampId? createdCampId;
   final String? submitError;
 
-  bool get canFinish => corners.isNotEmpty; // 2단계 소프트 가드와 동일 조건, 3단계 진입 시에도 재확인
 }
 ```
 
@@ -205,7 +202,7 @@ class SetupWizard extends _$SetupWizard {
   void removeCornerRow(int index);
   void setDefaults({int? targetMinutes, int? trackCountPerCorner}); // 이후 parseCornerNames 호출에만 영향, 이미 만들어진 행은 유지
 
-  bool tryAdvanceFromCornerStep(); // corners.isEmpty면 blockedMessage 세팅 후 false 반환, 아니면 step=2로 이동 후 true
+  bool tryAdvanceFromCornerStep(); // 코너 유무와 무관하게 step=2로 이동 후 true 반환
 
   // 3단계 확정 — §0에서 결정한 순차 실행 + 부분 실패 시 재시도 가능한 형태.
   // 의사코드(구현 로직 상세는 개발자 재량, 아래는 책임 범위만 명시):
@@ -218,7 +215,7 @@ class SetupWizard extends _$SetupWizard {
   //        성공: createTracksForCorner(createdCampId, corner.id, row.trackCount) 호출 → 둘 다 성공하면 status = created, createdCornerId 저장
   //        실패(둘 중 하나): status = failed, errorMessage 저장 — 다음 행 계속 진행(한 코너 실패가 나머지를 막지 않는다,
   //          §0의 "부분 실패를 투명하게 보여준다" 결정)
-  //   4. 모든 행이 created면 selectedCampIdProvider.notifier.select(createdCampId) 호출 후 완료 신호(화면이 라우팅 수행)
+  //   4. 모든 행이 created(빈 목록 포함)면 selectedCampIdProvider.notifier.select(createdCampId) 호출 후 완료 신호(화면이 라우팅 수행)
   //      하나라도 failed면 완료 신호를 보내지 않고 검토 화면에 실패 행 재시도 버튼을 노출한다
   Future<bool> submit(); // true = 전체 성공(라우팅 가능), false = 부분 실패(화면에 머무름)
 }
@@ -265,9 +262,7 @@ class _CornerTrackStep extends ConsumerWidget {
   //   이후 개별 행 수정(updateCornerRow)은 이 텍스트 영역과 독립적으로 SetupWizardCornerRow 리스트만 갱신한다.
   // 우측: 파싱된 corners를 표로 미리보기 — 각 행에 이름/목표시간/트랙 수 인라인 편집 필드 + 삭제 아이콘 버튼.
   // corners가 비어 있으면 EmptyState(message: '붙여넣거나 예시 템플릿을 사용하세요') 표시.
-  // blockedMessage != null이면 표 위에 danger 색 경고 텍스트로 "코너를 1개 이상 추가하세요" 노출.
-  // "다음" 버튼: setupWizardProvider.notifier.tryAdvanceFromCornerStep() 호출, false면 그대로 머무름(blockedMessage가
-  //   상태에 이미 세팅되어 위 경고가 자동으로 나타남 — 별도 SnackBar 불필요).
+  // "다음" 버튼: 코너 유무와 무관하게 setupWizardProvider.notifier.tryAdvanceFromCornerStep() 호출로 검토 단계로 이동한다.
 }
 
 // frontend/lib/admin/features/setup_wizard/steps/review_step.dart
@@ -353,7 +348,7 @@ frontend/lib/admin/features/
 - [ ] 1단계에서 캠프 이름을 비운 채 "다음"을 누르면 버튼이 비활성화 상태라 진행 자체가 안 된다(위젯 테스트)
 - [ ] 2단계에서 10줄 텍스트를 붙여넣고 "적용"하면 `corners.length == 10`이고 각 행의 `targetMinutes`/`trackCount`가 그 시점의 기본값으로 채워진다(unit 테스트, `SetupWizard.parseCornerNames`)
 - [ ] "예시 10개로 빠르게 시작" 클릭 시 텍스트 영역이 `kSetupWizardExampleCornerNames`로 채워지고 미리보기 표가 즉시 갱신된다(위젯 테스트)
-- [ ] 코너 0개 상태에서 "다음"을 누르면 `blockedMessage`가 세팅되고 화면에 "코너를 1개 이상 추가하세요"가 표시되며 3단계로 넘어가지 않는다(scenarios.md Feature 2-d 재현, 위젯 테스트)
+- [ ] 코너 0개 상태에서도 "다음"으로 3단계에 진입하고, 캠프만 생성한 뒤 코너·트랙 관리 화면으로 이동한다(위젯/통합 테스트)
 - [ ] 미리보기 표에서 개별 행의 이름/목표시간/트랙 수를 수정하면 해당 인덱스의 `SetupWizardCornerRow`만 갱신되고 나머지는 그대로다(unit 테스트, `updateCornerRow`)
 - [ ] 행 삭제 버튼이 해당 인덱스만 제거한다(unit 테스트, `removeCornerRow`)
 - [ ] 3단계 "설정 완료"를 눌렀을 때 `createCamp` → (기간 입력 시)`updateCamp` → 코너별 `createCorner`+`createTracksForCorner` 순서로 호출된다(unit 테스트, mock provider 호출 순서 검증 — `verifyInOrder` 류)

--- a/frontend/lib/admin/features/login/login_error_provider.dart
+++ b/frontend/lib/admin/features/login/login_error_provider.dart
@@ -1,0 +1,40 @@
+import 'package:dio/dio.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:cornermon/admin/session/admin_session_provider.dart';
+
+part 'login_error_provider.g.dart';
+
+sealed class AdminLoginUiError {
+  const AdminLoginUiError();
+}
+
+class AdminLoginInvalidCredentials extends AdminLoginUiError {
+  const AdminLoginInvalidCredentials();
+}
+
+class AdminLoginServerError extends AdminLoginUiError {
+  const AdminLoginServerError();
+}
+
+/// 로그인 화면에만 필요한 일시적인 오류 상태다.
+@riverpod
+class LoginError extends _$LoginError {
+  @override
+  AdminLoginUiError? build() => null;
+
+  Future<void> submit(String loginId, String password) async {
+    state = null;
+    try {
+      await ref.read(adminSessionProvider.notifier).login(loginId, password);
+    } on DioException catch (error) {
+      state = error.response?.statusCode == 401
+          ? const AdminLoginInvalidCredentials()
+          : const AdminLoginServerError();
+      rethrow;
+    } catch (_) {
+      state = const AdminLoginServerError();
+      rethrow;
+    }
+  }
+}

--- a/frontend/lib/admin/features/login/login_error_provider.g.dart
+++ b/frontend/lib/admin/features/login/login_error_provider.g.dart
@@ -1,0 +1,67 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'login_error_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 로그인 화면에만 필요한 일시적인 오류 상태다.
+
+@ProviderFor(LoginError)
+final loginErrorProvider = LoginErrorProvider._();
+
+/// 로그인 화면에만 필요한 일시적인 오류 상태다.
+final class LoginErrorProvider
+    extends $NotifierProvider<LoginError, AdminLoginUiError?> {
+  /// 로그인 화면에만 필요한 일시적인 오류 상태다.
+  LoginErrorProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'loginErrorProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$loginErrorHash();
+
+  @$internal
+  @override
+  LoginError create() => LoginError();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AdminLoginUiError? value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AdminLoginUiError?>(value),
+    );
+  }
+}
+
+String _$loginErrorHash() => r'9eb624ad2ca8d47423dd8e586f483152c660542b';
+
+/// 로그인 화면에만 필요한 일시적인 오류 상태다.
+
+abstract class _$LoginError extends $Notifier<AdminLoginUiError?> {
+  AdminLoginUiError? build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AdminLoginUiError?, AdminLoginUiError?>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AdminLoginUiError?, AdminLoginUiError?>,
+              AdminLoginUiError?,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/frontend/lib/admin/features/login/login_screen.dart
+++ b/frontend/lib/admin/features/login/login_screen.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:cornermon/admin/features/login/login_error_provider.dart';
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+
+class LoginScreen extends ConsumerStatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  ConsumerState<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends ConsumerState<LoginScreen> {
+  final _idController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _isSubmitting = false;
+
+  @override
+  void dispose() {
+    _idController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (_isSubmitting) return;
+    if (_idController.text.trim().isEmpty || _passwordController.text.isEmpty) {
+      setState(() {});
+      return;
+    }
+    setState(() => _isSubmitting = true);
+    try {
+      await ref
+          .read(loginErrorProvider.notifier)
+          .submit(_idController.text.trim(), _passwordController.text);
+    } catch (_) {
+      // 오류 문구는 LoginError provider가 관리한다.
+    } finally {
+      if (mounted) setState(() => _isSubmitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).brightness == Brightness.dark
+        ? AppColors.dark
+        : AppColors.light;
+    final error = ref.watch(loginErrorProvider);
+    final errorText = switch (error) {
+      AdminLoginInvalidCredentials() => 'ID 또는 비밀번호가 올바르지 않습니다',
+      AdminLoginServerError() => '일시적인 오류입니다. 잠시 후 다시 시도해주세요.',
+      null => null,
+    };
+    final canSubmit =
+        !_isSubmitting &&
+        _idController.text.trim().isNotEmpty &&
+        _passwordController.text.isNotEmpty;
+
+    return Scaffold(
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(AppSpacing.space6),
+          child: SizedBox(
+            width: 400,
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(AppSpacing.space6),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text('코너학습 관리자', style: AppTypography.title1),
+                    const SizedBox(height: AppSpacing.space2),
+                    Text('관리자 계정으로 로그인하세요.', style: AppTypography.body),
+                    const SizedBox(height: AppSpacing.space6),
+                    TextField(
+                      controller: _idController,
+                      enabled: !_isSubmitting,
+                      onChanged: (_) => setState(() {}),
+                      decoration: const InputDecoration(labelText: 'ID'),
+                    ),
+                    const SizedBox(height: AppSpacing.space4),
+                    TextField(
+                      controller: _passwordController,
+                      enabled: !_isSubmitting,
+                      obscureText: true,
+                      onChanged: (_) => setState(() {}),
+                      onSubmitted: (_) => _submit(),
+                      decoration: const InputDecoration(labelText: '비밀번호'),
+                    ),
+                    if (errorText != null) ...[
+                      const SizedBox(height: AppSpacing.space2),
+                      Text(
+                        errorText,
+                        style: AppTypography.caption.copyWith(
+                          color: colors.danger,
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: AppSpacing.space5),
+                    Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        SizedBox(
+                          width: double.infinity,
+                          child: AppButton(
+                            variant: AppButtonVariant.primary,
+                            label: '로그인',
+                            onPressed: canSubmit ? _submit : null,
+                          ),
+                        ),
+                        if (_isSubmitting)
+                          const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: AppSpacing.space4),
+                    Text('로그인 상태는 안전하게 유지됩니다.', style: AppTypography.caption),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
@@ -1,0 +1,206 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_state.dart';
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_templates.dart';
+import 'package:cornermon/admin/session/selected_camp_provider.dart';
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/providers/camp_providers.dart';
+import 'package:cornermon/shared/api/providers/corner_track_providers.dart';
+
+part 'setup_wizard_provider.g.dart';
+
+@riverpod
+class SetupWizard extends _$SetupWizard {
+  @override
+  SetupWizardState build() => const SetupWizardState();
+
+  void setCampInfo(String name, DateTime? startAt, DateTime? endAt) {
+    state = state.copyWith(
+      campName: name.trim(),
+      startAt: startAt,
+      endAt: endAt,
+    );
+  }
+
+  void goToStep(int step) =>
+      state = state.copyWith(step: step, clearBlockedMessage: true);
+
+  void parseCornerNames(String pastedText) {
+    final names = pastedText
+        .split(RegExp(r'\r?\n'))
+        .map((name) => name.trim())
+        .where((name) => name.isNotEmpty);
+    state = state.copyWith(
+      corners: [
+        for (final name in names)
+          SetupWizardCornerRow(
+            name: name,
+            targetMinutes: state.defaultTargetMinutes,
+            trackCount: state.defaultTrackCountPerCorner,
+          ),
+      ],
+      clearBlockedMessage: true,
+    );
+  }
+
+  void applyExampleTemplate() =>
+      parseCornerNames(kSetupWizardExampleCornerNames.join('\n'));
+
+  void updateCornerRow(
+    int index, {
+    String? name,
+    int? targetMinutes,
+    int? trackCount,
+  }) {
+    if (index < 0 || index >= state.corners.length) return;
+    final rows = [...state.corners];
+    rows[index] = rows[index].copyWith(
+      name: name?.trim(),
+      targetMinutes: targetMinutes != null && targetMinutes > 0
+          ? targetMinutes
+          : null,
+      trackCount: trackCount != null && trackCount > 0 ? trackCount : null,
+    );
+    state = state.copyWith(corners: rows);
+  }
+
+  void removeCornerRow(int index) {
+    if (index < 0 || index >= state.corners.length) return;
+    final rows = [...state.corners]..removeAt(index);
+    state = state.copyWith(corners: rows);
+  }
+
+  void setDefaults({int? targetMinutes, int? trackCountPerCorner}) {
+    state = state.copyWith(
+      defaultTargetMinutes: targetMinutes != null && targetMinutes > 0
+          ? targetMinutes
+          : null,
+      defaultTrackCountPerCorner:
+          trackCountPerCorner != null && trackCountPerCorner > 0
+          ? trackCountPerCorner
+          : null,
+    );
+  }
+
+  bool tryAdvanceFromCornerStep() {
+    if (state.corners.isEmpty) {
+      state = state.copyWith(blockedMessage: '코너를 1개 이상 추가하세요');
+      return false;
+    }
+    state = state.copyWith(step: 2, clearBlockedMessage: true);
+    return true;
+  }
+
+  Future<bool> submit() async {
+    if (!state.canFinish || state.isSubmitting) return false;
+    state = state.copyWith(isSubmitting: true, clearSubmitError: true);
+    CampId campId;
+    try {
+      campId = state.createdCampId ?? await _createCamp();
+      if (state.createdCampId == null) {
+        state = state.copyWith(createdCampId: campId);
+      }
+    } catch (_) {
+      state = state.copyWith(
+        isSubmitting: false,
+        submitError: '캠프를 만들지 못했습니다. 다시 시도해주세요.',
+      );
+      return false;
+    }
+
+    if (state.startAt != null || state.endAt != null) {
+      try {
+        await ref.read(
+          updateCampProvider(
+            campId,
+            startAt: state.startAt,
+            endAt: state.endAt,
+          ).future,
+        );
+      } catch (_) {
+        state = state.copyWith(
+          submitError: '캠프 기간은 저장하지 못했습니다. 설정에서 다시 지정할 수 있습니다.',
+        );
+      }
+    }
+
+    for (var index = 0; index < state.corners.length; index++) {
+      final row = state.corners[index];
+      if (row.status == SetupWizardCornerStatus.created) continue;
+      _replaceRow(
+        index,
+        row.copyWith(
+          status: SetupWizardCornerStatus.creating,
+          clearErrorMessage: true,
+        ),
+      );
+      try {
+        final cornerId =
+            row.createdCornerId ?? await _createCorner(campId, row);
+        if (row.createdCornerId == null) {
+          _replaceRow(
+            index,
+            row.copyWith(createdCornerId: cornerId, clearErrorMessage: true),
+          );
+        }
+        await ref.read(
+          createTracksForCornerProvider(
+            campId,
+            cornerId,
+            row.trackCount,
+          ).future,
+        );
+        _replaceRow(
+          index,
+          row.copyWith(
+            status: SetupWizardCornerStatus.created,
+            createdCornerId: cornerId,
+            clearErrorMessage: true,
+          ),
+        );
+      } catch (_) {
+        _replaceRow(
+          index,
+          row.copyWith(
+            status: SetupWizardCornerStatus.failed,
+            errorMessage: '생성하지 못했습니다. 재시도해주세요.',
+          ),
+        );
+      }
+    }
+
+    final allCreated = state.corners.every(
+      (row) => row.status == SetupWizardCornerStatus.created,
+    );
+    state = state.copyWith(isSubmitting: false);
+    if (!allCreated) return false;
+    ref.read(selectedCampIdProvider.notifier).select(campId);
+    ref.invalidate(campListProvider);
+    return true;
+  }
+
+  Future<CampId> _createCamp() async {
+    final camp = await ref.read(createCampProvider(state.campName).future);
+    final id = camp.id;
+    if (id == null) throw StateError('생성된 캠프 ID가 없습니다.');
+    return CampId(id);
+  }
+
+  Future<CornerId> _createCorner(
+    CampId campId,
+    SetupWizardCornerRow row,
+  ) async {
+    final corner = await ref.read(
+      createCornerProvider(campId, row.name, row.targetMinutes).future,
+    );
+    final id = corner.id;
+    if (id == null) throw StateError('생성된 코너 ID가 없습니다.');
+    return CornerId(id);
+  }
+
+  void _replaceRow(int index, SetupWizardCornerRow row) {
+    final rows = [...state.corners];
+    rows[index] = row;
+    state = state.copyWith(corners: rows);
+  }
+}

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
@@ -22,8 +22,7 @@ class SetupWizard extends _$SetupWizard {
     );
   }
 
-  void goToStep(int step) =>
-      state = state.copyWith(step: step, clearBlockedMessage: true);
+  void goToStep(int step) => state = state.copyWith(step: step);
 
   void parseCornerNames(String pastedText) {
     final names = pastedText
@@ -39,7 +38,6 @@ class SetupWizard extends _$SetupWizard {
             trackCount: state.defaultTrackCountPerCorner,
           ),
       ],
-      clearBlockedMessage: true,
     );
   }
 
@@ -83,16 +81,12 @@ class SetupWizard extends _$SetupWizard {
   }
 
   bool tryAdvanceFromCornerStep() {
-    if (state.corners.isEmpty) {
-      state = state.copyWith(blockedMessage: '코너를 1개 이상 추가하세요');
-      return false;
-    }
-    state = state.copyWith(step: 2, clearBlockedMessage: true);
+    state = state.copyWith(step: 2);
     return true;
   }
 
   Future<bool> submit() async {
-    if (!state.canFinish || state.isSubmitting) return false;
+    if (state.isSubmitting) return false;
     state = state.copyWith(isSubmitting: true, clearSubmitError: true);
     CampId campId;
     try {

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.g.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'setup_wizard_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+
+@ProviderFor(SetupWizard)
+final setupWizardProvider = SetupWizardProvider._();
+
+final class SetupWizardProvider
+    extends $NotifierProvider<SetupWizard, SetupWizardState> {
+  SetupWizardProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'setupWizardProvider',
+        isAutoDispose: true,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$setupWizardHash();
+
+  @$internal
+  @override
+  SetupWizard create() => SetupWizard();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(SetupWizardState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<SetupWizardState>(value),
+    );
+  }
+}
+
+String _$setupWizardHash() => r'a31e8ce615fa73aa2b31ce87bcaab9413a62b356';
+
+abstract class _$SetupWizard extends $Notifier<SetupWizardState> {
+  SetupWizardState build();
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<SetupWizardState, SetupWizardState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<SetupWizardState, SetupWizardState>,
+              SetupWizardState,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, build);
+  }
+}

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_screen.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
+import 'package:cornermon/admin/features/setup_wizard/steps/camp_info_step.dart';
+import 'package:cornermon/admin/features/setup_wizard/steps/corner_track_step.dart';
+import 'package:cornermon/admin/features/setup_wizard/steps/review_step.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
+
+class SetupWizardScreen extends ConsumerWidget {
+  const SetupWizardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final step = ref.watch(setupWizardProvider.select((value) => value.step));
+    final content = switch (step) {
+      0 => const CampInfoStep(),
+      1 => const CornerTrackStep(),
+      _ => const ReviewStep(),
+    };
+    return Scaffold(
+      body: Center(
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 840),
+          child: Card(
+            margin: const EdgeInsets.all(AppSpacing.space6),
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpacing.space6),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text('초기 설정', style: AppTypography.title1),
+                  const SizedBox(height: AppSpacing.space4),
+                  _StepIndicator(currentStep: step),
+                  const SizedBox(height: AppSpacing.space6),
+                  Flexible(child: SingleChildScrollView(child: content)),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _StepIndicator extends StatelessWidget {
+  const _StepIndicator({required this.currentStep});
+  final int currentStep;
+
+  @override
+  Widget build(BuildContext context) => Row(
+    children: [
+      for (var index = 0; index < 3; index++) ...[
+        Expanded(
+          child: Column(
+            children: [
+              CircleAvatar(
+                radius: 14,
+                backgroundColor: index <= currentStep
+                    ? Theme.of(context).colorScheme.primary
+                    : null,
+                child: Text('${index + 1}'),
+              ),
+              const SizedBox(height: AppSpacing.space1),
+              Text(['캠프 정보', '코너·트랙', '검토'][index]),
+            ],
+          ),
+        ),
+        if (index < 2) const Expanded(child: Divider()),
+      ],
+    ],
+  );
+}

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_state.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_state.dart
@@ -46,7 +46,6 @@ class SetupWizardState {
     this.corners = const [],
     this.defaultTargetMinutes = 10,
     this.defaultTrackCountPerCorner = 1,
-    this.blockedMessage,
     this.isSubmitting = false,
     this.createdCampId,
     this.submitError,
@@ -59,12 +58,9 @@ class SetupWizardState {
   final List<SetupWizardCornerRow> corners;
   final int defaultTargetMinutes;
   final int defaultTrackCountPerCorner;
-  final String? blockedMessage;
   final bool isSubmitting;
   final CampId? createdCampId;
   final String? submitError;
-
-  bool get canFinish => corners.isNotEmpty;
 
   SetupWizardState copyWith({
     int? step,
@@ -76,8 +72,6 @@ class SetupWizardState {
     List<SetupWizardCornerRow>? corners,
     int? defaultTargetMinutes,
     int? defaultTrackCountPerCorner,
-    String? blockedMessage,
-    bool clearBlockedMessage = false,
     bool? isSubmitting,
     CampId? createdCampId,
     String? submitError,
@@ -91,9 +85,6 @@ class SetupWizardState {
     defaultTargetMinutes: defaultTargetMinutes ?? this.defaultTargetMinutes,
     defaultTrackCountPerCorner:
         defaultTrackCountPerCorner ?? this.defaultTrackCountPerCorner,
-    blockedMessage: clearBlockedMessage
-        ? null
-        : blockedMessage ?? this.blockedMessage,
     isSubmitting: isSubmitting ?? this.isSubmitting,
     createdCampId: createdCampId ?? this.createdCampId,
     submitError: clearSubmitError ? null : submitError ?? this.submitError,

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_state.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_state.dart
@@ -1,0 +1,101 @@
+import 'package:cornermon/shared/api/ids.dart';
+
+enum SetupWizardCornerStatus { pending, creating, created, failed }
+
+class SetupWizardCornerRow {
+  const SetupWizardCornerRow({
+    required this.name,
+    required this.targetMinutes,
+    required this.trackCount,
+    this.status = SetupWizardCornerStatus.pending,
+    this.createdCornerId,
+    this.errorMessage,
+  });
+
+  final String name;
+  final int targetMinutes;
+  final int trackCount;
+  final SetupWizardCornerStatus status;
+  final CornerId? createdCornerId;
+  final String? errorMessage;
+
+  SetupWizardCornerRow copyWith({
+    String? name,
+    int? targetMinutes,
+    int? trackCount,
+    SetupWizardCornerStatus? status,
+    CornerId? createdCornerId,
+    String? errorMessage,
+    bool clearErrorMessage = false,
+  }) => SetupWizardCornerRow(
+    name: name ?? this.name,
+    targetMinutes: targetMinutes ?? this.targetMinutes,
+    trackCount: trackCount ?? this.trackCount,
+    status: status ?? this.status,
+    createdCornerId: createdCornerId ?? this.createdCornerId,
+    errorMessage: clearErrorMessage ? null : errorMessage ?? this.errorMessage,
+  );
+}
+
+class SetupWizardState {
+  const SetupWizardState({
+    this.step = 0,
+    this.campName = '',
+    this.startAt,
+    this.endAt,
+    this.corners = const [],
+    this.defaultTargetMinutes = 10,
+    this.defaultTrackCountPerCorner = 1,
+    this.blockedMessage,
+    this.isSubmitting = false,
+    this.createdCampId,
+    this.submitError,
+  });
+
+  final int step;
+  final String campName;
+  final DateTime? startAt;
+  final DateTime? endAt;
+  final List<SetupWizardCornerRow> corners;
+  final int defaultTargetMinutes;
+  final int defaultTrackCountPerCorner;
+  final String? blockedMessage;
+  final bool isSubmitting;
+  final CampId? createdCampId;
+  final String? submitError;
+
+  bool get canFinish => corners.isNotEmpty;
+
+  SetupWizardState copyWith({
+    int? step,
+    String? campName,
+    DateTime? startAt,
+    DateTime? endAt,
+    bool clearStartAt = false,
+    bool clearEndAt = false,
+    List<SetupWizardCornerRow>? corners,
+    int? defaultTargetMinutes,
+    int? defaultTrackCountPerCorner,
+    String? blockedMessage,
+    bool clearBlockedMessage = false,
+    bool? isSubmitting,
+    CampId? createdCampId,
+    String? submitError,
+    bool clearSubmitError = false,
+  }) => SetupWizardState(
+    step: step ?? this.step,
+    campName: campName ?? this.campName,
+    startAt: clearStartAt ? null : startAt ?? this.startAt,
+    endAt: clearEndAt ? null : endAt ?? this.endAt,
+    corners: corners ?? this.corners,
+    defaultTargetMinutes: defaultTargetMinutes ?? this.defaultTargetMinutes,
+    defaultTrackCountPerCorner:
+        defaultTrackCountPerCorner ?? this.defaultTrackCountPerCorner,
+    blockedMessage: clearBlockedMessage
+        ? null
+        : blockedMessage ?? this.blockedMessage,
+    isSubmitting: isSubmitting ?? this.isSubmitting,
+    createdCampId: createdCampId ?? this.createdCampId,
+    submitError: clearSubmitError ? null : submitError ?? this.submitError,
+  );
+}

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_templates.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_templates.dart
@@ -1,0 +1,12 @@
+const List<String> kSetupWizardExampleCornerNames = [
+  '1코너',
+  '2코너',
+  '3코너',
+  '4코너',
+  '5코너',
+  '6코너',
+  '7코너',
+  '8코너',
+  '9코너',
+  '10코너',
+];

--- a/frontend/lib/admin/features/setup_wizard/steps/camp_info_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/camp_info_step.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+
+class CampInfoStep extends ConsumerStatefulWidget {
+  const CampInfoStep({super.key});
+
+  @override
+  ConsumerState<CampInfoStep> createState() => _CampInfoStepState();
+}
+
+class _CampInfoStepState extends ConsumerState<CampInfoStep> {
+  late final TextEditingController _nameController;
+  DateTime? _startAt;
+  DateTime? _endAt;
+
+  @override
+  void initState() {
+    super.initState();
+    final state = ref.read(setupWizardProvider);
+    _nameController = TextEditingController(text: state.campName);
+    _startAt = state.startAt;
+    _endAt = state.endAt;
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _selectDate(bool isStart) async {
+    final current = isStart ? _startAt : _endAt;
+    final selected = await showDatePicker(
+      context: context,
+      initialDate: current ?? DateTime.now(),
+      firstDate: DateTime(2020),
+      lastDate: DateTime(2100),
+    );
+    if (selected != null) {
+      setState(() => isStart ? _startAt = selected : _endAt = selected);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final valid = _nameController.text.trim().isNotEmpty;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text('캠프 정보를 입력하세요.'),
+        const SizedBox(height: AppSpacing.space4),
+        TextField(
+          controller: _nameController,
+          onChanged: (_) => setState(() {}),
+          decoration: const InputDecoration(labelText: '캠프 이름'),
+        ),
+        const SizedBox(height: AppSpacing.space3),
+        Wrap(
+          spacing: AppSpacing.space3,
+          runSpacing: AppSpacing.space2,
+          children: [
+            OutlinedButton(
+              onPressed: () => _selectDate(true),
+              child: Text(
+                _startAt == null ? '시작일 선택 (선택)' : '시작일 ${_date(_startAt!)}',
+              ),
+            ),
+            OutlinedButton(
+              onPressed: () => _selectDate(false),
+              child: Text(
+                _endAt == null ? '종료일 선택 (선택)' : '종료일 ${_date(_endAt!)}',
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.space6),
+        Align(
+          alignment: Alignment.centerRight,
+          child: AppButton(
+            variant: AppButtonVariant.primary,
+            label: '다음',
+            onPressed: valid
+                ? () {
+                    ref
+                        .read(setupWizardProvider.notifier)
+                        .setCampInfo(_nameController.text, _startAt, _endAt);
+                    ref.read(setupWizardProvider.notifier).goToStep(1);
+                  }
+                : null,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String _date(DateTime value) =>
+    '${value.year}.${value.month.toString().padLeft(2, '0')}.${value.day.toString().padLeft(2, '0')}';

--- a/frontend/lib/admin/features/setup_wizard/steps/corner_track_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/corner_track_step.dart
@@ -4,7 +4,6 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_state.dart';
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_templates.dart';
-import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 
@@ -40,9 +39,6 @@ class _CornerTrackStepState extends ConsumerState<CornerTrackStep> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(setupWizardProvider);
-    final colors = Theme.of(context).brightness == Brightness.dark
-        ? AppColors.dark
-        : AppColors.light;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -91,10 +87,6 @@ class _CornerTrackStepState extends ConsumerState<CornerTrackStep> {
             ),
           ],
         ),
-        if (state.blockedMessage != null) ...[
-          const SizedBox(height: AppSpacing.space3),
-          Text(state.blockedMessage!, style: TextStyle(color: colors.danger)),
-        ],
         const SizedBox(height: AppSpacing.space4),
         if (state.corners.isEmpty)
           const Padding(

--- a/frontend/lib/admin/features/setup_wizard/steps/corner_track_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/corner_track_step.dart
@@ -1,0 +1,183 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_state.dart';
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_templates.dart';
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+
+class CornerTrackStep extends ConsumerStatefulWidget {
+  const CornerTrackStep({super.key});
+
+  @override
+  ConsumerState<CornerTrackStep> createState() => _CornerTrackStepState();
+}
+
+class _CornerTrackStepState extends ConsumerState<CornerTrackStep> {
+  final _pasteController = TextEditingController();
+  final _minutesController = TextEditingController(text: '10');
+  final _trackController = TextEditingController(text: '1');
+
+  @override
+  void dispose() {
+    _pasteController.dispose();
+    _minutesController.dispose();
+    _trackController.dispose();
+    super.dispose();
+  }
+
+  void _apply() {
+    final notifier = ref.read(setupWizardProvider.notifier);
+    notifier.setDefaults(
+      targetMinutes: int.tryParse(_minutesController.text),
+      trackCountPerCorner: int.tryParse(_trackController.text),
+    );
+    notifier.parseCornerNames(_pasteController.text);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(setupWizardProvider);
+    final colors = Theme.of(context).brightness == Brightness.dark
+        ? AppColors.dark
+        : AppColors.light;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        const Text('코너 이름을 줄바꿈으로 입력하세요.'),
+        const SizedBox(height: AppSpacing.space3),
+        TextField(
+          controller: _pasteController,
+          maxLines: 5,
+          decoration: const InputDecoration(hintText: '1코너\n2코너'),
+        ),
+        const SizedBox(height: AppSpacing.space3),
+        Wrap(
+          spacing: AppSpacing.space3,
+          runSpacing: AppSpacing.space2,
+          children: [
+            SizedBox(
+              width: 140,
+              child: TextField(
+                controller: _minutesController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: '기본 목표 시간(분)'),
+              ),
+            ),
+            SizedBox(
+              width: 140,
+              child: TextField(
+                controller: _trackController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: '코너당 트랙 수'),
+              ),
+            ),
+            AppButton(
+              variant: AppButtonVariant.secondary,
+              label: '입력 적용',
+              onPressed: _apply,
+            ),
+            AppButton(
+              variant: AppButtonVariant.secondary,
+              label: '예시 10개로 빠르게 시작',
+              onPressed: () {
+                _pasteController.text = kSetupWizardExampleCornerNames.join(
+                  '\n',
+                );
+                ref.read(setupWizardProvider.notifier).applyExampleTemplate();
+              },
+            ),
+          ],
+        ),
+        if (state.blockedMessage != null) ...[
+          const SizedBox(height: AppSpacing.space3),
+          Text(state.blockedMessage!, style: TextStyle(color: colors.danger)),
+        ],
+        const SizedBox(height: AppSpacing.space4),
+        if (state.corners.isEmpty)
+          const Padding(
+            padding: EdgeInsets.all(AppSpacing.space6),
+            child: Center(child: Text('붙여넣거나 예시 템플릿을 사용하세요')),
+          )
+        else
+          ...state.corners.indexed.map(
+            (entry) => _CornerRow(index: entry.$1, row: entry.$2),
+          ),
+        const SizedBox(height: AppSpacing.space6),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            AppButton(
+              variant: AppButtonVariant.secondary,
+              label: '이전',
+              onPressed: () =>
+                  ref.read(setupWizardProvider.notifier).goToStep(0),
+            ),
+            AppButton(
+              variant: AppButtonVariant.primary,
+              label: '다음',
+              onPressed: () => ref
+                  .read(setupWizardProvider.notifier)
+                  .tryAdvanceFromCornerStep(),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _CornerRow extends ConsumerWidget {
+  const _CornerRow({required this.index, required this.row});
+  final int index;
+  final SetupWizardCornerRow row;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) => Padding(
+    padding: const EdgeInsets.only(bottom: AppSpacing.space2),
+    child: Row(
+      children: [
+        Expanded(
+          flex: 3,
+          child: TextFormField(
+            initialValue: row.name,
+            onChanged: (value) => ref
+                .read(setupWizardProvider.notifier)
+                .updateCornerRow(index, name: value),
+            decoration: const InputDecoration(labelText: '코너 이름'),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.space2),
+        Expanded(
+          child: TextFormField(
+            initialValue: '${row.targetMinutes}',
+            keyboardType: TextInputType.number,
+            onChanged: (value) => ref
+                .read(setupWizardProvider.notifier)
+                .updateCornerRow(index, targetMinutes: int.tryParse(value)),
+            decoration: const InputDecoration(labelText: '분'),
+          ),
+        ),
+        const SizedBox(width: AppSpacing.space2),
+        Expanded(
+          child: TextFormField(
+            initialValue: '${row.trackCount}',
+            keyboardType: TextInputType.number,
+            onChanged: (value) => ref
+                .read(setupWizardProvider.notifier)
+                .updateCornerRow(index, trackCount: int.tryParse(value)),
+            decoration: const InputDecoration(labelText: '트랙'),
+          ),
+        ),
+        IconButton(
+          onPressed: () =>
+              ref.read(setupWizardProvider.notifier).removeCornerRow(index),
+          icon: const Icon(Icons.delete_outline),
+          tooltip: '삭제',
+        ),
+      ],
+    ),
+  );
+}

--- a/frontend/lib/admin/features/setup_wizard/steps/review_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/review_step.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_state.dart';
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+
+class ReviewStep extends ConsumerWidget {
+  const ReviewStep({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(setupWizardProvider);
+    final colors = Theme.of(context).brightness == Brightness.dark
+        ? AppColors.dark
+        : AppColors.light;
+    final tracks = state.corners.fold<int>(
+      0,
+      (total, row) => total + row.trackCount,
+    );
+    final hasFailures = state.corners.any(
+      (row) => row.status == SetupWizardCornerStatus.failed,
+    );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text('캠프: ${state.campName}'),
+        Text('기간: ${_dateRange(state.startAt, state.endAt)}'),
+        Text('코너 ${state.corners.length}개 · 트랙 총 $tracks개'),
+        if (state.submitError != null) ...[
+          const SizedBox(height: AppSpacing.space3),
+          Container(
+            padding: const EdgeInsets.all(AppSpacing.space3),
+            color: colors.danger.withValues(alpha: .1),
+            child: Text(
+              state.submitError!,
+              style: TextStyle(color: colors.danger),
+            ),
+          ),
+        ],
+        if (state.isSubmitting || hasFailures) ...[
+          const SizedBox(height: AppSpacing.space4),
+          const Text('생성 상태'),
+          ...state.corners.map(
+            (row) => ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(row.name),
+              subtitle: row.errorMessage == null
+                  ? null
+                  : Text(row.errorMessage!),
+              trailing: _StatusLabel(status: row.status),
+            ),
+          ),
+        ],
+        const SizedBox(height: AppSpacing.space6),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            AppButton(
+              variant: AppButtonVariant.secondary,
+              label: '이전',
+              onPressed: state.isSubmitting
+                  ? null
+                  : () => ref.read(setupWizardProvider.notifier).goToStep(1),
+            ),
+            Stack(
+              alignment: Alignment.center,
+              children: [
+                AppButton(
+                  variant: AppButtonVariant.primary,
+                  label: hasFailures ? '실패한 코너 재시도' : '설정 완료 → 코너·트랙 준비로',
+                  onPressed: state.isSubmitting
+                      ? null
+                      : () async {
+                          final completed = await ref
+                              .read(setupWizardProvider.notifier)
+                              .submit();
+                          if (completed && context.mounted) {
+                            context.go('/corner-track-manage');
+                          }
+                        },
+                ),
+                if (state.isSubmitting)
+                  const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _StatusLabel extends StatelessWidget {
+  const _StatusLabel({required this.status});
+  final SetupWizardCornerStatus status;
+
+  @override
+  Widget build(BuildContext context) => Text(switch (status) {
+    SetupWizardCornerStatus.pending => '대기',
+    SetupWizardCornerStatus.creating => '생성 중',
+    SetupWizardCornerStatus.created => '완료',
+    SetupWizardCornerStatus.failed => '실패',
+  });
+}
+
+String _dateRange(DateTime? start, DateTime? end) {
+  String format(DateTime? value) => value == null
+      ? '미지정'
+      : '${value.year}.${value.month.toString().padLeft(2, '0')}.${value.day.toString().padLeft(2, '0')}';
+  return '${format(start)} ~ ${format(end)}';
+}

--- a/frontend/lib/admin/router/admin_router.dart
+++ b/frontend/lib/admin/router/admin_router.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:cornermon/admin/features/admin_stub_screen.dart';
+import 'package:cornermon/admin/features/login/login_screen.dart';
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_screen.dart';
 import 'package:cornermon/admin/session/admin_session_provider.dart';
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/admin/widgets/admin_scaffold.dart';
@@ -30,8 +32,11 @@ final adminRouterProvider = Provider<GoRouter>((ref) {
     refreshListenable: refresh,
     redirect: (_, state) => _redirect(ref, state.matchedLocation),
     routes: [
-      _plainRoute('/login', 'A0 로그인'),
-      _plainRoute('/setup-wizard', 'A0-b 초기 설정'),
+      GoRoute(path: '/login', builder: (_, _) => const LoginScreen()),
+      GoRoute(
+        path: '/setup-wizard',
+        builder: (_, _) => const SetupWizardScreen(),
+      ),
       _plainRoute('/camps', 'A0-c 캠프 목록'),
       _plainRoute('/camps/start', 'A0-e 코너학습 시작'),
       _plainRoute('/badges', 'A0-d QR 배지'),

--- a/frontend/test/admin/features/setup_wizard/setup_wizard_provider_test.dart
+++ b/frontend/test/admin/features/setup_wizard/setup_wizard_provider_test.dart
@@ -1,0 +1,49 @@
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_state.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('SetupWizard', () {
+    test('parses non-empty lines using current defaults', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+      final notifier = container.read(setupWizardProvider.notifier);
+
+      notifier.setDefaults(targetMinutes: 15, trackCountPerCorner: 2);
+      notifier.parseCornerNames('미술\n\n과학\n음악');
+
+      final state = container.read(setupWizardProvider);
+      expect(state.corners.map((row) => row.name), ['미술', '과학', '음악']);
+      expect(
+        state.corners.every(
+          (row) => row.targetMinutes == 15 && row.trackCount == 2,
+        ),
+        isTrue,
+      );
+    });
+
+    test(
+      'blocks advance without a corner and changes only the requested row',
+      () {
+        final container = ProviderContainer();
+        addTearDown(container.dispose);
+        final notifier = container.read(setupWizardProvider.notifier);
+
+        expect(notifier.tryAdvanceFromCornerStep(), isFalse);
+        expect(
+          container.read(setupWizardProvider).blockedMessage,
+          '코너를 1개 이상 추가하세요',
+        );
+
+        notifier.parseCornerNames('1코너\n2코너');
+        notifier.updateCornerRow(1, targetMinutes: 20, trackCount: 3);
+        final rows = container.read(setupWizardProvider).corners;
+        expect(rows[0].targetMinutes, 10);
+        expect(rows[1].targetMinutes, 20);
+        expect(rows[1].trackCount, 3);
+        expect(rows[0].status, SetupWizardCornerStatus.pending);
+      },
+    );
+  });
+}

--- a/frontend/test/admin/features/setup_wizard/setup_wizard_provider_test.dart
+++ b/frontend/test/admin/features/setup_wizard/setup_wizard_provider_test.dart
@@ -24,17 +24,14 @@ void main() {
     });
 
     test(
-      'blocks advance without a corner and changes only the requested row',
+      'allows advancing without a corner and changes only the requested row',
       () {
         final container = ProviderContainer();
         addTearDown(container.dispose);
         final notifier = container.read(setupWizardProvider.notifier);
 
-        expect(notifier.tryAdvanceFromCornerStep(), isFalse);
-        expect(
-          container.read(setupWizardProvider).blockedMessage,
-          '코너를 1개 이상 추가하세요',
-        );
+        expect(notifier.tryAdvanceFromCornerStep(), isTrue);
+        expect(container.read(setupWizardProvider).step, 2);
 
         notifier.parseCornerNames('1코너\n2코너');
         notifier.updateCornerRow(1, targetMinutes: 20, trackCount: 3);

--- a/frontend/test/admin/router/admin_router_test.dart
+++ b/frontend/test/admin/router/admin_router_test.dart
@@ -68,7 +68,9 @@ void main() {
     adminId: 'admin-1',
   );
 
-  testWidgets('ShouldRedirectUnauthenticatedDashboardRequestToLogin', (tester) async {
+  testWidgets('ShouldRedirectUnauthenticatedDashboardRequestToLogin', (
+    tester,
+  ) async {
     // arrange
     final container = _container(session: const AdminSessionUnauthenticated());
     addTearDown(container.dispose);
@@ -79,19 +81,24 @@ void main() {
     await tester.pumpAndSettle();
 
     // assert
-    expect(find.text('A0 로그인'), findsOneWidget);
+    expect(find.text('코너학습 관리자'), findsOneWidget);
   });
 
-  testWidgets('ShouldRedirectLoginToSetupOrCampListByCampCount', (tester) async {
+  testWidgets('ShouldRedirectLoginToSetupOrCampListByCampCount', (
+    tester,
+  ) async {
     // arrange
     final emptyContainer = _container(session: authenticated);
-    final campContainer = _container(session: authenticated, camps: [_camp(CampStatus.PENDING)]);
+    final campContainer = _container(
+      session: authenticated,
+      camps: [_camp(CampStatus.PENDING)],
+    );
     addTearDown(emptyContainer.dispose);
     addTearDown(campContainer.dispose);
 
     // act & assert
     await _pumpApp(tester, emptyContainer);
-    expect(find.text('A0-b 초기 설정'), findsOneWidget);
+    expect(find.text('초기 설정'), findsOneWidget);
     await tester.pumpWidget(const SizedBox());
     await _pumpApp(tester, campContainer);
     expect(find.text('A0-c 캠프 목록'), findsOneWidget);
@@ -147,9 +154,9 @@ void main() {
     final activeCamp = _camp(CampStatus.ACTIVE);
     final container = ProviderContainer(
       overrides: [
-        campDetailProvider(campId).overrideWith(
-          (ref) => Future<Camp>.error(StateError('재조회하면 안 됩니다.')),
-        ),
+        campDetailProvider(
+          campId,
+        ).overrideWith((ref) => Future<Camp>.error(StateError('재조회하면 안 됩니다.'))),
       ],
     );
     addTearDown(container.dispose);


### PR DESCRIPTION
## 변경 사항
- 관리자 ID/비밀번호 로그인 화면과 401/서버 오류 인라인 상태를 구현했습니다.
- 최초 캠프 생성, 기간 저장, 코너·트랙 순차 생성, 부분 실패 재시도 가능한 3단계 초기 설정 마법사를 추가했습니다.
- 로그인/마법사 실제 화면을 라우터에 연결하고 Riverpod 생성 범위를 관리자 기능까지 확장했습니다.

## 검증
- flutter analyze lib/admin lib/main_admin.dart 통과
- flutter test test/admin 통과
- git diff --check 통과
- flutter test 실행: 기존 진행자 앱이 최신 생성 API 타입과 불일치해 컴파일 실패(예: EMessagesApi, Message, provider family 시그니처). 이번 변경 범위 밖의 기존 문제입니다.

## 종료 조건
- 로그인 성공 시 기존 라우팅 가드가 캠프 유무에 따라 설정 마법사 또는 캠프 목록으로 이동합니다.
- 마법사는 캠프/기간/코너/트랙을 생성하고 실패한 행만 안전하게 재시도합니다.