### PR TITLE
공지사항 목록 조회에 TrackAuth 허용

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -362,6 +362,13 @@ const docTemplate = `{
                 "summary": "진행자 트랙 PIN 로그인",
                 "parameters": [
                     {
+                        "type": "string",
+                        "description": "기기 신뢰 토큰 (opaque token, 값을 그대로 전달)",
+                        "name": "X-Device-Token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
                         "description": "6자리 숫자 트랙 PIN",
                         "name": "request",
                         "in": "body",
@@ -849,9 +856,12 @@ const docTemplate = `{
                 "security": [
                     {
                         "AdminAuth": []
+                    },
+                    {
+                        "TrackAuth": []
                     }
                 ],
-                "description": "관리자가 보낸 BROADCAST 메시지들의 목록을 조회한다.",
+                "description": "관리자 또는 진행자가 캠프에 발송된 BROADCAST 메시지들의 목록을 조회한다.",
                 "produces": [
                     "application/json"
                 ],
@@ -880,6 +890,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -3597,9 +3613,9 @@ const docTemplate = `{
             "in": "header"
         },
         "TrustedDeviceAuth": {
-            "description": "관리자 승인된 기기 신뢰 토큰 (TRUSTED_DEVICE)",
+            "description": "관리자 승인된 기기 신뢰 토큰 (TRUSTED_DEVICE) — opaque token, 값을 그대로 전달",
             "type": "apiKey",
-            "name": "Authorization",
+            "name": "X-Device-Token",
             "in": "header"
         }
     }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -355,6 +355,13 @@
                 "summary": "진행자 트랙 PIN 로그인",
                 "parameters": [
                     {
+                        "type": "string",
+                        "description": "기기 신뢰 토큰 (opaque token, 값을 그대로 전달)",
+                        "name": "X-Device-Token",
+                        "in": "header",
+                        "required": true
+                    },
+                    {
                         "description": "6자리 숫자 트랙 PIN",
                         "name": "request",
                         "in": "body",
@@ -842,9 +849,12 @@
                 "security": [
                     {
                         "AdminAuth": []
+                    },
+                    {
+                        "TrackAuth": []
                     }
                 ],
-                "description": "관리자가 보낸 BROADCAST 메시지들의 목록을 조회한다.",
+                "description": "관리자 또는 진행자가 캠프에 발송된 BROADCAST 메시지들의 목록을 조회한다.",
                 "produces": [
                     "application/json"
                 ],
@@ -873,6 +883,12 @@
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -3590,9 +3606,9 @@
             "in": "header"
         },
         "TrustedDeviceAuth": {
-            "description": "관리자 승인된 기기 신뢰 토큰 (TRUSTED_DEVICE)",
+            "description": "관리자 승인된 기기 신뢰 토큰 (TRUSTED_DEVICE) — opaque token, 값을 그대로 전달",
             "type": "apiKey",
-            "name": "Authorization",
+            "name": "X-Device-Token",
             "in": "header"
         }
     }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -952,6 +952,11 @@ paths:
       - application/json
       description: 신뢰 기기에서 트랙 PIN 으로 로그인하여 트랙 세션 토큰을 발급받는다.
       parameters:
+      - description: 기기 신뢰 토큰 (opaque token, 값을 그대로 전달)
+        in: header
+        name: X-Device-Token
+        required: true
+        type: string
       - description: 6자리 숫자 트랙 PIN
         in: body
         name: request
@@ -1242,7 +1247,7 @@ paths:
       - B. Resource Management (Admin)
   /camps/{campId}/messages/broadcast:
     get:
-      description: 관리자가 보낸 BROADCAST 메시지들의 목록을 조회한다.
+      description: 관리자 또는 진행자가 캠프에 발송된 BROADCAST 메시지들의 목록을 조회한다.
       parameters:
       - description: 캠프 ID
         in: path
@@ -1262,8 +1267,13 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
+      - TrackAuth: []
       summary: 발송된 공지사항 목록
       tags:
       - E. Message
@@ -2320,8 +2330,8 @@ securityDefinitions:
     name: Authorization
     type: apiKey
   TrustedDeviceAuth:
-    description: 관리자 승인된 기기 신뢰 토큰 (TRUSTED_DEVICE)
+    description: 관리자 승인된 기기 신뢰 토큰 (TRUSTED_DEVICE) — opaque token, 값을 그대로 전달
     in: header
-    name: Authorization
+    name: X-Device-Token
     type: apiKey
 swagger: "2.0"

--- a/backend/docs/artifacts/plan/20260715_broadcast_list_track_auth_plan_.md
+++ b/backend/docs/artifacts/plan/20260715_broadcast_list_track_auth_plan_.md
@@ -1,0 +1,120 @@
+# 공지사항 목록 조회(ListBroadcasts) TrackAuth 허용
+
+## 배경
+
+`GET /camps/{campId}/messages/broadcast` (`MessageHandler.ListBroadcasts`)는 현재 `admin` 라우트
+그룹(`AdminAuthMiddleware`)에만 등록되어 있어 관리자 세션이 없으면 미들웨어 단계에서 401로
+막힌다. 진행자(Track) 앱에서도 자신의 캠프 공지사항 목록을 조회해야 하므로 TrackAuth도 허용한다.
+
+공지사항은 캠프 단위 리소스이고 세션 검증은 이미 미들웨어에서 처리하므로, 핸들러/유스케이스에
+캠프-트랙 스코프 매칭 로직을 추가하지 않는다. 유효한 세션(Admin 또는 Facilitator)만 있으면
+요청한 `campId`의 공지사항 목록을 그대로 반환한다.
+
+> 이전 설계안(`AnnouncementUsecase.GetCampIDByTrack` 추가 후 트랙-캠프 스코프 검증)은 폐기.
+> 사유: 세션 유효성은 미들웨어가 이미 보장하고, 공지사항 조회는 트랙 개인정보가 아닌 캠프
+> 단위 공개 정보이므로 usecase 계층에 스코프 검증 책임을 추가할 필요가 없음.
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| **P0** | UC-1: 관리자가 캠프 공지 목록 조회 | AdminSession으로 `campId`의 공지사항 목록 조회 | 프로덕션 핵심 로직 (기존 동작 유지) |
+| **P0** | UC-2: 진행자가 캠프 공지 목록 조회 | FacilitatorSession으로 `campId`의 공지사항 목록 조회 | 프로덕션 핵심 로직 (신규) |
+| P1 | UC-3: 인증 정보 없음 | 토큰 미제공/무효 시 미들웨어 단계에서 401 | 보안 (기존 미들웨어 그대로 적용) |
+
+## 기존 코드 확인 사항
+
+- `MessageAuthMiddleware` (`auth_middleware.go:63`)는 Admin/Facilitator 토큰을 모두 시도하여
+  성공한 세션을 `c.Set("adminSession", ...)` 또는 `c.Set("facilitatorSession", ...)`로 저장한다.
+  이미 `GET /tracks/:trackId/messages`, `GET /tracks/:trackId/messages/unread-count`가 이 패턴으로
+  `message` 그룹(`router.go:119-122`)에 등록되어 있다.
+- Echo는 동일 method+path를 두 그룹에 중복 등록할 수 없으므로(`router.go:117` 주석 참고),
+  `GET /camps/:campId/messages/broadcast`를 `admin` 그룹에서 제거하고 `message` 그룹으로 옮긴다.
+- `MessageHandler.ListBroadcasts` (`message_handler.go:106`) 자체는 세션 종류를 구분하지 않고
+  이미 `campID` 하나로 `ListNoticesByCamp`를 호출하므로 **핸들러 코드 변경 불필요**.
+- `AnnouncementUsecase`, `AnnouncementService`(`usecase/announcement.go`) 변경 불필요.
+
+## 설계
+
+### 1. 라우팅 변경 (유일한 코드 변경)
+
+```go
+// backend/internal/infrastructure/web/router.go
+
+// ── E. Message (Admin) ──
+if h.Message != nil {
+    admin.POST("/camps/:campId/messages/broadcast", h.Message.SendBroadcast)
+    // 제거: admin.GET("/camps/:campId/messages/broadcast", h.Message.ListBroadcasts)
+    admin.GET("/messages/broadcast/:id/receipts", h.Message.GetBroadcastReceipts)
+    admin.POST("/tracks/:trackId/messages", h.Message.SendDirect)
+
+    // Both administrator and facilitator sessions may access these paths.
+    message := v1.Group("")
+    message.Use(MessageAuthMiddleware(adminAuth, trackAuth))
+    message.GET("/camps/:campId/messages/broadcast", h.Message.ListBroadcasts) // 이동
+    message.GET("/tracks/:trackId/messages", h.Message.ListDirectMessages)
+    message.GET("/tracks/:trackId/messages/unread-count", h.Message.GetUnreadCount)
+}
+```
+
+### 2. Swagger 주석 갱신
+
+`ListBroadcasts` 주석에 `@Security TrackAuth` 추가 (핸들러 로직은 불변, 주석만 갱신).
+
+```go
+// @Summary      발송된 공지사항 목록
+// @Description  관리자 또는 진행자가 캠프에 발송된 BROADCAST 메시지들의 목록을 조회한다.
+// @Tags         E. Message
+// @Security     AdminAuth
+// @Security     TrackAuth
+// @Produce      json
+// @Param        campId path string true "캠프 ID"
+// @Success      200 {array} MessageResponse
+// @Failure      400 {object} ErrorResponse
+// @Failure      401 {object} ErrorResponse
+// @Router       /camps/{campId}/messages/broadcast [get]
+func (h *MessageHandler) ListBroadcasts(c echo.Context) error {
+    // 기존 코드 그대로 유지 — 변경 없음
+}
+```
+
+### 3. 변경 없는 항목 (명시적 확인용)
+
+- `AnnouncementUsecase` 인터페이스: 변경 없음
+- `AnnouncementService`: 변경 없음
+- `domain` 패키지: 변경 없음
+- `MessageHandler.ListBroadcasts` 함수 본문: 변경 없음 (라우팅 위치만 이동)
+
+## 검증 항목
+
+### 아키텍처 검증
+- [x] `domain`/`usecase` 패키지 diff 없음
+- [x] 라우팅 외 핸들러 로직 diff 없음 (swagger 주석만 갱신)
+- [x] `router.go`에서 `GET /camps/:campId/messages/broadcast`가 `admin` 그룹에서 제거되고
+      `message` 그룹(`MessageAuthMiddleware`)으로 이동, 중복 등록 없음
+
+### 유즈케이스 검증 (테스트 케이스)
+- [x] UC-1: AdminSession으로 `GET /camps/{campId}/messages/broadcast` 호출 시 200 + 목록 반환 (회귀)
+      — `TestListBroadcastsShoudReturnNoticesWhenAdminSessionPresent`,
+      `TestListBroadcastsRouteShoudAuthenticateBothAdminAndTrackSessions/admin`
+- [x] UC-2: FacilitatorSession으로 동일 엔드포인트 호출 시 200 + 목록 반환 (신규)
+      — `TestListBroadcastsShoudReturnNoticesWhenFacilitatorSessionPresent`,
+      `TestListBroadcastsRouteShoudAuthenticateBothAdminAndTrackSessions/track`
+- [x] UC-3: 토큰 없이 호출 시 401 — `TestListBroadcastsRouteShoudRejectRequestWithoutSession`
+
+### API 문서
+- [x] `api/swagger.yaml`(`api/openapi.yaml`은 이 저장소에 없음 — swag 생성 소스가 `api/swagger.yaml`)
+  `/camps/{campId}/messages/broadcast` GET의 `security`에 TrackAuth 추가
+  (`swag init -g internal/infrastructure/web/doc.go -o ../api --parseDependency --parseInternal`로 재생성)
+- [x] swag 주석과 swagger.yaml/json/docs.go 정합성 확인 완료 (재생성 시 이전 미반영분인
+  X-Device-Token 헤더 수정 diff도 함께 동기화됨 — 별도 커밋으로 분리)
+
+## 결과
+
+- 변경 파일: `backend/internal/infrastructure/web/router.go`,
+  `backend/internal/infrastructure/web/message_handler.go` (swagger 주석만),
+  `backend/internal/infrastructure/web/message_handler_test.go`,
+  `backend/internal/infrastructure/web/router_test.go`,
+  `api/swagger.yaml`, `api/swagger.json`, `api/docs.go` (자동 생성)
+- `go build ./...`, `go vet ./...`, `go test ./...` 전체 통과
+- `gofmt -l`로 변경 파일 포맷 확인 완료

--- a/backend/internal/infrastructure/web/message_handler.go
+++ b/backend/internal/infrastructure/web/message_handler.go
@@ -95,13 +95,15 @@ func (h *MessageHandler) SendBroadcast(c echo.Context) error {
 }
 
 // @Summary      발송된 공지사항 목록
-// @Description  관리자가 보낸 BROADCAST 메시지들의 목록을 조회한다.
+// @Description  관리자 또는 진행자가 캠프에 발송된 BROADCAST 메시지들의 목록을 조회한다.
 // @Tags         E. Message
 // @Security     AdminAuth
+// @Security     TrackAuth
 // @Produce      json
 // @Param        campId path string true "캠프 ID"
 // @Success      200 {array} MessageResponse
 // @Failure      400 {object} ErrorResponse
+// @Failure      401 {object} ErrorResponse
 // @Router       /camps/{campId}/messages/broadcast [get]
 func (h *MessageHandler) ListBroadcasts(c echo.Context) error {
 	campID := domain.CampID(c.Param("campId"))

--- a/backend/internal/infrastructure/web/message_handler_test.go
+++ b/backend/internal/infrastructure/web/message_handler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/usecase"
 
 	"github.com/labstack/echo/v4"
 )
@@ -32,6 +33,72 @@ func (m *messageUsecaseForHandler) ListDirectMessages(_ context.Context, _ domai
 
 func (m *messageUsecaseForHandler) GetUnreadCount(context.Context, domain.TrackID, domain.SenderRole) (int, error) {
 	return 0, nil
+}
+
+type announcementUsecaseForHandler struct {
+	notices []*domain.Announcement
+}
+
+func (a *announcementUsecaseForHandler) SendAnnouncement(context.Context, domain.CampID, string, domain.AdminID) (*domain.Announcement, error) {
+	return nil, nil
+}
+
+func (a *announcementUsecaseForHandler) ListNoticesByCamp(context.Context, domain.CampID) ([]*domain.Announcement, error) {
+	return a.notices, nil
+}
+
+func (a *announcementUsecaseForHandler) GetAnnouncementReceipts(context.Context, domain.AnnouncementID) ([]usecase.BroadcastReceiptDTO, error) {
+	return nil, nil
+}
+
+func (a *announcementUsecaseForHandler) MarkNoticeRead(context.Context, string, domain.AnnouncementID) error {
+	return nil
+}
+
+func TestListBroadcastsShoudReturnNoticesWhenAdminSessionPresent(t *testing.T) {
+	// Arrange
+	uc := &announcementUsecaseForHandler{notices: []*domain.Announcement{{ID: "notice-1", CampID: "camp-1", Content: "hello"}}}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/camps/camp-1/messages/broadcast", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("campId")
+	c.SetParamValues("camp-1")
+	c.Set("adminSession", &domain.AdminSession{AdminID: "admin-1"})
+
+	// Act
+	err := NewMessageHandler(&messageUsecaseForHandler{}, uc).ListBroadcasts(c)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestListBroadcastsShoudReturnNoticesWhenFacilitatorSessionPresent(t *testing.T) {
+	// Arrange
+	uc := &announcementUsecaseForHandler{notices: []*domain.Announcement{{ID: "notice-1", CampID: "camp-1", Content: "hello"}}}
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/camps/camp-1/messages/broadcast", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("campId")
+	c.SetParamValues("camp-1")
+	c.Set("facilitatorSession", &domain.FacilitatorSession{TrackID: "track-1"})
+
+	// Act
+	err := NewMessageHandler(&messageUsecaseForHandler{}, uc).ListBroadcasts(c)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
 }
 
 func TestListDirectMessagesShoudRejectRequestWhenSessionTrackDiffers(t *testing.T) {

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -109,7 +109,6 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 	// ── E. Message (Admin) ──
 	if h.Message != nil {
 		admin.POST("/camps/:campId/messages/broadcast", h.Message.SendBroadcast)
-		admin.GET("/camps/:campId/messages/broadcast", h.Message.ListBroadcasts)
 		admin.GET("/messages/broadcast/:id/receipts", h.Message.GetBroadcastReceipts)
 		admin.POST("/tracks/:trackId/messages", h.Message.SendDirect)
 
@@ -118,6 +117,7 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 		// before group middleware is evaluated.
 		message := v1.Group("")
 		message.Use(MessageAuthMiddleware(adminAuth, trackAuth))
+		message.GET("/camps/:campId/messages/broadcast", h.Message.ListBroadcasts)
 		message.GET("/tracks/:trackId/messages", h.Message.ListDirectMessages)
 		message.GET("/tracks/:trackId/messages/unread-count", h.Message.GetUnreadCount)
 	}

--- a/backend/internal/infrastructure/web/router_test.go
+++ b/backend/internal/infrastructure/web/router_test.go
@@ -61,3 +61,48 @@ func TestMessageRoutesShoudAuthenticateAdminAndTrackWithoutDuplicateRouteRegistr
 		})
 	}
 }
+
+func TestListBroadcastsRouteShoudAuthenticateBothAdminAndTrackSessions(t *testing.T) {
+	// Arrange
+	announcementUC := &announcementUsecaseForHandler{notices: []*domain.Announcement{{ID: "notice-1", CampID: "camp-1", Content: "hello"}}}
+	e := echo.New()
+	RegisterRoutes(e, &Handlers{Auth: &AuthHandler{}, Device: &DeviceHandler{}, Message: NewMessageHandler(&messageUsecaseForHandler{}, announcementUC)}, adminAuthForMessageRoutes{}, trackAuthForMessageRoutes{})
+
+	for _, tc := range []struct {
+		name  string
+		token string
+	}{
+		{name: "admin", token: "admin-token"},
+		{name: "track", token: "track-token"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Act
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/camps/camp-1/messages/broadcast", nil)
+			req.Header.Set(echo.HeaderAuthorization, "Bearer "+tc.token)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			// Assert
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestListBroadcastsRouteShoudRejectRequestWithoutSession(t *testing.T) {
+	// Arrange
+	announcementUC := &announcementUsecaseForHandler{}
+	e := echo.New()
+	RegisterRoutes(e, &Handlers{Auth: &AuthHandler{}, Device: &DeviceHandler{}, Message: NewMessageHandler(&messageUsecaseForHandler{}, announcementUC)}, adminAuthForMessageRoutes{}, trackAuthForMessageRoutes{})
+
+	// Act
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/camps/camp-1/messages/broadcast", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected status 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- `GET /camps/{campId}/messages/broadcast`를 관리자 전용에서 관리자/진행자 공용 라우트로 변경
- 세션 검증은 기존 `MessageAuthMiddleware`가 담당하므로 핸들러/유스케이스 로직은 변경 없음
- 기존 `ListDirectMessages`/`GetUnreadCount`와 동일한 패턴으로 `admin` 라우트 그룹에서 `message` 그룹으로 라우팅만 이동
- swag 재생성 결과 이전 커밋(X-Device-Token 헤더 수정)에서 미반영이던 swagger 정의도 함께 동기화됨

## Plan
`backend/docs/artifacts/plan/20260715_broadcast_list_track_auth_plan_.md`

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` 전체 통과
- [x] `gofmt -l` 변경 파일 포맷 확인
- [x] UC-1: AdminSession으로 조회 시 200 (`TestListBroadcastsShoudReturnNoticesWhenAdminSessionPresent`, `TestListBroadcastsRouteShoudAuthenticateBothAdminAndTrackSessions/admin`)
- [x] UC-2: FacilitatorSession으로 조회 시 200 (`TestListBroadcastsShoudReturnNoticesWhenFacilitatorSessionPresent`, `TestListBroadcastsRouteShoudAuthenticateBothAdminAndTrackSessions/track`)
- [x] UC-3: 세션 없이 조회 시 401 (`TestListBroadcastsRouteShoudRejectRequestWithoutSession`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)