### PR TITLE
docs: clarify X-Device-Token header format in TrustedDeviceAuth

### DIFF
--- a/backend/internal/infrastructure/web/auth_handler.go
+++ b/backend/internal/infrastructure/web/auth_handler.go
@@ -255,6 +255,7 @@ func (h *AuthHandler) RevokeAdminSession(c echo.Context) error {
 // @Security     TrustedDeviceAuth
 // @Accept       json
 // @Produce      json
+// @Param        X-Device-Token header string true "기기 신뢰 토큰 (opaque token, 값을 그대로 전달)"
 // @Param        request body TrackLoginRequest true "6자리 숫자 트랙 PIN"
 // @Success      200 {object} TrackLoginResponse "로그인 성공 — 트랙 세션 토큰 발급"
 // @Failure      400 {object} ErrorResponse "잘못된 PIN (지연 가능)"

--- a/backend/internal/infrastructure/web/doc.go
+++ b/backend/internal/infrastructure/web/doc.go
@@ -8,8 +8,8 @@ package web
 
 // @securityDefinitions.apikey TrustedDeviceAuth
 // @in header
-// @name Authorization
-// @description 관리자 승인된 기기 신뢰 토큰 (TRUSTED_DEVICE)
+// @name X-Device-Token
+// @description 관리자 승인된 기기 신뢰 토큰 (TRUSTED_DEVICE) — opaque token, 값을 그대로 전달
 
 // @securityDefinitions.apikey TrackAuth
 // @in header


### PR DESCRIPTION
## Summary
- Update TrustedDeviceAuth securityDefinition to use X-Device-Token header instead of Authorization
- Add parameter documentation for X-Device-Token to TrackLogin endpoint
- Clarify that device tokens are opaque and passed as raw values (no Bearer prefix)

## Test plan
- [x] Code compiles
- [x] Swagger spec will regenerate with correct header name

🤖 Generated with [Claude Code](https://claude.com/claude-code)