### PR TITLE
Remove admin refresh token, add sliding access-token session

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -155,7 +155,7 @@ const docTemplate = `{
         },
         "/auth/admin/login": {
             "post": {
-                "description": "관리자 ID/비밀번호로 로그인하여 액세스 토큰과 리프레시 토큰을 발급받는다.",
+                "description": "관리자 ID/비밀번호로 로그인하여 액세스 토큰을 발급받는다. 토큰은 슬라이딩 세션으로 활동이 있으면 만료가 연장된다.",
                 "consumes": [
                     "application/json"
                 ],
@@ -211,37 +211,6 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "로그아웃 성공"
-                    },
-                    "401": {
-                        "description": "권한 없음",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/admin/refresh": {
-            "post": {
-                "security": [
-                    {
-                        "AdminRefreshAuth": []
-                    }
-                ],
-                "description": "리프레시 토큰으로 새 액세스 토큰을 발급한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "관리자 액세스 토큰 재발급",
-                "responses": {
-                    "200": {
-                        "description": "새 액세스 토큰 발급",
-                        "schema": {
-                            "$ref": "#/definitions/AdminRefreshResponse"
-                        }
                     },
                     "401": {
                         "description": "권한 없음",
@@ -2578,20 +2547,6 @@ const docTemplate = `{
                 },
                 "expiresInSeconds": {
                     "type": "integer"
-                },
-                "refreshToken": {
-                    "type": "string"
-                }
-            }
-        },
-        "AdminRefreshResponse": {
-            "type": "object",
-            "properties": {
-                "accessToken": {
-                    "type": "string"
-                },
-                "expiresInSeconds": {
-                    "type": "integer"
                 }
             }
         },
@@ -2944,6 +2899,10 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/TrackSummaryResponse"
                     }
+                },
+                "campId": {
+                    "type": "string",
+                    "format": "uuid"
                 },
                 "cornerMetric": {
                     "$ref": "#/definitions/CornerMetricResponse"
@@ -3595,13 +3554,7 @@ const docTemplate = `{
     },
     "securityDefinitions": {
         "AdminAuth": {
-            "description": "관리자 액세스 토큰 (ADMIN)",
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
-        },
-        "AdminRefreshAuth": {
-            "description": "관리자 리프레시 토큰 (ADMIN_REFRESH) — 액세스 토큰 재발급 전용",
+            "description": "관리자 액세스 토큰 (ADMIN) — 슬라이딩 세션, 활동 시 12시간 단위로 만료 연장",
             "type": "apiKey",
             "name": "Authorization",
             "in": "header"

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -148,7 +148,7 @@
         },
         "/auth/admin/login": {
             "post": {
-                "description": "관리자 ID/비밀번호로 로그인하여 액세스 토큰과 리프레시 토큰을 발급받는다.",
+                "description": "관리자 ID/비밀번호로 로그인하여 액세스 토큰을 발급받는다. 토큰은 슬라이딩 세션으로 활동이 있으면 만료가 연장된다.",
                 "consumes": [
                     "application/json"
                 ],
@@ -204,37 +204,6 @@
                 "responses": {
                     "204": {
                         "description": "로그아웃 성공"
-                    },
-                    "401": {
-                        "description": "권한 없음",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/auth/admin/refresh": {
-            "post": {
-                "security": [
-                    {
-                        "AdminRefreshAuth": []
-                    }
-                ],
-                "description": "리프레시 토큰으로 새 액세스 토큰을 발급한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "관리자 액세스 토큰 재발급",
-                "responses": {
-                    "200": {
-                        "description": "새 액세스 토큰 발급",
-                        "schema": {
-                            "$ref": "#/definitions/AdminRefreshResponse"
-                        }
                     },
                     "401": {
                         "description": "권한 없음",
@@ -2571,20 +2540,6 @@
                 },
                 "expiresInSeconds": {
                     "type": "integer"
-                },
-                "refreshToken": {
-                    "type": "string"
-                }
-            }
-        },
-        "AdminRefreshResponse": {
-            "type": "object",
-            "properties": {
-                "accessToken": {
-                    "type": "string"
-                },
-                "expiresInSeconds": {
-                    "type": "integer"
                 }
             }
         },
@@ -3592,13 +3547,7 @@
     },
     "securityDefinitions": {
         "AdminAuth": {
-            "description": "관리자 액세스 토큰 (ADMIN)",
-            "type": "apiKey",
-            "name": "Authorization",
-            "in": "header"
-        },
-        "AdminRefreshAuth": {
-            "description": "관리자 리프레시 토큰 (ADMIN_REFRESH) — 액세스 토큰 재발급 전용",
+            "description": "관리자 액세스 토큰 (ADMIN) — 슬라이딩 세션, 활동 시 12시간 단위로 만료 연장",
             "type": "apiKey",
             "name": "Authorization",
             "in": "header"

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -13,15 +13,6 @@ definitions:
         type: string
       expiresInSeconds:
         type: integer
-      refreshToken:
-        type: string
-    type: object
-  AdminRefreshResponse:
-    properties:
-      accessToken:
-        type: string
-      expiresInSeconds:
-        type: integer
     type: object
   AdminSessionResponse:
     properties:
@@ -817,7 +808,7 @@ paths:
     post:
       consumes:
       - application/json
-      description: 관리자 ID/비밀번호로 로그인하여 액세스 토큰과 리프레시 토큰을 발급받는다.
+      description: 관리자 ID/비밀번호로 로그인하여 액세스 토큰을 발급받는다. 토큰은 슬라이딩 세션으로 활동이 있으면 만료가 연장된다.
       parameters:
       - description: 로그인 정보
         in: body
@@ -854,25 +845,6 @@ paths:
       security:
       - AdminAuth: []
       summary: 관리자 로그아웃
-      tags:
-      - A. Auth & Device Trust
-  /auth/admin/refresh:
-    post:
-      description: 리프레시 토큰으로 새 액세스 토큰을 발급한다.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: 새 액세스 토큰 발급
-          schema:
-            $ref: '#/definitions/AdminRefreshResponse'
-        "401":
-          description: 권한 없음
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - AdminRefreshAuth: []
-      summary: 관리자 액세스 토큰 재발급
       tags:
       - A. Auth & Device Trust
   /auth/admin/sessions:
@@ -2318,12 +2290,7 @@ paths:
       - B. Resource Management (Admin)
 securityDefinitions:
   AdminAuth:
-    description: 관리자 액세스 토큰 (ADMIN)
-    in: header
-    name: Authorization
-    type: apiKey
-  AdminRefreshAuth:
-    description: 관리자 리프레시 토큰 (ADMIN_REFRESH) — 액세스 토큰 재발급 전용
+    description: 관리자 액세스 토큰 (ADMIN) — 슬라이딩 세션, 활동 시 12시간 단위로 만료 연장
     in: header
     name: Authorization
     type: apiKey

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -224,12 +224,9 @@ SELECT * FROM admin_sessions WHERE id = $1;
 -- name: GetAdminSessionByAccessTokenHash :one
 SELECT * FROM admin_sessions WHERE access_token_hash = $1;
 
--- name: GetAdminSessionByRefreshTokenHash :one
-SELECT * FROM admin_sessions WHERE refresh_token_hash = $1;
-
 -- name: SaveAdminSession :exec
-INSERT INTO admin_sessions (id, admin_id, access_token_hash, refresh_token_hash, device_info, created_at, last_used_at, revoked_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO admin_sessions (id, admin_id, access_token_hash, device_info, created_at, last_used_at, revoked_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (id) DO UPDATE SET
     last_used_at = EXCLUDED.last_used_at,
     revoked_at = EXCLUDED.revoked_at;

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -164,17 +164,15 @@ CREATE TABLE admin_sessions (
     id VARCHAR(50) PRIMARY KEY,
     admin_id VARCHAR(50) NOT NULL REFERENCES admins(id) ON DELETE CASCADE,
     access_token_hash VARCHAR(255) NOT NULL UNIQUE,
-    refresh_token_hash VARCHAR(255) NOT NULL UNIQUE,
     device_info TEXT NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL,
     last_used_at TIMESTAMP WITH TIME ZONE NOT NULL,
     revoked_at TIMESTAMP WITH TIME ZONE
 );
-COMMENT ON TABLE admin_sessions IS '관리자의 인증 토큰(Access/Refresh) 세션을 관리하는 테이블';
+COMMENT ON TABLE admin_sessions IS '관리자의 인증 토큰(Access) 세션을 관리하는 테이블';
 COMMENT ON COLUMN admin_sessions.id IS '세션 고유 식별자';
 COMMENT ON COLUMN admin_sessions.admin_id IS '관리자 식별자';
 COMMENT ON COLUMN admin_sessions.access_token_hash IS 'Access Token 해시';
-COMMENT ON COLUMN admin_sessions.refresh_token_hash IS 'Refresh Token 해시';
 COMMENT ON COLUMN admin_sessions.device_info IS '로그인 환경(User-Agent 등) 정보';
 COMMENT ON COLUMN admin_sessions.created_at IS '세션 생성 시간';
 COMMENT ON COLUMN admin_sessions.last_used_at IS '마지막 세션 사용 시간 (슬라이딩 만료용)';

--- a/backend/docs/artifacts/plan/20260716_admin_refresh_token_removal_plan_.md
+++ b/backend/docs/artifacts/plan/20260716_admin_refresh_token_removal_plan_.md
@@ -1,0 +1,158 @@
+# 관리자 Refresh Token 제거 Plan
+
+## 배경
+
+관리자 인증은 opaque token(불투명 토큰) 방식이라 서버가 세션을 DB 해시 조회로 완전히 통제한다. Refresh 토큰을 두는 이유는 보통 JWT처럼 "발급 후 서버 통제력이 약해지는" 토큰에서 access 토큰 수명을 짧게 유지하기 위함인데, 지금 구조는 그 이점 없이 (refresh 토큰 미rotate, idle TTL만 연장) 세션 하이재킹 취약점만 추가로 안고 있다.
+
+관리자 계정 수가 적고 로그인 UX 비용이 크지 않으므로, refresh 플로우를 완전히 제거하고 access 토큰 단일 구조 + TTL 연장으로 단순화한다.
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| **P0** | UC-11 로그인 (변경) | 관리자 ID/PW 로그인 시 access 토큰만 발급 (refresh 토큰 발급 제거) | **프로덕션 핵심 로직** |
+| **P0** | UC-13 액세스 토큰 검증 (유지) | 기존 로직 그대로, TTL 상수만 연장 | **프로덕션 핵심 로직** |
+| P1 | UC-12 리프레시 (삭제) | `AdminAuthService.RefreshToken`, `/auth/admin/refresh` 엔드포인트, `AdminRefreshAuth` 시큐리티 스킴 전체 삭제 | 제거 대상 |
+| P1 | 만료 시 재로그인 | Access 토큰 만료 시 클라이언트는 재로그인만 수행 (refresh 재발급 없음) | 프론트 영향 있음 — 프론트 별도 대응 필요 (본 plan은 백엔드 한정) |
+
+## 아키텍처 영향
+
+- Domain / Usecase / Infrastructure 3계층 모두 수정. `domain`은 외부 의존성 없이 필드/메서드만 제거.
+- 새 인터페이스 생성 없음 — 기존 `AdminAuthUsecase`, `AdminSessionRepository` 포트에서 불필요해진 메서드만 제거.
+- **API 스키마 변경 있음** → `workflow/Collaborate.md` 절차에 따라 swagger 주석(`auth_handler.go`, `doc.go`) 갱신 필수 (본 레포는 별도 `api/openapi.yaml` 없이 `swag` 주석이 소스임을 확인함).
+
+## 객체/메서드 변경 정의
+
+### Domain — `backend/internal/domain/admin.go`
+
+```go
+type AdminSession struct {
+    ID              AdminSessionID
+    AdminID         AdminID
+    AccessTokenHash string
+    // RefreshTokenHash string  // 삭제
+    DeviceInfo      string
+    CreatedAt       time.Time
+    LastUsedAt      time.Time
+    RevokedAt       Optional[time.Time]
+}
+
+// TouchRefresh → TouchActivity(now)로 이름 변경 (역할: 슬라이딩 세션의 활동 시각 갱신, refresh 전용 의미 제거)
+// IsRefreshExpired → IsExpired(now, idleTTL)로 이름 변경 (refresh 문맥 제거, access 세션의 idle 만료 판정으로 의미 전환)
+// Revoke(now)는 유지 — 로그아웃/강제 종료에 계속 사용됨
+```
+
+### Usecase — `backend/internal/usecase/auth_admin.go`
+
+```go
+const AdminAccessTokenTTL = 12 * time.Hour // 30분 → 12시간으로 연장 (재로그인 부담 완화)
+// AdminRefreshTokenIdleTTL 삭제
+
+// Login - UC-11 (시그니처 변경: refresh 토큰 반환 제거)
+func (s *AdminAuthService) Login(
+    ctx context.Context,
+    username string,
+    password string,
+    deviceInfo string,
+) (string /* access token */, *domain.AdminSession, error)
+
+// RefreshToken - UC-12 전체 삭제
+
+// ValidateAccessToken - UC-13 (슬라이딩 세션: 검증 성공 시 LastUsedAt 갱신 후 저장)
+func (s *AdminAuthService) ValidateAccessToken(
+    ctx context.Context,
+    accessToken string,
+) (*domain.AdminSession, error)
+// 책임: 세션 조회 + 만료/취소 확인 + LastUsedAt 갱신(TouchActivity) + 저장(활동 있으면 TTL 연장, 방치 시 12h 후 만료)
+```
+
+### Port — `backend/internal/usecase/port.go`
+
+```go
+type AdminSessionRepository interface {
+    // GetByRefreshTokenHash(ctx, hash) 삭제
+    // 나머지 메서드 유지
+}
+```
+
+### Web — `backend/internal/infrastructure/web/auth_handler.go`
+
+```go
+type AdminAuthUsecase interface {
+    Login(ctx context.Context, username, password, deviceInfo string) (string, *domain.AdminSession, error)
+    // RefreshToken(...) 삭제
+    RevokeSession(ctx context.Context, sessionID domain.AdminSessionID, actorAdminID domain.AdminID) error
+    ListSessions(ctx context.Context, adminID domain.AdminID) ([]*domain.AdminSession, error)
+    ForceTrackLogout(ctx context.Context, trackID domain.TrackID, actorAdminID domain.AdminID) error
+}
+
+type AdminLoginResponse struct {
+    AccessToken      string `json:"accessToken"`
+    // RefreshToken 필드 삭제
+    ExpiresInSeconds int    `json:"expiresInSeconds"` // 1800 → 43200 (12h)
+}
+
+// AdminRefreshResponse 구조체 전체 삭제
+// AdminRefresh 핸들러 전체 삭제 (swagger 주석 포함)
+```
+
+### Router — `backend/internal/infrastructure/web/router.go`
+
+- `admin.POST("/auth/admin/refresh", h.Auth.AdminRefresh)` 라인 삭제
+
+### Swagger 문서 헤더 — `backend/internal/infrastructure/web/doc.go`
+
+- `@securityDefinitions.apikey AdminRefreshAuth` 및 설명 라인 삭제
+- `swag init` (또는 프로젝트의 codegen 커맨드) 재실행하여 생성 문서 갱신
+
+### Postgres — `backend/internal/infrastructure/postgres/admin_session_repo.go`, `db/query.sql`, `db/schema.sql`
+
+```sql
+-- db/schema.sql
+-- admin_sessions 테이블에서 refresh_token_hash 컬럼 삭제
+```
+
+- `GetAdminSessionByRefreshTokenHash` 쿼리 삭제
+- 나머지 쿼리(`GetAdminSessionByID`, `GetAdminSessionByAccessTokenHash`, list, `CreateAdminSession`)에서 `refresh_token_hash` 컬럼 참조 제거
+- `sqlc generate` 재실행하여 `internal/infrastructure/postgres/db/*.go` 갱신 (직접 손으로 수정하지 않음)
+- **DB 마이그레이션 도구 없음(레포에 `db/migrations/` 부재, `db/schema.sql` 단일 소스)** → 실제 운영 DB에 반영할 `ALTER TABLE admin_sessions DROP COLUMN refresh_token_hash;` 실행 방법은 사용자 확인 필요 (로컬 개발 DB는 schema.sql 재적용으로 충분하나, 배포 환경 반영 절차는 이 plan 범위 밖)
+
+### Tests
+
+- `internal/domain/admin_test.go`: `RefreshTokenHash`, `IsRefreshExpired`, `TouchRefresh` 관련 테스트 삭제
+- `internal/usecase/auth_admin_test.go`: `Login` 테스트에서 refresh 반환값 검증 제거, `TestAdminAuthService_RefreshToken` 전체 삭제
+- `internal/usecase/mock_test.go`: `MockAdminSessionRepository.GetByRefreshTokenHash` 삭제
+
+## 구현 단계
+
+| Phase | 작업 | 파일 | 예상 소요 |
+|---|---|---|---|
+| A | Domain 계층 수정 (필드/메서드 삭제) | `internal/domain/admin.go`, `admin_test.go` | 15분 |
+| B | Usecase 계층 수정 (Login 시그니처, RefreshToken 삭제, TTL 상수) | `internal/usecase/auth_admin.go`, `port.go`, `auth_admin_test.go`, `mock_test.go` | 30분 |
+| C | Web 계층 수정 (핸들러/DTO/라우터/swagger) | `auth_handler.go`, `router.go`, `doc.go` | 30분 |
+| D | DB 계층 수정 (schema, query, sqlc 재생성, repo) | `db/schema.sql`, `db/query.sql`, `admin_session_repo.go` | 30분 |
+| E | 전체 빌드/테스트, swag 재생성 확인 | - | 15분 |
+
+## 검증 체크리스트
+
+### 아키텍처 검증
+- [ ] `domain` 패키지에 외부 의존성 없음 (변경 없음, 필드만 제거)
+- [ ] `usecase` 계층이 여전히 `AdminSessionRepository` 인터페이스에만 의존
+- [ ] 새 인터페이스 생성 없음 (기존 포트 축소만 진행)
+
+### 유즈케이스 검증
+- [ ] UC-11: 로그인 시 access 토큰만 반환, refresh 토큰 없음
+- [ ] UC-13: access 토큰이 TTL(12h) 내에서 유효, 만료 후 401
+- [ ] `/auth/admin/refresh` 라우트 자체가 404 (삭제 확인)
+- [ ] `go build ./...`, `go vet ./...` 통과
+- [ ] `go test ./...` 통과 (수정된 테스트 포함)
+- [ ] swagger 생성 문서에 `AdminRefreshAuth`/`AdminRefreshResponse` 미노출
+- [ ] `sqlc generate` 후 `admin_sessions` 관련 생성 코드에 `refresh_token_hash` 미참조
+
+### 확정된 결정 사항
+- [x] 슬라이딩 세션 적용: `ValidateAccessToken` 성공 시 `LastUsedAt` 갱신 + 저장 (활동 있으면 연장, idle 12h 후 만료)
+- [x] Access 토큰 TTL: 12시간 (idle 기준)
+- [x] 대상 클라이언트: 모바일(Flutter)만 우선 고려. 웹(캠프 생성용)은 별도 검토 대상, 이 plan 범위 밖
+
+### 미결 사항 (사용자 확인 필요)
+- [ ] 운영 DB에 `refresh_token_hash` 컬럼 DROP을 어떻게 반영할지 (마이그레이션 도구 부재 — 로컬 개발은 schema.sql 재적용으로 충분)

--- a/backend/internal/domain/admin.go
+++ b/backend/internal/domain/admin.go
@@ -11,18 +11,17 @@ type Admin struct {
 }
 
 type AdminSession struct {
-	ID               AdminSessionID
-	AdminID          AdminID
-	AccessTokenHash  string
-	RefreshTokenHash string
-	DeviceInfo       string
-	CreatedAt        time.Time
-	LastUsedAt       time.Time
-	RevokedAt        Optional[time.Time]
+	ID              AdminSessionID
+	AdminID         AdminID
+	AccessTokenHash string
+	DeviceInfo      string
+	CreatedAt       time.Time
+	LastUsedAt      time.Time
+	RevokedAt       Optional[time.Time]
 }
 
-// TouchRefresh는 세션의 마지막 사용 시각을 갱신하여 슬라이딩 만료 처리를 수행합니다.
-func (s *AdminSession) TouchRefresh(now time.Time) {
+// TouchActivity는 세션의 마지막 사용 시각을 갱신하여 슬라이딩 만료 처리를 수행합니다.
+func (s *AdminSession) TouchActivity(now time.Time) {
 	s.LastUsedAt = now
 }
 
@@ -35,8 +34,8 @@ func (s *AdminSession) Revoke(now time.Time) error {
 	return nil
 }
 
-// IsRefreshExpired는 리프레시 세션이 비활성 만료 시간(idleTTL) 또는 취소 여부에 의해 만료되었는지 확인합니다.
-func (s *AdminSession) IsRefreshExpired(now time.Time, idleTTL time.Duration) bool {
+// IsExpired는 세션이 비활성 만료 시간(idleTTL) 또는 취소 여부에 의해 만료되었는지 확인합니다.
+func (s *AdminSession) IsExpired(now time.Time, idleTTL time.Duration) bool {
 	if s.RevokedAt.IsSet() {
 		return true
 	}

--- a/backend/internal/domain/admin_test.go
+++ b/backend/internal/domain/admin_test.go
@@ -14,32 +14,31 @@ func TestAdminSession_Lifecycle(t *testing.T) {
 
 	t.Run("Session touch sliding expiration and expiry verification", func(t *testing.T) {
 		session := &domain.AdminSession{
-			ID:               domain.AdminSessionID("session-1"),
-			AdminID:          domain.AdminID("admin-1"),
-			AccessTokenHash:  "access-hash",
-			RefreshTokenHash: "refresh-hash",
-			CreatedAt:        now,
-			LastUsedAt:       now,
-			RevokedAt:        domain.None[time.Time](),
+			ID:              domain.AdminSessionID("session-1"),
+			AdminID:         domain.AdminID("admin-1"),
+			AccessTokenHash: "access-hash",
+			CreatedAt:       now,
+			LastUsedAt:      now,
+			RevokedAt:       domain.None[time.Time](),
 		}
 
 		// 1. Initially not expired
-		if session.IsRefreshExpired(now.Add(10*time.Minute), idleTTL) {
+		if session.IsExpired(now.Add(10*time.Minute), idleTTL) {
 			t.Error("expected session not to be expired")
 		}
 
 		// 2. Expired after idleTTL
-		if !session.IsRefreshExpired(now.Add(31*time.Minute), idleTTL) {
+		if !session.IsExpired(now.Add(31*time.Minute), idleTTL) {
 			t.Error("expected session to be expired after idleTTL")
 		}
 
-		// 3. TouchRefresh slides expiration
-		session.TouchRefresh(now.Add(10 * time.Minute))
-		if session.IsRefreshExpired(now.Add(31*time.Minute), idleTTL) {
+		// 3. TouchActivity slides expiration
+		session.TouchActivity(now.Add(10 * time.Minute))
+		if session.IsExpired(now.Add(31*time.Minute), idleTTL) {
 			t.Error("expected session not to be expired because lastUsedAt was touched")
 		}
 
-		// 4. TouchRefresh updates LastUsedAt
+		// 4. TouchActivity updates LastUsedAt
 		if !session.LastUsedAt.Equal(now.Add(10 * time.Minute)) {
 			t.Errorf("expected LastUsedAt to be touched, got %v", session.LastUsedAt)
 		}
@@ -58,7 +57,7 @@ func TestAdminSession_Lifecycle(t *testing.T) {
 		}
 
 		// Expired because it is revoked
-		if !session.IsRefreshExpired(now, idleTTL) {
+		if !session.IsExpired(now, idleTTL) {
 			t.Error("expected session to be expired because it was revoked")
 		}
 

--- a/backend/internal/infrastructure/postgres/admin_session_repo.go
+++ b/backend/internal/infrastructure/postgres/admin_session_repo.go
@@ -29,13 +29,12 @@ func (r *pgAdminSessionRepository) queries(ctx context.Context) *db.Queries {
 
 func mapAdminSession(row db.AdminSession) *domain.AdminSession {
 	s := &domain.AdminSession{
-		ID:               domain.AdminSessionID(row.ID),
-		AdminID:          domain.AdminID(row.AdminID),
-		AccessTokenHash:  row.AccessTokenHash,
-		RefreshTokenHash: row.RefreshTokenHash,
-		DeviceInfo:       row.DeviceInfo,
-		CreatedAt:        row.CreatedAt.Time,
-		LastUsedAt:       row.LastUsedAt.Time,
+		ID:              domain.AdminSessionID(row.ID),
+		AdminID:         domain.AdminID(row.AdminID),
+		AccessTokenHash: row.AccessTokenHash,
+		DeviceInfo:      row.DeviceInfo,
+		CreatedAt:       row.CreatedAt.Time,
+		LastUsedAt:      row.LastUsedAt.Time,
 	}
 
 	if row.RevokedAt.Valid {
@@ -69,26 +68,14 @@ func (r *pgAdminSessionRepository) GetByAccessTokenHash(ctx context.Context, has
 	return mapAdminSession(row), nil
 }
 
-func (r *pgAdminSessionRepository) GetByRefreshTokenHash(ctx context.Context, hash string) (*domain.AdminSession, error) {
-	row, err := r.queries(ctx).GetAdminSessionByRefreshTokenHash(ctx, hash)
-	if err != nil {
-		if err == pgx.ErrNoRows {
-			return nil, nil
-		}
-		return nil, errs.Wrap(ctx, err)
-	}
-	return mapAdminSession(row), nil
-}
-
 func (r *pgAdminSessionRepository) Save(ctx context.Context, session *domain.AdminSession) error {
 	params := db.SaveAdminSessionParams{
-		ID:               string(session.ID),
-		AdminID:          string(session.AdminID),
-		AccessTokenHash:  session.AccessTokenHash,
-		RefreshTokenHash: session.RefreshTokenHash,
-		DeviceInfo:       session.DeviceInfo,
-		CreatedAt:        pgtype.Timestamptz{Time: session.CreatedAt, Valid: !session.CreatedAt.IsZero()},
-		LastUsedAt:       pgtype.Timestamptz{Time: session.LastUsedAt, Valid: !session.LastUsedAt.IsZero()},
+		ID:              string(session.ID),
+		AdminID:         string(session.AdminID),
+		AccessTokenHash: session.AccessTokenHash,
+		DeviceInfo:      session.DeviceInfo,
+		CreatedAt:       pgtype.Timestamptz{Time: session.CreatedAt, Valid: !session.CreatedAt.IsZero()},
+		LastUsedAt:      pgtype.Timestamptz{Time: session.LastUsedAt, Valid: !session.LastUsedAt.IsZero()},
 	}
 
 	if val, ok := session.RevokedAt.Value(); ok {

--- a/backend/internal/infrastructure/postgres/db/models.go
+++ b/backend/internal/infrastructure/postgres/db/models.go
@@ -18,7 +18,7 @@ type Admin struct {
 	PasswordHash string `json:"password_hash"`
 }
 
-// 관리자의 인증 토큰(Access/Refresh) 세션을 관리하는 테이블
+// 관리자의 인증 토큰(Access) 세션을 관리하는 테이블
 type AdminSession struct {
 	// 세션 고유 식별자
 	ID string `json:"id"`
@@ -26,8 +26,6 @@ type AdminSession struct {
 	AdminID string `json:"admin_id"`
 	// Access Token 해시
 	AccessTokenHash string `json:"access_token_hash"`
-	// Refresh Token 해시
-	RefreshTokenHash string `json:"refresh_token_hash"`
 	// 로그인 환경(User-Agent 등) 정보
 	DeviceInfo string `json:"device_info"`
 	// 세션 생성 시간

--- a/backend/internal/infrastructure/postgres/db/querier.go
+++ b/backend/internal/infrastructure/postgres/db/querier.go
@@ -14,7 +14,6 @@ type Querier interface {
 	GetAdminByUsername(ctx context.Context, username string) (Admin, error)
 	GetAdminSession(ctx context.Context, id string) (AdminSession, error)
 	GetAdminSessionByAccessTokenHash(ctx context.Context, accessTokenHash string) (AdminSession, error)
-	GetAdminSessionByRefreshTokenHash(ctx context.Context, refreshTokenHash string) (AdminSession, error)
 	GetAnnouncementReceiptByAnnouncementAndTrack(ctx context.Context, arg GetAnnouncementReceiptByAnnouncementAndTrackParams) (AnnouncementReceipt, error)
 	GetBadge(ctx context.Context, id string) (Badge, error)
 	GetBadgeByQRPayload(ctx context.Context, qrPayload string) (Badge, error)

--- a/backend/internal/infrastructure/postgres/db/query.sql.go
+++ b/backend/internal/infrastructure/postgres/db/query.sql.go
@@ -43,7 +43,7 @@ func (q *Queries) GetAdminByUsername(ctx context.Context, username string) (Admi
 }
 
 const getAdminSession = `-- name: GetAdminSession :one
-SELECT id, admin_id, access_token_hash, refresh_token_hash, device_info, created_at, last_used_at, revoked_at FROM admin_sessions WHERE id = $1
+SELECT id, admin_id, access_token_hash, device_info, created_at, last_used_at, revoked_at FROM admin_sessions WHERE id = $1
 `
 
 func (q *Queries) GetAdminSession(ctx context.Context, id string) (AdminSession, error) {
@@ -53,7 +53,6 @@ func (q *Queries) GetAdminSession(ctx context.Context, id string) (AdminSession,
 		&i.ID,
 		&i.AdminID,
 		&i.AccessTokenHash,
-		&i.RefreshTokenHash,
 		&i.DeviceInfo,
 		&i.CreatedAt,
 		&i.LastUsedAt,
@@ -63,7 +62,7 @@ func (q *Queries) GetAdminSession(ctx context.Context, id string) (AdminSession,
 }
 
 const getAdminSessionByAccessTokenHash = `-- name: GetAdminSessionByAccessTokenHash :one
-SELECT id, admin_id, access_token_hash, refresh_token_hash, device_info, created_at, last_used_at, revoked_at FROM admin_sessions WHERE access_token_hash = $1
+SELECT id, admin_id, access_token_hash, device_info, created_at, last_used_at, revoked_at FROM admin_sessions WHERE access_token_hash = $1
 `
 
 func (q *Queries) GetAdminSessionByAccessTokenHash(ctx context.Context, accessTokenHash string) (AdminSession, error) {
@@ -73,27 +72,6 @@ func (q *Queries) GetAdminSessionByAccessTokenHash(ctx context.Context, accessTo
 		&i.ID,
 		&i.AdminID,
 		&i.AccessTokenHash,
-		&i.RefreshTokenHash,
-		&i.DeviceInfo,
-		&i.CreatedAt,
-		&i.LastUsedAt,
-		&i.RevokedAt,
-	)
-	return i, err
-}
-
-const getAdminSessionByRefreshTokenHash = `-- name: GetAdminSessionByRefreshTokenHash :one
-SELECT id, admin_id, access_token_hash, refresh_token_hash, device_info, created_at, last_used_at, revoked_at FROM admin_sessions WHERE refresh_token_hash = $1
-`
-
-func (q *Queries) GetAdminSessionByRefreshTokenHash(ctx context.Context, refreshTokenHash string) (AdminSession, error) {
-	row := q.db.QueryRow(ctx, getAdminSessionByRefreshTokenHash, refreshTokenHash)
-	var i AdminSession
-	err := row.Scan(
-		&i.ID,
-		&i.AdminID,
-		&i.AccessTokenHash,
-		&i.RefreshTokenHash,
 		&i.DeviceInfo,
 		&i.CreatedAt,
 		&i.LastUsedAt,
@@ -569,7 +547,7 @@ func (q *Queries) ListActiveTracksByCamp(ctx context.Context, campID string) ([]
 }
 
 const listAdminSessionsByAdmin = `-- name: ListAdminSessionsByAdmin :many
-SELECT id, admin_id, access_token_hash, refresh_token_hash, device_info, created_at, last_used_at, revoked_at FROM admin_sessions
+SELECT id, admin_id, access_token_hash, device_info, created_at, last_used_at, revoked_at FROM admin_sessions
 WHERE admin_id = $1 AND revoked_at IS NULL
 `
 
@@ -586,7 +564,6 @@ func (q *Queries) ListAdminSessionsByAdmin(ctx context.Context, adminID string) 
 			&i.ID,
 			&i.AdminID,
 			&i.AccessTokenHash,
-			&i.RefreshTokenHash,
 			&i.DeviceInfo,
 			&i.CreatedAt,
 			&i.LastUsedAt,
@@ -1247,22 +1224,21 @@ func (q *Queries) ResetTrackUnreadCount(ctx context.Context, arg ResetTrackUnrea
 }
 
 const saveAdminSession = `-- name: SaveAdminSession :exec
-INSERT INTO admin_sessions (id, admin_id, access_token_hash, refresh_token_hash, device_info, created_at, last_used_at, revoked_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+INSERT INTO admin_sessions (id, admin_id, access_token_hash, device_info, created_at, last_used_at, revoked_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (id) DO UPDATE SET
     last_used_at = EXCLUDED.last_used_at,
     revoked_at = EXCLUDED.revoked_at
 `
 
 type SaveAdminSessionParams struct {
-	ID               string             `json:"id"`
-	AdminID          string             `json:"admin_id"`
-	AccessTokenHash  string             `json:"access_token_hash"`
-	RefreshTokenHash string             `json:"refresh_token_hash"`
-	DeviceInfo       string             `json:"device_info"`
-	CreatedAt        pgtype.Timestamptz `json:"created_at"`
-	LastUsedAt       pgtype.Timestamptz `json:"last_used_at"`
-	RevokedAt        pgtype.Timestamptz `json:"revoked_at"`
+	ID              string             `json:"id"`
+	AdminID         string             `json:"admin_id"`
+	AccessTokenHash string             `json:"access_token_hash"`
+	DeviceInfo      string             `json:"device_info"`
+	CreatedAt       pgtype.Timestamptz `json:"created_at"`
+	LastUsedAt      pgtype.Timestamptz `json:"last_used_at"`
+	RevokedAt       pgtype.Timestamptz `json:"revoked_at"`
 }
 
 func (q *Queries) SaveAdminSession(ctx context.Context, arg SaveAdminSessionParams) error {
@@ -1270,7 +1246,6 @@ func (q *Queries) SaveAdminSession(ctx context.Context, arg SaveAdminSessionPara
 		arg.ID,
 		arg.AdminID,
 		arg.AccessTokenHash,
-		arg.RefreshTokenHash,
 		arg.DeviceInfo,
 		arg.CreatedAt,
 		arg.LastUsedAt,

--- a/backend/internal/infrastructure/web/auth_handler.go
+++ b/backend/internal/infrastructure/web/auth_handler.go
@@ -3,7 +3,6 @@ package web
 import (
 	"context"
 	"net/http"
-	"strings"
 	"time"
 
 	"cornermon/backend/internal/domain"
@@ -13,8 +12,7 @@ import (
 )
 
 type AdminAuthUsecase interface {
-	Login(ctx context.Context, username, password, deviceInfo string) (string, string, *domain.AdminSession, error)
-	RefreshToken(ctx context.Context, refreshToken string) (string, error)
+	Login(ctx context.Context, username, password, deviceInfo string) (string, *domain.AdminSession, error)
 	RevokeSession(ctx context.Context, sessionID domain.AdminSessionID, actorAdminID domain.AdminID) error
 	ListSessions(ctx context.Context, adminID domain.AdminID) ([]*domain.AdminSession, error)
 	ForceTrackLogout(ctx context.Context, trackID domain.TrackID, actorAdminID domain.AdminID) error
@@ -52,14 +50,8 @@ type AdminLoginRequest struct {
 
 type AdminLoginResponse struct {
 	AccessToken      string `json:"accessToken"`
-	RefreshToken     string `json:"refreshToken"`
 	ExpiresInSeconds int    `json:"expiresInSeconds"`
 } // @name AdminLoginResponse
-
-type AdminRefreshResponse struct {
-	AccessToken      string `json:"accessToken"`
-	ExpiresInSeconds int    `json:"expiresInSeconds"`
-} // @name AdminRefreshResponse
 
 type TrackLoginRequest struct {
 	PIN string `json:"pin"`
@@ -84,7 +76,7 @@ func NewAuthHandler(
 }
 
 // @Summary      관리자 로그인
-// @Description  관리자 ID/비밀번호로 로그인하여 액세스 토큰과 리프레시 토큰을 발급받는다.
+// @Description  관리자 ID/비밀번호로 로그인하여 액세스 토큰을 발급받는다. 토큰은 슬라이딩 세션으로 활동이 있으면 만료가 연장된다.
 // @Tags         A. Auth & Device Trust
 // @Accept       json
 // @Produce      json
@@ -99,41 +91,14 @@ func (h *AuthHandler) AdminLogin(c echo.Context) error {
 	}
 
 	deviceInfo := c.Request().UserAgent()
-	access, refresh, _, err := h.adminAuth.Login(c.Request().Context(), req.ID, req.Password, deviceInfo)
+	access, _, err := h.adminAuth.Login(c.Request().Context(), req.ID, req.Password, deviceInfo)
 	if err != nil {
 		return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: err.Error()})
 	}
 
 	return c.JSON(http.StatusOK, AdminLoginResponse{
 		AccessToken:      access,
-		RefreshToken:     refresh,
-		ExpiresInSeconds: 1800,
-	})
-}
-
-// @Summary      관리자 액세스 토큰 재발급
-// @Description  리프레시 토큰으로 새 액세스 토큰을 발급한다.
-// @Tags         A. Auth & Device Trust
-// @Security     AdminRefreshAuth
-// @Produce      json
-// @Success      200 {object} AdminRefreshResponse "새 액세스 토큰 발급"
-// @Failure      401 {object} ErrorResponse "권한 없음"
-// @Router       /auth/admin/refresh [post]
-func (h *AuthHandler) AdminRefresh(c echo.Context) error {
-	authHeader := c.Request().Header.Get("Authorization")
-	refreshToken := strings.TrimPrefix(authHeader, "Bearer ")
-	if refreshToken == "" {
-		return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "missing token"})
-	}
-
-	access, err := h.adminAuth.RefreshToken(c.Request().Context(), refreshToken)
-	if err != nil {
-		return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: err.Error()})
-	}
-
-	return c.JSON(http.StatusOK, AdminRefreshResponse{
-		AccessToken:      access,
-		ExpiresInSeconds: 1800,
+		ExpiresInSeconds: int(usecase.AdminAccessTokenTTL.Seconds()),
 	})
 }
 

--- a/backend/internal/infrastructure/web/doc.go
+++ b/backend/internal/infrastructure/web/doc.go
@@ -19,9 +19,4 @@ package web
 // @securityDefinitions.apikey AdminAuth
 // @in header
 // @name Authorization
-// @description 관리자 액세스 토큰 (ADMIN)
-
-// @securityDefinitions.apikey AdminRefreshAuth
-// @in header
-// @name Authorization
-// @description 관리자 리프레시 토큰 (ADMIN_REFRESH) — 액세스 토큰 재발급 전용
+// @description 관리자 액세스 토큰 (ADMIN) — 슬라이딩 세션, 활동 시 12시간 단위로 만료 연장

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -36,7 +36,6 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 	admin := v1.Group("")
 	admin.Use(AdminAuthMiddleware(adminAuth))
 
-	admin.POST("/auth/admin/refresh", h.Auth.AdminRefresh)
 	admin.POST("/auth/admin/logout", h.Auth.AdminLogout)
 	admin.GET("/auth/admin/sessions", h.Auth.ListAdminSessions)
 	admin.POST("/auth/admin/sessions/:id/revoke", h.Auth.RevokeAdminSession)

--- a/backend/internal/usecase/auth_admin.go
+++ b/backend/internal/usecase/auth_admin.go
@@ -10,8 +10,7 @@ import (
 	"github.com/google/uuid"
 )
 
-const AdminAccessTokenTTL = 30 * time.Minute
-const AdminRefreshTokenIdleTTL = 12 * time.Hour
+const AdminAccessTokenTTL = 12 * time.Hour
 
 type AdminAuthService struct {
 	admins              AdminRepository
@@ -57,43 +56,37 @@ func (s *AdminAuthService) Login(
 	username string,
 	password string,
 	deviceInfo string,
-) (string, string, *domain.AdminSession, error) {
+) (string, *domain.AdminSession, error) {
 	now := s.nowFn()
 
 	admin, err := s.admins.GetByUsername(ctx, username)
 	if err != nil {
-		return "", "", nil, err
+		return "", nil, err
 	}
 	if admin == nil {
 		s.recordAuditLog(ctx, "anonymous", "ADMIN_LOGIN", username, false, map[string]any{"error": "admin not found"})
-		return "", "", nil, errors.New("invalid username or password")
+		return "", nil, errors.New("invalid username or password")
 	}
 
 	if err := verifyPassword(admin.PasswordHash, password); err != nil {
 		s.recordAuditLog(ctx, "anonymous", "ADMIN_LOGIN", username, false, map[string]any{"error": "invalid password"})
-		return "", "", nil, errors.New("invalid username or password")
+		return "", nil, errors.New("invalid username or password")
 	}
 
 	plainAccess, accessHash, err := generateOpaqueToken()
 	if err != nil {
-		return "", "", nil, err
-	}
-
-	plainRefresh, refreshHash, err := generateOpaqueToken()
-	if err != nil {
-		return "", "", nil, err
+		return "", nil, err
 	}
 
 	sessionID := domain.AdminSessionID(s.uuidFn())
 	session := &domain.AdminSession{
-		ID:               sessionID,
-		AdminID:          admin.ID,
-		AccessTokenHash:  accessHash,
-		RefreshTokenHash: refreshHash,
-		DeviceInfo:       deviceInfo,
-		CreatedAt:        now,
-		LastUsedAt:       now,
-		RevokedAt:        domain.None[time.Time](),
+		ID:              sessionID,
+		AdminID:         admin.ID,
+		AccessTokenHash: accessHash,
+		DeviceInfo:      deviceInfo,
+		CreatedAt:       now,
+		LastUsedAt:      now,
+		RevokedAt:       domain.None[time.Time](),
 	}
 
 	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
@@ -102,49 +95,14 @@ func (s *AdminAuthService) Login(
 
 	if err != nil {
 		s.recordAuditLog(ctx, "anonymous", "ADMIN_LOGIN", username, false, map[string]any{"error": err.Error()})
-		return "", "", nil, err
+		return "", nil, err
 	}
 
 	s.recordAuditLog(ctx, string(admin.ID), "ADMIN_LOGIN", string(session.ID), true, nil)
-	return plainAccess, plainRefresh, session, nil
+	return plainAccess, session, nil
 }
 
-// RefreshToken - UC-12
-func (s *AdminAuthService) RefreshToken(
-	ctx context.Context,
-	refreshToken string,
-) (string, error) {
-	now := s.nowFn()
-	refreshHash := hashSHA256(refreshToken)
-
-	session, err := s.sessions.GetByRefreshTokenHash(ctx, refreshHash)
-	if err != nil {
-		return "", err
-	}
-	if session == nil || session.IsRefreshExpired(now, AdminRefreshTokenIdleTTL) {
-		return "", errors.New("refresh token expired or revoked")
-	}
-
-	plainAccess, accessHash, err := generateOpaqueToken()
-	if err != nil {
-		return "", err
-	}
-
-	session.AccessTokenHash = accessHash
-	session.TouchRefresh(now)
-
-	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
-		return s.sessions.Save(ctx, session)
-	})
-
-	if err != nil {
-		return "", err
-	}
-
-	return plainAccess, nil
-}
-
-// ValidateAccessToken - UC-13
+// ValidateAccessToken - UC-13 (슬라이딩 세션: 검증 성공 시 활동 시각을 갱신하여 TTL을 연장)
 func (s *AdminAuthService) ValidateAccessToken(
 	ctx context.Context,
 	accessToken string,
@@ -160,12 +118,19 @@ func (s *AdminAuthService) ValidateAccessToken(
 		return nil, errors.New("session not found")
 	}
 
-	if session.RevokedAt.IsSet() {
-		return nil, domain.ErrSessionRevoked
+	if session.IsExpired(now, AdminAccessTokenTTL) {
+		if session.RevokedAt.IsSet() {
+			return nil, domain.ErrSessionRevoked
+		}
+		return nil, errors.New("access token expired")
 	}
 
-	if now.After(session.LastUsedAt.Add(AdminAccessTokenTTL)) {
-		return nil, errors.New("access token expired")
+	session.TouchActivity(now)
+	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		return s.sessions.Save(ctx, session)
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return session, nil

--- a/backend/internal/usecase/auth_admin_test.go
+++ b/backend/internal/usecase/auth_admin_test.go
@@ -31,14 +31,14 @@ func TestAdminAuthService_Login(t *testing.T) {
 		s.uuidFn = func() string { return "session-uuid" }
 
 		// Act
-		access, refresh, session, err := s.Login(context.Background(), "admin-1", "admin-password", "PC")
+		access, session, err := s.Login(context.Background(), "admin-1", "admin-password", "PC")
 
 		// Assert
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if access == "" || refresh == "" {
-			t.Fatal("expected non-empty tokens")
+		if access == "" {
+			t.Fatal("expected non-empty token")
 		}
 		if session.ID != "session-uuid" {
 			t.Errorf("expected session ID 'session-uuid', got '%s'", session.ID)
@@ -63,7 +63,7 @@ func TestAdminAuthService_Login(t *testing.T) {
 		s := NewAdminAuthService(admins, sessions, facSessions, tracks, corners, broadcaster, auditLogs, tx)
 
 		// Act
-		_, _, _, err := s.Login(context.Background(), "admin-1", "wrong-password", "PC")
+		_, _, err := s.Login(context.Background(), "admin-1", "wrong-password", "PC")
 
 		// Assert
 		if err == nil {
@@ -72,34 +72,57 @@ func TestAdminAuthService_Login(t *testing.T) {
 	})
 }
 
-func TestAdminAuthService_RefreshToken(t *testing.T) {
-	t.Run("ShouldRefreshTokenSuccessfullyWhenNotExpired", func(t *testing.T) {
+func TestAdminAuthService_ValidateAccessToken(t *testing.T) {
+	t.Run("ShouldSlideExpirationWhenAccessTokenIsValid", func(t *testing.T) {
 		// Arrange
 		now := time.Now()
 		sessions := NewMockAdminSessionRepository()
 		session := &domain.AdminSession{
-			ID:               "session-1",
-			AdminID:          "admin-1",
-			AccessTokenHash:  "access-hash-1",
-			RefreshTokenHash: hashSHA256("refresh-token-1"),
-			CreatedAt:        now.Add(-1 * time.Hour),
-			LastUsedAt:       now.Add(-10 * time.Minute),
+			ID:              "session-1",
+			AdminID:         "admin-1",
+			AccessTokenHash: hashSHA256("access-token-1"),
+			CreatedAt:       now.Add(-1 * time.Hour),
+			LastUsedAt:      now.Add(-10 * time.Minute),
 		}
 		sessions.Sessions["session-1"] = session
 
 		s := NewAdminAuthService(nil, sessions, nil, nil, nil, nil, nil, &MockTxManager{})
-
 		s.nowFn = func() time.Time { return now }
 
 		// Act
-		newAccess, err := s.RefreshToken(context.Background(), "refresh-token-1")
+		got, err := s.ValidateAccessToken(context.Background(), "access-token-1")
 
 		// Assert
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
-		if newAccess == "" {
-			t.Fatal("expected non-empty access token")
+		if !got.LastUsedAt.Equal(now) {
+			t.Errorf("expected LastUsedAt to slide to %v, got %v", now, got.LastUsedAt)
+		}
+	})
+
+	t.Run("ShouldFailWhenAccessTokenIdleExpired", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		sessions := NewMockAdminSessionRepository()
+		session := &domain.AdminSession{
+			ID:              "session-1",
+			AdminID:         "admin-1",
+			AccessTokenHash: hashSHA256("access-token-1"),
+			CreatedAt:       now.Add(-13 * time.Hour),
+			LastUsedAt:      now.Add(-13 * time.Hour),
+		}
+		sessions.Sessions["session-1"] = session
+
+		s := NewAdminAuthService(nil, sessions, nil, nil, nil, nil, nil, &MockTxManager{})
+		s.nowFn = func() time.Time { return now }
+
+		// Act
+		_, err := s.ValidateAccessToken(context.Background(), "access-token-1")
+
+		// Assert
+		if err == nil {
+			t.Fatal("expected error, got nil")
 		}
 	})
 }

--- a/backend/internal/usecase/mock_test.go
+++ b/backend/internal/usecase/mock_test.go
@@ -451,15 +451,6 @@ func (r *MockAdminSessionRepository) GetByAccessTokenHash(ctx context.Context, h
 	return nil, nil
 }
 
-func (r *MockAdminSessionRepository) GetByRefreshTokenHash(ctx context.Context, hash string) (*domain.AdminSession, error) {
-	for _, s := range r.Sessions {
-		if s.RefreshTokenHash == hash {
-			return s, nil
-		}
-	}
-	return nil, nil
-}
-
 func (r *MockAdminSessionRepository) Save(ctx context.Context, session *domain.AdminSession) error {
 	r.Sessions[session.ID] = session
 	return nil

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -125,7 +125,6 @@ type AdminRepository interface {
 type AdminSessionRepository interface {
 	Get(ctx context.Context, id domain.AdminSessionID) (*domain.AdminSession, error)
 	GetByAccessTokenHash(ctx context.Context, hash string) (*domain.AdminSession, error)
-	GetByRefreshTokenHash(ctx context.Context, hash string) (*domain.AdminSession, error)
 	Save(ctx context.Context, session *domain.AdminSession) error
 	ListByAdmin(ctx context.Context, adminID domain.AdminID) ([]*domain.AdminSession, error)
 }

--- a/docs/artifacts/plan/20260716_admin_refresh_removal_frontend_notice_.md
+++ b/docs/artifacts/plan/20260716_admin_refresh_removal_frontend_notice_.md
@@ -1,0 +1,74 @@
+# [프론트엔드 공지] 관리자 인증 API 변경 — Refresh Token 제거
+
+> 대상: Flutter 관리자 앱(`main_admin.dart`) 개발자
+> 관련 plan: `20260716_admin_refresh_token_removal_plan_.md` (같은 폴더)
+> 상태: 백엔드 구현 진행 중 (이 문서 기준으로 프론트 작업 시작 가능)
+
+## 한 줄 요약
+
+관리자 로그인에서 **refresh token이 완전히 없어집니다.** access token 하나만 발급되고, 대신 수명이 늘어나고(30분 → 12시간) 활동이 있으면 자동 연장(슬라이딩)됩니다.
+
+## 왜 바뀌나
+
+기존 구조는 access/refresh 이중 토큰 + refresh 시 idle TTL만 연장하는 방식이었는데, 이건 JWT의 단점(짧은 access TTL 강제)과 전통적 세션의 단점(탈취 시 재사용 가능)을 동시에 안고 있었습니다. 관리자 계정은 opaque token으로 서버가 이미 완전히 통제하고 있어서, 이 이중 구조가 주는 이점이 없다고 판단해 제거합니다.
+
+## API 변경 사항
+
+### 1. `POST /auth/admin/login` 응답 변경
+
+**Before**
+```json
+{
+  "accessToken": "...",
+  "refreshToken": "...",
+  "expiresInSeconds": 1800
+}
+```
+
+**After**
+```json
+{
+  "accessToken": "...",
+  "expiresInSeconds": 43200
+}
+```
+
+- `refreshToken` 필드가 응답에서 **완전히 사라집니다.**
+- `expiresInSeconds`가 1800(30분) → 43200(12시간)으로 늘어납니다.
+
+### 2. `POST /auth/admin/refresh` 엔드포인트 삭제
+
+- 이 엔드포인트는 더 이상 존재하지 않습니다 (404).
+- `AdminRefreshAuth` 시큐리티 스킴도 API 문서에서 사라집니다.
+
+### 3. 슬라이딩 세션 동작 (새로 생김)
+
+- access token을 사용해 API를 호출할 때마다(인증 성공 시) 서버가 내부적으로 만료 시각을 12시간 뒤로 다시 연장합니다.
+- 즉, **앱을 계속 쓰고 있으면 로그아웃되지 않고**, 12시간 이상 아예 요청을 안 보내면(방치) 그때 토큰이 만료되어 401이 납니다.
+- 프론트가 별도로 "언제 갱신할지" 신경 쓸 필요 없음 — 그냥 access token을 계속 같은 방식으로 보내기만 하면 됩니다.
+
+## 프론트엔드에서 해야 할 일
+
+1. **refresh 관련 코드 전부 제거**
+   - 로그인 응답에서 `refreshToken` 파싱/저장하는 코드 삭제
+   - `/auth/admin/refresh` 호출 로직(백그라운드 갱신 타이머, 401 인터셉터의 refresh 재시도 로직 등) 삭제
+   - 보안 저장소(Keychain 등)에 refresh token 저장하던 부분 제거
+
+2. **401 처리 방식 변경**
+   - 기존: access token 만료 → refresh 시도 → 실패 시 로그인 화면
+   - 변경 후: access token 만료(401) → **바로 로그인 화면으로 이동** (재시도 로직 불필요, 단순해짐)
+
+3. **access token만 안전하게 저장**
+   - `flutter_secure_storage` 등으로 access token만 저장하면 됩니다 (구조 단순화).
+
+4. **UX 참고**
+   - TTL이 12시간+슬라이딩이라 실사용 중에는 거의 로그아웃 안 됩니다. 앱을 며칠간 아예 안 켰을 때만 재로그인이 필요합니다.
+
+## 영향받지 않는 것
+
+- `TrustedDeviceAuth`, `TrackAuth` (진행자/기기 신뢰 토큰) — 이번 변경과 무관, 그대로 유지됩니다.
+- 로그인 요청(`AdminLoginRequest`), 로그아웃(`/auth/admin/logout`), 세션 목록/강제종료 API — 응답 스키마 변경 없음.
+
+## 문의
+
+백엔드 구현 세부사항이나 스키마 관련 질문은 위 plan 문서 참고, 그 외 궁금한 점 있으면 언제든 물어봐 주세요.

--- a/docs/artifacts/plan/20260716_admin_refresh_token_removal_plan_.md
+++ b/docs/artifacts/plan/20260716_admin_refresh_token_removal_plan_.md
@@ -1,0 +1,158 @@
+# 관리자 Refresh Token 제거 Plan
+
+## 배경
+
+관리자 인증은 opaque token(불투명 토큰) 방식이라 서버가 세션을 DB 해시 조회로 완전히 통제한다. Refresh 토큰을 두는 이유는 보통 JWT처럼 "발급 후 서버 통제력이 약해지는" 토큰에서 access 토큰 수명을 짧게 유지하기 위함인데, 지금 구조는 그 이점 없이 (refresh 토큰 미rotate, idle TTL만 연장) 세션 하이재킹 취약점만 추가로 안고 있다.
+
+관리자 계정 수가 적고 로그인 UX 비용이 크지 않으므로, refresh 플로우를 완전히 제거하고 access 토큰 단일 구조 + TTL 연장으로 단순화한다.
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| **P0** | UC-11 로그인 (변경) | 관리자 ID/PW 로그인 시 access 토큰만 발급 (refresh 토큰 발급 제거) | **프로덕션 핵심 로직** |
+| **P0** | UC-13 액세스 토큰 검증 (유지) | 기존 로직 그대로, TTL 상수만 연장 | **프로덕션 핵심 로직** |
+| P1 | UC-12 리프레시 (삭제) | `AdminAuthService.RefreshToken`, `/auth/admin/refresh` 엔드포인트, `AdminRefreshAuth` 시큐리티 스킴 전체 삭제 | 제거 대상 |
+| P1 | 만료 시 재로그인 | Access 토큰 만료 시 클라이언트는 재로그인만 수행 (refresh 재발급 없음) | 프론트 영향 있음 — 프론트 별도 대응 필요 (본 plan은 백엔드 한정) |
+
+## 아키텍처 영향
+
+- Domain / Usecase / Infrastructure 3계층 모두 수정. `domain`은 외부 의존성 없이 필드/메서드만 제거.
+- 새 인터페이스 생성 없음 — 기존 `AdminAuthUsecase`, `AdminSessionRepository` 포트에서 불필요해진 메서드만 제거.
+- **API 스키마 변경 있음** → `workflow/Collaborate.md` 절차에 따라 swagger 주석(`auth_handler.go`, `doc.go`) 갱신 필수 (본 레포는 별도 `api/openapi.yaml` 없이 `swag` 주석이 소스임을 확인함).
+
+## 객체/메서드 변경 정의
+
+### Domain — `backend/internal/domain/admin.go`
+
+```go
+type AdminSession struct {
+    ID              AdminSessionID
+    AdminID         AdminID
+    AccessTokenHash string
+    // RefreshTokenHash string  // 삭제
+    DeviceInfo      string
+    CreatedAt       time.Time
+    LastUsedAt      time.Time
+    RevokedAt       Optional[time.Time]
+}
+
+// TouchRefresh → TouchActivity(now)로 이름 변경 (역할: 슬라이딩 세션의 활동 시각 갱신, refresh 전용 의미 제거)
+// IsRefreshExpired → IsExpired(now, idleTTL)로 이름 변경 (refresh 문맥 제거, access 세션의 idle 만료 판정으로 의미 전환)
+// Revoke(now)는 유지 — 로그아웃/강제 종료에 계속 사용됨
+```
+
+### Usecase — `backend/internal/usecase/auth_admin.go`
+
+```go
+const AdminAccessTokenTTL = 12 * time.Hour // 30분 → 12시간으로 연장 (재로그인 부담 완화)
+// AdminRefreshTokenIdleTTL 삭제
+
+// Login - UC-11 (시그니처 변경: refresh 토큰 반환 제거)
+func (s *AdminAuthService) Login(
+    ctx context.Context,
+    username string,
+    password string,
+    deviceInfo string,
+) (string /* access token */, *domain.AdminSession, error)
+
+// RefreshToken - UC-12 전체 삭제
+
+// ValidateAccessToken - UC-13 (슬라이딩 세션: 검증 성공 시 LastUsedAt 갱신 후 저장)
+func (s *AdminAuthService) ValidateAccessToken(
+    ctx context.Context,
+    accessToken string,
+) (*domain.AdminSession, error)
+// 책임: 세션 조회 + 만료/취소 확인 + LastUsedAt 갱신(TouchActivity) + 저장(활동 있으면 TTL 연장, 방치 시 12h 후 만료)
+```
+
+### Port — `backend/internal/usecase/port.go`
+
+```go
+type AdminSessionRepository interface {
+    // GetByRefreshTokenHash(ctx, hash) 삭제
+    // 나머지 메서드 유지
+}
+```
+
+### Web — `backend/internal/infrastructure/web/auth_handler.go`
+
+```go
+type AdminAuthUsecase interface {
+    Login(ctx context.Context, username, password, deviceInfo string) (string, *domain.AdminSession, error)
+    // RefreshToken(...) 삭제
+    RevokeSession(ctx context.Context, sessionID domain.AdminSessionID, actorAdminID domain.AdminID) error
+    ListSessions(ctx context.Context, adminID domain.AdminID) ([]*domain.AdminSession, error)
+    ForceTrackLogout(ctx context.Context, trackID domain.TrackID, actorAdminID domain.AdminID) error
+}
+
+type AdminLoginResponse struct {
+    AccessToken      string `json:"accessToken"`
+    // RefreshToken 필드 삭제
+    ExpiresInSeconds int    `json:"expiresInSeconds"` // 1800 → 43200 (12h)
+}
+
+// AdminRefreshResponse 구조체 전체 삭제
+// AdminRefresh 핸들러 전체 삭제 (swagger 주석 포함)
+```
+
+### Router — `backend/internal/infrastructure/web/router.go`
+
+- `admin.POST("/auth/admin/refresh", h.Auth.AdminRefresh)` 라인 삭제
+
+### Swagger 문서 헤더 — `backend/internal/infrastructure/web/doc.go`
+
+- `@securityDefinitions.apikey AdminRefreshAuth` 및 설명 라인 삭제
+- `swag init` (또는 프로젝트의 codegen 커맨드) 재실행하여 생성 문서 갱신
+
+### Postgres — `backend/internal/infrastructure/postgres/admin_session_repo.go`, `db/query.sql`, `db/schema.sql`
+
+```sql
+-- db/schema.sql
+-- admin_sessions 테이블에서 refresh_token_hash 컬럼 삭제
+```
+
+- `GetAdminSessionByRefreshTokenHash` 쿼리 삭제
+- 나머지 쿼리(`GetAdminSessionByID`, `GetAdminSessionByAccessTokenHash`, list, `CreateAdminSession`)에서 `refresh_token_hash` 컬럼 참조 제거
+- `sqlc generate` 재실행하여 `internal/infrastructure/postgres/db/*.go` 갱신 (직접 손으로 수정하지 않음)
+- **DB 마이그레이션 도구 없음(레포에 `db/migrations/` 부재, `db/schema.sql` 단일 소스)** → 실제 운영 DB에 반영할 `ALTER TABLE admin_sessions DROP COLUMN refresh_token_hash;` 실행 방법은 사용자 확인 필요 (로컬 개발 DB는 schema.sql 재적용으로 충분하나, 배포 환경 반영 절차는 이 plan 범위 밖)
+
+### Tests
+
+- `internal/domain/admin_test.go`: `RefreshTokenHash`, `IsRefreshExpired`, `TouchRefresh` 관련 테스트 삭제
+- `internal/usecase/auth_admin_test.go`: `Login` 테스트에서 refresh 반환값 검증 제거, `TestAdminAuthService_RefreshToken` 전체 삭제
+- `internal/usecase/mock_test.go`: `MockAdminSessionRepository.GetByRefreshTokenHash` 삭제
+
+## 구현 단계
+
+| Phase | 작업 | 파일 | 예상 소요 |
+|---|---|---|---|
+| A | Domain 계층 수정 (필드/메서드 삭제) | `internal/domain/admin.go`, `admin_test.go` | 15분 |
+| B | Usecase 계층 수정 (Login 시그니처, RefreshToken 삭제, TTL 상수) | `internal/usecase/auth_admin.go`, `port.go`, `auth_admin_test.go`, `mock_test.go` | 30분 |
+| C | Web 계층 수정 (핸들러/DTO/라우터/swagger) | `auth_handler.go`, `router.go`, `doc.go` | 30분 |
+| D | DB 계층 수정 (schema, query, sqlc 재생성, repo) | `db/schema.sql`, `db/query.sql`, `admin_session_repo.go` | 30분 |
+| E | 전체 빌드/테스트, swag 재생성 확인 | - | 15분 |
+
+## 검증 체크리스트
+
+### 아키텍처 검증
+- [ ] `domain` 패키지에 외부 의존성 없음 (변경 없음, 필드만 제거)
+- [ ] `usecase` 계층이 여전히 `AdminSessionRepository` 인터페이스에만 의존
+- [ ] 새 인터페이스 생성 없음 (기존 포트 축소만 진행)
+
+### 유즈케이스 검증
+- [ ] UC-11: 로그인 시 access 토큰만 반환, refresh 토큰 없음
+- [ ] UC-13: access 토큰이 TTL(12h) 내에서 유효, 만료 후 401
+- [ ] `/auth/admin/refresh` 라우트 자체가 404 (삭제 확인)
+- [ ] `go build ./...`, `go vet ./...` 통과
+- [ ] `go test ./...` 통과 (수정된 테스트 포함)
+- [ ] swagger 생성 문서에 `AdminRefreshAuth`/`AdminRefreshResponse` 미노출
+- [ ] `sqlc generate` 후 `admin_sessions` 관련 생성 코드에 `refresh_token_hash` 미참조
+
+### 확정된 결정 사항
+- [x] 슬라이딩 세션 적용: `ValidateAccessToken` 성공 시 `LastUsedAt` 갱신 + 저장 (활동 있으면 연장, idle 12h 후 만료)
+- [x] Access 토큰 TTL: 12시간 (idle 기준)
+- [x] 대상 클라이언트: 모바일(Flutter)만 우선 고려. 웹(캠프 생성용)은 별도 검토 대상, 이 plan 범위 밖
+
+### 미결 사항 (사용자 확인 필요)
+- [ ] 운영 DB에 `refresh_token_hash` 컬럼 DROP을 어떻게 반영할지 (마이그레이션 도구 부재 — 로컬 개발은 schema.sql 재적용으로 충분)


### PR DESCRIPTION
## Summary
- Removed the admin refresh-token flow entirely (`POST /auth/admin/refresh`, `AdminRefreshAuth`, `RefreshToken` usecase/domain/DB fields) — it added the reuse-hijack risk of a traditional session on top of JWT-style access-token TTL pressure, without the benefit either design intends, since admin sessions are already opaque tokens fully controlled server-side.
- Extended `AdminAccessTokenTTL` from 30 minutes to 12 hours and made it a sliding session: `ValidateAccessToken` now refreshes `LastUsedAt` on every successful check, so active admins stay logged in and idle ones expire after 12h.
- Dropped `refresh_token_hash` from `admin_sessions` (schema + sqlc regen) and regenerated the swagger spec (`api/docs.go`, `api/swagger.yaml`, `api/swagger.json`).
- Added plan docs at `backend/docs/artifacts/plan/` and `docs/artifacts/plan/`, plus a frontend-facing change notice (`docs/artifacts/plan/20260716_admin_refresh_removal_frontend_notice_.md`) describing the API/behavior change for the Flutter admin app.

## Frontend impact
Login response no longer includes `refreshToken`; `expiresInSeconds` is now 43200. `/auth/admin/refresh` is gone (404). On 401, the app should go straight to re-login instead of attempting a refresh. See the frontend notice doc for details.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (updated domain/usecase tests for sliding-session behavior)
- [x] `sqlc generate` — verified no `refresh_token_hash` remains in generated code
- [x] `make swag` — verified `AdminRefreshAuth`/`AdminRefreshResponse` no longer appear in generated spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)