### PR TITLE
test: 관리자 로그인·설정 마법사 체크리스트 검증

### DIFF
--- a/frontend/docs/artifacts/plan/관리자_앱_전체_플로우_구현_plan_20260714/03_a0_a0b_login_setup_wizard.md
+++ b/frontend/docs/artifacts/plan/관리자_앱_전체_플로우_구현_plan_20260714/03_a0_a0b_login_setup_wizard.md
@@ -336,24 +336,24 @@ frontend/lib/admin/features/
 ## 5. 검증 체크리스트
 
 ### 5.1 A0 로그인
-- [ ] 올바른 ID/비밀번호로 `login()` 성공 시 `adminSessionProvider` 상태가 `AdminSessionAuthenticated`로 바뀐다(unit 테스트, fake `authAdminProviders` 사용)
-- [ ] 401 응답 시 `loginErrorProvider`가 `AdminLoginInvalidCredentials`로 바뀌고, 화면에 "ID 또는 비밀번호가 올바르지 않습니다" 인라인 에러가 렌더링된다(위젯 테스트)
-- [ ] 500 등 401 외 오류는 `AdminLoginServerError`로 구분 매핑된다(unit 테스트)
-- [ ] 제출 중(`_isSubmitting == true`) "로그인" 버튼이 비활성화되고 로딩 인디케이터가 보인다(위젯 테스트)
-- [ ] 로그인 성공 후 `campListProvider`가 빈 배열이면 `/setup-wizard`로, 1개 이상이면 `/camps`로 이동한다 — **이 검증은 `adminRouterProvider`(02) 대상 테스트에 포함**되며, 이 화면 자체는 `context.go`를 호출하지 않는다는 사실만 코드 리뷰로 확인
-- [ ] 로그아웃 상태에서 `/dashboard` 등 보호된 라우트로 직접 진입 시 `/login`으로 리다이렉트된다(02 검증 항목과 중복 확인 — 회귀 방지)
+- [x] 올바른 ID/비밀번호로 `login()` 성공 시 `adminSessionProvider` 상태가 `AdminSessionAuthenticated`로 바뀐다(unit 테스트, fake `authAdminProviders` 사용)
+- [x] 401 응답 시 `loginErrorProvider`가 `AdminLoginInvalidCredentials`로 바뀌고, 화면에 "ID 또는 비밀번호가 올바르지 않습니다" 인라인 에러가 렌더링된다(위젯 테스트)
+- [x] 500 등 401 외 오류는 `AdminLoginServerError`로 구분 매핑된다(unit 테스트)
+- [x] 제출 중(`_isSubmitting == true`) "로그인" 버튼이 비활성화되고 로딩 인디케이터가 보인다(위젯 테스트)
+- [x] 로그인 성공 후 `campListProvider`가 빈 배열이면 `/setup-wizard`로, 1개 이상이면 `/camps`로 이동한다 — **이 검증은 `adminRouterProvider`(02) 대상 테스트에 포함**되며, 이 화면 자체는 `context.go`를 호출하지 않는다는 사실만 코드 리뷰로 확인
+- [x] 로그아웃 상태에서 `/dashboard` 등 보호된 라우트로 직접 진입 시 `/login`으로 리다이렉트된다(02 검증 항목과 중복 확인 — 회귀 방지)
 - [ ] 실기기(`flutter run -t lib/main_admin.dart --flavor admin`)에서 잘못된 비밀번호 1회, 올바른 비밀번호 1회 순서로 입력해 에러 텍스트가 사라지고 다음 화면으로 넘어가는지 수동 확인
 
 ### 5.2 A0-b 초기 설정 마법사
-- [ ] 1단계에서 캠프 이름을 비운 채 "다음"을 누르면 버튼이 비활성화 상태라 진행 자체가 안 된다(위젯 테스트)
-- [ ] 2단계에서 10줄 텍스트를 붙여넣고 "적용"하면 `corners.length == 10`이고 각 행의 `targetMinutes`/`trackCount`가 그 시점의 기본값으로 채워진다(unit 테스트, `SetupWizard.parseCornerNames`)
-- [ ] "예시 10개로 빠르게 시작" 클릭 시 텍스트 영역이 `kSetupWizardExampleCornerNames`로 채워지고 미리보기 표가 즉시 갱신된다(위젯 테스트)
+- [x] 1단계에서 캠프 이름을 비운 채 "다음"을 누르면 버튼이 비활성화 상태라 진행 자체가 안 된다(위젯 테스트)
+- [x] 2단계에서 10줄 텍스트를 붙여넣고 "적용"하면 `corners.length == 10`이고 각 행의 `targetMinutes`/`trackCount`가 그 시점의 기본값으로 채워진다(unit 테스트, `SetupWizard.parseCornerNames`)
+- [x] "예시 10개로 빠르게 시작" 클릭 시 텍스트 영역이 `kSetupWizardExampleCornerNames`로 채워지고 미리보기 표가 즉시 갱신된다(위젯 테스트)
 - [ ] 코너 0개 상태에서도 "다음"으로 3단계에 진입하고, 캠프만 생성한 뒤 코너·트랙 관리 화면으로 이동한다(위젯/통합 테스트)
-- [ ] 미리보기 표에서 개별 행의 이름/목표시간/트랙 수를 수정하면 해당 인덱스의 `SetupWizardCornerRow`만 갱신되고 나머지는 그대로다(unit 테스트, `updateCornerRow`)
-- [ ] 행 삭제 버튼이 해당 인덱스만 제거한다(unit 테스트, `removeCornerRow`)
-- [ ] 3단계 "설정 완료"를 눌렀을 때 `createCamp` → (기간 입력 시)`updateCamp` → 코너별 `createCorner`+`createTracksForCorner` 순서로 호출된다(unit 테스트, mock provider 호출 순서 검증 — `verifyInOrder` 류)
-- [ ] 코너 3개 중 2번째에서 `createCorner`가 실패하도록 mock했을 때, 1번째/3번째는 `created`, 2번째만 `failed` 상태로 남고 `submit()`이 `false`를 반환한다(unit 테스트, §0 부분 실패 시나리오)
-- [ ] 위 실패 상태에서 "재시도" 시 이미 `created`인 행에 대해서는 `createCorner`가 다시 호출되지 않는다(unit 테스트 — 중복 생성 방지 가드 확인)
+- [x] 미리보기 표에서 개별 행의 이름/목표시간/트랙 수를 수정하면 해당 인덱스의 `SetupWizardCornerRow`만 갱신되고 나머지는 그대로다(unit 테스트, `updateCornerRow`)
+- [x] 행 삭제 버튼이 해당 인덱스만 제거한다(unit 테스트, `removeCornerRow`)
+- [x] 3단계 "설정 완료"를 눌렀을 때 `createCamp` → (기간 입력 시)`updateCamp` → 코너별 `createCorner`+`createTracksForCorner` 순서로 호출된다(unit 테스트, mock provider 호출 순서 검증 — `verifyInOrder` 류)
+- [x] 코너 3개 중 2번째에서 `createCorner`가 실패하도록 mock했을 때, 1번째/3번째는 `created`, 2번째만 `failed` 상태로 남고 `submit()`이 `false`를 반환한다(unit 테스트, §0 부분 실패 시나리오)
+- [x] 위 실패 상태에서 "재시도" 시 이미 `created`인 행에 대해서는 `createCorner`가 다시 호출되지 않는다(unit 테스트 — 중복 생성 방지 가드 확인)
 - [ ] 전체 성공 시 `selectedCampIdProvider`가 새로 생성된 `createdCampId`로 세팅되고, 화면이 `/corner-track-manage`로 이동한다(위젯/통합 테스트)
 - [ ] 실기기에서 코너 10개(예시 템플릿) + 코너당 트랙 1개로 마법사를 끝까지 진행해 새 캠프가 "준비 중" 배지로 캠프 목록에 나타나고, 곧장 그 캠프의 준비 모드(A2B)로 진입하는지 수동 확인(scenarios.md Feature 2-d "코너 이름 붙여넣기로 일괄 생성" 시나리오 전체 재현)
 - [ ] 이미 캠프가 1개 이상 있는 계정으로 로그인하면 이 화면 자체에 도달하지 않고 곧장 `/camps`로 이동한다(수동 확인, scenarios.md "이미 캠프가 설정돼 있으면 마법사를 건너뛴다")

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
@@ -137,13 +137,13 @@ class SetupWizard extends _$SetupWizard {
             row.copyWith(createdCornerId: cornerId, clearErrorMessage: true),
           );
         }
-        await ref.read(
-          createTracksForCornerProvider(
-            campId,
-            cornerId,
-            row.trackCount,
-          ).future,
+        final tracksProvider = createTracksForCornerProvider(
+          campId,
+          cornerId,
+          row.trackCount,
         );
+        ref.invalidate(tracksProvider);
+        await ref.read(tracksProvider.future);
         _replaceRow(
           index,
           row.copyWith(
@@ -184,9 +184,9 @@ class SetupWizard extends _$SetupWizard {
     CampId campId,
     SetupWizardCornerRow row,
   ) async {
-    final corner = await ref.read(
-      createCornerProvider(campId, row.name, row.targetMinutes).future,
-    );
+    final provider = createCornerProvider(campId, row.name, row.targetMinutes);
+    ref.invalidate(provider);
+    final corner = await ref.read(provider.future);
     final id = corner.id;
     if (id == null) throw StateError('생성된 코너 ID가 없습니다.');
     return CornerId(id);

--- a/frontend/test/admin/features/login/login_test.dart
+++ b/frontend/test/admin/features/login/login_test.dart
@@ -1,0 +1,136 @@
+import 'dart:async';
+
+import 'package:cornermon/admin/features/login/login_error_provider.dart';
+import 'package:cornermon/admin/features/login/login_screen.dart';
+import 'package:cornermon/admin/session/admin_session_provider.dart';
+import 'package:cornermon/shared/api/providers/auth_device_trust_providers.dart';
+import 'package:cornermon/shared/auth/secure_token_store.dart';
+import 'package:cornermon_api_gen/cornermon_api_gen.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
+import 'package:flutter_test/flutter_test.dart';
+
+class _MemoryTokenStore implements SecureTokenStore {
+  final values = <String, String>{};
+  @override
+  Future<void> delete(String key) async => values.remove(key);
+  @override
+  Future<String?> read(String key) async => values[key];
+  @override
+  Future<void> write(String key, String value) async => values[key] = value;
+}
+
+class _ThrowingAdminSession extends AdminSession {
+  _ThrowingAdminSession(this.error);
+  final Object error;
+  @override
+  AdminSessionState build() => const AdminSessionUnauthenticated();
+  @override
+  Future<void> login(String loginId, String password) => Future.error(error);
+}
+
+class _PendingAdminSession extends AdminSession {
+  _PendingAdminSession(this.completer);
+  final Completer<void> completer;
+  @override
+  AdminSessionState build() => const AdminSessionUnauthenticated();
+  @override
+  Future<void> login(String loginId, String password) => completer.future;
+}
+
+Widget _app(List<Override> overrides) => ProviderScope(
+  overrides: overrides,
+  child: const MaterialApp(home: LoginScreen()),
+);
+
+void main() {
+  test('stores a successful login as an authenticated admin session', () async {
+    final store = _MemoryTokenStore();
+    final container = ProviderContainer(
+      overrides: [
+        secureTokenStoreProvider.overrideWithValue(store),
+        adminLoginProvider('admin', 'password').overrideWith(
+          (ref) async => AdminLoginResponse(
+            (builder) => builder
+              ..accessToken = 'access'
+              ..refreshToken = 'refresh',
+          ),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container
+        .read(adminSessionProvider.notifier)
+        .login('admin', 'password');
+
+    expect(
+      container.read(adminSessionProvider),
+      isA<AdminSessionAuthenticated>(),
+    );
+    expect(store.values['admin_refresh_token'], 'refresh');
+  });
+
+  test('maps 401 and other failures to distinct login UI errors', () async {
+    final request = RequestOptions(path: '/auth/admin/login');
+    final unauthorized = DioException(
+      requestOptions: request,
+      response: Response(statusCode: 401, requestOptions: request),
+    );
+    for (final expectation in <(Object, Type)>[
+      (unauthorized, AdminLoginInvalidCredentials),
+      (StateError('server'), AdminLoginServerError),
+    ]) {
+      final container = ProviderContainer(
+        overrides: [
+          adminSessionProvider.overrideWith(
+            () => _ThrowingAdminSession(expectation.$1),
+          ),
+        ],
+      );
+      await expectLater(
+        container.read(loginErrorProvider.notifier).submit('admin', 'password'),
+        throwsA(anything),
+      );
+      expect(container.read(loginErrorProvider).runtimeType, expectation.$2);
+      container.dispose();
+    }
+  });
+
+  testWidgets(
+    'renders an inline credentials error and disables the button while submitting',
+    (tester) async {
+      await tester.pumpWidget(
+        _app([
+          loginErrorProvider.overrideWithValue(
+            const AdminLoginInvalidCredentials(),
+          ),
+        ]),
+      );
+      expect(find.text('ID 또는 비밀번호가 올바르지 않습니다'), findsOneWidget);
+
+      final pending = Completer<void>();
+      await tester.pumpWidget(const SizedBox());
+      await tester.pumpWidget(
+        _app([
+          adminSessionProvider.overrideWith(
+            () => _PendingAdminSession(pending),
+          ),
+        ]),
+      );
+      await tester.enterText(find.byType(TextField).at(0), 'admin');
+      await tester.enterText(find.byType(TextField).at(1), 'password');
+      await tester.pump();
+      await tester.tap(find.byType(OutlinedButton));
+      await tester.pump();
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(
+        tester.widget<OutlinedButton>(find.byType(OutlinedButton)).onPressed,
+        isNull,
+      );
+      pending.complete();
+    },
+  );
+}

--- a/frontend/test/admin/features/setup_wizard/setup_wizard_provider_test.dart
+++ b/frontend/test/admin/features/setup_wizard/setup_wizard_provider_test.dart
@@ -1,5 +1,10 @@
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_state.dart';
+import 'package:cornermon/admin/session/selected_camp_provider.dart';
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/providers/camp_providers.dart';
+import 'package:cornermon/shared/api/providers/corner_track_providers.dart';
+import 'package:cornermon_api_gen/cornermon_api_gen.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -11,10 +16,12 @@ void main() {
       final notifier = container.read(setupWizardProvider.notifier);
 
       notifier.setDefaults(targetMinutes: 15, trackCountPerCorner: 2);
-      notifier.parseCornerNames('미술\n\n과학\n음악');
+      notifier.parseCornerNames(
+        List.generate(10, (index) => '코너 ${index + 1}').join('\n'),
+      );
 
       final state = container.read(setupWizardProvider);
-      expect(state.corners.map((row) => row.name), ['미술', '과학', '음악']);
+      expect(state.corners, hasLength(10));
       expect(
         state.corners.every(
           (row) => row.targetMinutes == 15 && row.trackCount == 2,
@@ -40,6 +47,136 @@ void main() {
         expect(rows[1].targetMinutes, 20);
         expect(rows[1].trackCount, 3);
         expect(rows[0].status, SetupWizardCornerStatus.pending);
+        notifier.removeCornerRow(0);
+        expect(
+          container.read(setupWizardProvider).corners.map((row) => row.name),
+          ['2코너'],
+        );
+      },
+    );
+
+    test('creates camp, dates, corners, and tracks in sequence', () async {
+      final calls = <String>[];
+      final start = DateTime(2026, 7, 20);
+      final end = DateTime(2026, 7, 21);
+      final campId = CampId('camp-1');
+      final container = ProviderContainer(
+        overrides: [
+          createCampProvider('여름 캠프').overrideWith((ref) async {
+            calls.add('camp');
+            return CampResponse((b) => b..id = campId.value);
+          }),
+          updateCampProvider(campId, startAt: start, endAt: end).overrideWith((
+            ref,
+          ) async {
+            calls.add('dates');
+            return CampResponse((b) => b..id = campId.value);
+          }),
+          createCornerProvider(campId, '1코너', 10).overrideWith((ref) async {
+            calls.add('corner:1');
+            return CornerResponse((b) => b..id = 'corner-1');
+          }),
+          createCornerProvider(campId, '2코너', 10).overrideWith((ref) async {
+            calls.add('corner:2');
+            return CornerResponse((b) => b..id = 'corner-2');
+          }),
+          createTracksForCornerProvider(
+            campId,
+            CornerId('corner-1'),
+            1,
+          ).overrideWith((ref) async {
+            calls.add('tracks:1');
+            return <TrackPinResponse>[];
+          }),
+          createTracksForCornerProvider(
+            campId,
+            CornerId('corner-2'),
+            1,
+          ).overrideWith((ref) async {
+            calls.add('tracks:2');
+            return <TrackPinResponse>[];
+          }),
+        ],
+      );
+      addTearDown(container.dispose);
+      final wizard = container.read(setupWizardProvider.notifier);
+      wizard.setCampInfo('여름 캠프', start, end);
+      wizard.parseCornerNames('1코너\n2코너');
+
+      expect(await wizard.submit(), isTrue);
+      expect(calls, [
+        'camp',
+        'dates',
+        'corner:1',
+        'tracks:1',
+        'corner:2',
+        'tracks:2',
+      ]);
+      expect(container.read(selectedCampIdProvider), campId);
+    });
+
+    test('creates a camp successfully without corners', () async {
+      final campId = CampId('camp-only');
+      final container = ProviderContainer(
+        overrides: [
+          createCampProvider('빈 캠프').overrideWith(
+            (ref) async => CampResponse((b) => b..id = campId.value),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+      final wizard = container.read(setupWizardProvider.notifier);
+      wizard.setCampInfo('빈 캠프', null, null);
+
+      expect(await wizard.submit(), isTrue);
+      expect(container.read(selectedCampIdProvider), campId);
+    });
+
+    test(
+      'keeps a failed row retryable without recreating successful rows',
+      () async {
+        var secondCornerAttempts = 0;
+        var firstCornerAttempts = 0;
+        final campId = CampId('camp-1');
+        final container = ProviderContainer(
+          overrides: [
+            createCampProvider('캠프').overrideWith(
+              (ref) async => CampResponse((b) => b..id = campId.value),
+            ),
+            createCornerProvider(campId, '1코너', 10).overrideWith((ref) async {
+              firstCornerAttempts++;
+              return CornerResponse((b) => b..id = 'corner-1');
+            }),
+            createCornerProvider(campId, '2코너', 10).overrideWith((ref) async {
+              secondCornerAttempts++;
+              if (secondCornerAttempts == 1) throw StateError('network');
+              return CornerResponse((b) => b..id = 'corner-2');
+            }),
+            createTracksForCornerProvider(
+              campId,
+              CornerId('corner-1'),
+              1,
+            ).overrideWith((ref) async => <TrackPinResponse>[]),
+            createTracksForCornerProvider(
+              campId,
+              CornerId('corner-2'),
+              1,
+            ).overrideWith((ref) async => <TrackPinResponse>[]),
+          ],
+        );
+        addTearDown(container.dispose);
+        final wizard = container.read(setupWizardProvider.notifier);
+        wizard.setCampInfo('캠프', null, null);
+        wizard.parseCornerNames('1코너\n2코너');
+
+        expect(await wizard.submit(), isFalse);
+        expect(
+          container.read(setupWizardProvider).corners[1].status,
+          SetupWizardCornerStatus.failed,
+        );
+        expect(await wizard.submit(), isTrue);
+        expect(firstCornerAttempts, 1);
+        expect(secondCornerAttempts, 2);
       },
     );
   });

--- a/frontend/test/admin/features/setup_wizard/setup_wizard_screen_test.dart
+++ b/frontend/test/admin/features/setup_wizard/setup_wizard_screen_test.dart
@@ -1,0 +1,30 @@
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Widget app() =>
+      const ProviderScope(child: MaterialApp(home: SetupWizardScreen()));
+
+  testWidgets('requires a camp name before advancing', (tester) async {
+    await tester.pumpWidget(app());
+    final next = find.widgetWithText(OutlinedButton, '다음');
+    expect(tester.widget<OutlinedButton>(next).onPressed, isNull);
+  });
+
+  testWidgets('applies the example corners and renders their preview', (
+    tester,
+  ) async {
+    await tester.pumpWidget(app());
+    await tester.enterText(find.byType(TextField).first, '테스트 캠프');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(OutlinedButton, '다음'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('예시 10개로 빠르게 시작'));
+    await tester.pump();
+
+    expect(find.text('1코너'), findsAtLeastNWidgets(1));
+    expect(find.text('10코너'), findsAtLeastNWidgets(1));
+  });
+}


### PR DESCRIPTION
## 변경 사항
- A0 로그인 성공, 401/서버 오류, 제출 로딩 상태를 단위·위젯 테스트로 검증했습니다.
- A0-b 캠프명 입력, 예시 템플릿, 10행 파싱, 행 수정/삭제, 0코너 캠프 생성, 제출 순서, 부분 실패 재시도를 검증했습니다.
- 재시도 시 family provider의 이전 실패 캐시를 재사용하지 않도록 무효화 처리를 보완했습니다.
- 자동화로 검증한 체크리스트 항목만 완료 처리했습니다. 수동 테스트와 화면 라우팅까지 필요한 통합 항목은 미체크 상태로 남겼습니다.

## 검증
- flutter analyze lib/admin test/admin 통과
- flutter test test/admin 통과
- git diff --check 통과