### PR TITLE
feat: 관리자 앱 골격 라우팅 완료

### DIFF
--- a/frontend/docs/artifacts/plan/프론트엔드_스캐폴딩_아키텍처_plan_20260709/06_admin_app_skeleton.md
+++ b/frontend/docs/artifacts/plan/프론트엔드_스캐폴딩_아키텍처_plan_20260709/06_admin_app_skeleton.md
@@ -1,5 +1,7 @@
 # Phase 06 — 관리자 앱 골격 (A0~A15)
 
+> 구현 상태: 진행 중 (`feat/admin-skeleton-test-infra`, 2026-07-16)
+
 > 선행조건: Phase 02(디자인시스템), 03(API 계층/entities), 04(인증/SSE), 05(진행자 앱 골격 — 공유 기반이 좁은 화면 세트로 먼저 검증됨).
 > 목적: 관리자 앱(`AdminApp`)의 캠프 상태별 사이드바 3모드 라우팅 가드를 세우고, A0~A15 20개 화면을 빈 Scaffold로 스캐폴딩한다. 실제 레이아웃(§screen-spec-admin.md 상세)은 이 Phase의 범위 밖.
 > 근거: screen-spec-admin.md "전체 내비게이션 구조", design-system.md §3.2(3모드 사이드바 그리드).
@@ -77,9 +79,9 @@ class DashboardScreen extends ConsumerWidget {
 예상 소요시간: **14~18시간** (화면 20개 스캐폴딩 자체는 반복 작업이나, 3모드 라우트 가드와 A2B의 A3/A4 통합 진입점 배선이 핵심 난이도).
 
 ## 4. 검증
-- [ ] PENDING 캠프 진입 시 대시보드(A1)/메시지(A10·A11)/리포트(A12)/감사로그(A13) 라우트가 차단되고, 코너·트랙(A2B)/조현황(A5)/기기관리(A8)/설정(A15)만 허용된다(URL 직접 조작 시도로도 우회 불가)
-- [ ] ENDED 캠프는 리포트(A12) 외 전 라우트가 차단된다
-- [ ] 로그인(A0)/초기설정마법사(A0-b)/캠프목록(A0-c)/QR배지사전생성(A0-d) 4화면만 사이드바 없이 렌더링되고, 나머지 화면은 항상 3모드 사이드바 중 하나를 동반한다
-- [ ] `AdminSidebar`가 캠프 상태 변경(예: A0-e "코너학습 시작" 실행)에 반응해 재조회 없이 즉시 모드를 전환한다
-- [ ] A2(코너상세) 화면에는 "전체 PIN 내보내기" 버튼이 없고 A2B에만 존재함을 코드 리뷰로 확인(screen-spec-admin.md A4 결정 반영)
-- [ ] `flutter run -t lib/main_admin.dart --flavor admin`으로 실기기/에뮬레이터에서 A0→A0-c→(PENDING 캠프 선택)→A2B, (ACTIVE 캠프 선택)→A1 두 경로가 목업 provider override로 수동 구동된다
+- [x] PENDING 캠프 진입 시 대시보드(A1)/메시지(A10·A11)/리포트(A12)/감사로그(A13) 라우트가 차단되고, 코너·트랙(A2B)/조현황(A5)/기기관리(A8)/설정(A15)만 허용된다(URL 직접 조작 시도로도 우회 불가). `admin_router_test.dart`로 PENDING 차단을 검증했다.
+- [x] ENDED 캠프는 리포트(A12) 외 전 라우트가 차단된다. `admin_router_test.dart`로 설정 라우트 차단을 검증했다.
+- [x] 로그인(A0)/초기설정마법사(A0-b)/캠프목록(A0-c)/QR배지사전생성(A0-d) 4화면만 사이드바 없이 렌더링되고, 나머지 화면은 항상 3모드 사이드바 중 하나를 동반한다. 독립 라우트와 `AdminScaffold` 적용을 코드 리뷰했다.
+- [x] `AdminSidebar`가 캠프 상태 변경(예: A0-e "코너학습 시작" 실행)에 반응해 재조회 없이 즉시 모드를 전환한다. `admin_router_test.dart`의 시작 성공 시나리오로 검증했다.
+- [x] A2(코너상세) 화면에는 "전체 PIN 내보내기" 버튼이 없고 A2B에만 존재함을 코드 리뷰로 확인했다(screen-spec-admin.md A4 결정 반영).
+- [x] `flutter run -t lib/main_admin.dart --flavor admin` 수동 검증은 제외한다(사용자 결정, 2026-07-16). 동일 상태 전이는 `test/admin/router/admin_router_test.dart`의 Riverpod override 기반 자동 검증으로 확인한다.

--- a/frontend/lib/admin/entities/group_ext.dart
+++ b/frontend/lib/admin/entities/group_ext.dart
@@ -1,19 +1,17 @@
 import '../../shared/api/domain_aliases.dart' as api;
 
 extension AdminGroupX on api.Group {
-  bool get isFinished {
-    final Iterable<api.CornerProgress> itin = itinerary ?? const <api.CornerProgress>[];
-    if (itin.isEmpty) return false;
-    return itin.every((p) => p.status == api.VisitStatusPerCorner.COMPLETED);
-  }
-
   int get completedCount {
-    final Iterable<api.CornerProgress> itin = itinerary ?? const <api.CornerProgress>[];
-    return itin.where((p) => p.status == api.VisitStatusPerCorner.COMPLETED).length;
+    final Iterable<api.CornerProgress> itin =
+        itinerary ?? const <api.CornerProgress>[];
+    return itin
+        .where((p) => p.status == api.VisitStatusPerCorner.COMPLETED)
+        .length;
   }
 
   String get completedCountLabel {
-    final Iterable<api.CornerProgress> itin = itinerary ?? const <api.CornerProgress>[];
+    final Iterable<api.CornerProgress> itin =
+        itinerary ?? const <api.CornerProgress>[];
     final total = itin.length;
     return '$completedCount/$total';
   }

--- a/frontend/lib/admin/features/broadcast/broadcast_screen.dart
+++ b/frontend/lib/admin/features/broadcast/broadcast_screen.dart
@@ -1,0 +1,5 @@
+import '../admin_stub_screen.dart';
+
+class BroadcastScreen extends AdminStubScreen {
+  const BroadcastScreen({super.key}) : super(title: 'A10 공지');
+}

--- a/frontend/lib/admin/features/corner_detail/corner_detail_screen.dart
+++ b/frontend/lib/admin/features/corner_detail/corner_detail_screen.dart
@@ -1,0 +1,6 @@
+import '../admin_stub_screen.dart';
+
+/// A2. PIN 내보내기는 A2B에서만 제공한다.
+class CornerDetailScreen extends AdminStubScreen {
+  const CornerDetailScreen({super.key}) : super(title: 'A2 코너 상세');
+}

--- a/frontend/lib/admin/features/device_registration/device_registration_screen.dart
+++ b/frontend/lib/admin/features/device_registration/device_registration_screen.dart
@@ -1,0 +1,5 @@
+import '../admin_stub_screen.dart';
+
+class DeviceRegistrationScreen extends AdminStubScreen {
+  const DeviceRegistrationScreen({super.key}) : super(title: 'A8 기기 등록 관리');
+}

--- a/frontend/lib/admin/features/duplicate_visit_approve/duplicate_visit_approve_screen.dart
+++ b/frontend/lib/admin/features/duplicate_visit_approve/duplicate_visit_approve_screen.dart
@@ -1,0 +1,6 @@
+import '../admin_stub_screen.dart';
+
+class DuplicateVisitApproveScreen extends AdminStubScreen {
+  const DuplicateVisitApproveScreen({super.key})
+    : super(title: 'A7 중복 방문 예외 승인');
+}

--- a/frontend/lib/admin/features/end_camp/end_camp_screen.dart
+++ b/frontend/lib/admin/features/end_camp/end_camp_screen.dart
@@ -1,0 +1,5 @@
+import '../admin_stub_screen.dart';
+
+class EndCampScreen extends AdminStubScreen {
+  const EndCampScreen({super.key}) : super(title: 'A14 코너학습 종료');
+}

--- a/frontend/lib/admin/features/group_detail/group_detail_screen.dart
+++ b/frontend/lib/admin/features/group_detail/group_detail_screen.dart
@@ -1,0 +1,5 @@
+import '../admin_stub_screen.dart';
+
+class GroupDetailScreen extends AdminStubScreen {
+  const GroupDetailScreen({super.key}) : super(title: 'A6 조 상세');
+}

--- a/frontend/lib/admin/features/group_list/group_list_screen.dart
+++ b/frontend/lib/admin/features/group_list/group_list_screen.dart
@@ -1,0 +1,5 @@
+import '../admin_stub_screen.dart';
+
+class GroupListScreen extends AdminStubScreen {
+  const GroupListScreen({super.key}) : super(title: 'A5 조 현황');
+}

--- a/frontend/lib/admin/features/lockout_session_manage/lockout_session_manage_screen.dart
+++ b/frontend/lib/admin/features/lockout_session_manage/lockout_session_manage_screen.dart
@@ -1,0 +1,5 @@
+import '../admin_stub_screen.dart';
+
+class LockoutSessionManageScreen extends AdminStubScreen {
+  const LockoutSessionManageScreen({super.key}) : super(title: 'A9 잠금해제·세션 관리');
+}

--- a/frontend/lib/admin/features/track_direct/track_direct_screen.dart
+++ b/frontend/lib/admin/features/track_direct/track_direct_screen.dart
@@ -1,0 +1,5 @@
+import '../admin_stub_screen.dart';
+
+class TrackDirectScreen extends AdminStubScreen {
+  const TrackDirectScreen({super.key}) : super(title: 'A11 트랙 다이렉트');
+}

--- a/frontend/lib/admin/router/admin_router.dart
+++ b/frontend/lib/admin/router/admin_router.dart
@@ -7,6 +7,15 @@ import 'package:cornermon/admin/features/login/login_screen.dart';
 import 'package:cornermon/admin/features/camp_list/camp_list_screen.dart';
 import 'package:cornermon/admin/features/badge_precreate/badge_precreate_screen.dart';
 import 'package:cornermon/admin/features/dashboard/dashboard_screen.dart';
+import 'package:cornermon/admin/features/corner_detail/corner_detail_screen.dart';
+import 'package:cornermon/admin/features/group_list/group_list_screen.dart';
+import 'package:cornermon/admin/features/group_detail/group_detail_screen.dart';
+import 'package:cornermon/admin/features/duplicate_visit_approve/duplicate_visit_approve_screen.dart';
+import 'package:cornermon/admin/features/device_registration/device_registration_screen.dart';
+import 'package:cornermon/admin/features/lockout_session_manage/lockout_session_manage_screen.dart';
+import 'package:cornermon/admin/features/broadcast/broadcast_screen.dart';
+import 'package:cornermon/admin/features/track_direct/track_direct_screen.dart';
+import 'package:cornermon/admin/features/end_camp/end_camp_screen.dart';
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_screen.dart';
 import 'package:cornermon/admin/session/admin_session_provider.dart';
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
@@ -41,31 +50,57 @@ final adminRouterProvider = Provider<GoRouter>((ref) {
         builder: (_, _) => const SetupWizardScreen(),
       ),
       GoRoute(path: '/camps', builder: (_, _) => const CampListScreen()),
-      _plainRoute('/camps/start', 'A0-e 코너학습 시작'),
       GoRoute(path: '/badges', builder: (_, _) => const BadgePrecreateScreen()),
       GoRoute(
         path: '/dashboard',
         builder: (_, _) => const AdminScaffold(body: DashboardScreen()),
       ),
-      _screenRoute('/corners/:cornerId', 'A2 코너 상세'),
+      GoRoute(
+        path: '/corners/:cornerId',
+        builder: (_, _) => const AdminScaffold(body: CornerDetailScreen()),
+      ),
       _screenRoute('/corner-track-manage', 'A2B 코너·트랙 관리'),
-      _screenRoute('/groups', 'A5 조 현황'),
-      _screenRoute('/groups/:groupId', 'A6 조 상세'),
-      _screenRoute('/devices', 'A8 기기 관리'),
-      _screenRoute('/sessions', 'A9 세션 관리'),
-      _screenRoute('/messages/broadcast', 'A10 공지 메시지'),
-      _screenRoute('/messages/direct', 'A11 다이렉트 메시지'),
+      GoRoute(
+        path: '/groups',
+        builder: (_, _) => const AdminScaffold(body: GroupListScreen()),
+      ),
+      GoRoute(
+        path: '/groups/:groupId',
+        builder: (_, _) => const AdminScaffold(body: GroupDetailScreen()),
+      ),
+      GoRoute(
+        path: '/groups/:groupId/duplicate-visits',
+        builder: (_, _) =>
+            const AdminScaffold(body: DuplicateVisitApproveScreen()),
+      ),
+      GoRoute(
+        path: '/devices',
+        builder: (_, _) =>
+            const AdminScaffold(body: DeviceRegistrationScreen()),
+      ),
+      GoRoute(
+        path: '/sessions',
+        builder: (_, _) =>
+            const AdminScaffold(body: LockoutSessionManageScreen()),
+      ),
+      GoRoute(
+        path: '/messages/broadcast',
+        builder: (_, _) => const AdminScaffold(body: BroadcastScreen()),
+      ),
+      GoRoute(
+        path: '/messages/direct',
+        builder: (_, _) => const AdminScaffold(body: TrackDirectScreen()),
+      ),
       _screenRoute('/report', 'A12 리포트'),
       _screenRoute('/audit-log', 'A13 감사 로그'),
+      GoRoute(
+        path: '/end-camp',
+        builder: (_, _) => const AdminScaffold(body: EndCampScreen()),
+      ),
       _screenRoute('/settings', 'A15 설정'),
     ],
   );
 });
-
-GoRoute _plainRoute(String path, String title) => GoRoute(
-  path: path,
-  builder: (_, _) => AdminStubScreen(title: title),
-);
 
 GoRoute _screenRoute(String path, String title) => GoRoute(
   path: path,
@@ -92,8 +127,7 @@ String? _redirect(Ref ref, String location) {
   return switch (camp!.status!) {
     CampStatus.PENDING =>
       _preparingLocations.contains(location) ? null : '/corner-track-manage',
-    CampStatus.ACTIVE =>
-      _preparingLocations.contains(location) ? '/dashboard' : null,
+    CampStatus.ACTIVE => null,
     CampStatus.ENDED => location == '/report' ? null : '/report',
     _ => '/camps',
   };

--- a/frontend/lib/admin/widgets/corner_status_card.dart
+++ b/frontend/lib/admin/widgets/corner_status_card.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+/// 관리자 대시보드에서 쓰는 코너 상태 카드의 공통 골격이다.
+class CornerStatusCard extends StatelessWidget {
+  const CornerStatusCard({
+    required this.title,
+    required this.statusLabel,
+    required this.statusIcon,
+    required this.statusColor,
+    required this.trackSummary,
+    required this.durationSummary,
+    this.isBottleneck = false,
+    this.onTap,
+    super.key,
+  });
+
+  final String title;
+  final String statusLabel;
+  final IconData statusIcon;
+  final Color statusColor;
+  final String trackSummary;
+  final String durationSummary;
+  final bool isBottleneck;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) => Card(
+    clipBehavior: Clip.antiAlias,
+    child: InkWell(
+      onTap: onTap,
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border(
+            left: BorderSide(
+              color: isBottleneck ? Colors.red : statusColor,
+              width: 4,
+            ),
+          ),
+        ),
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(title, style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Icon(statusIcon, color: statusColor),
+                const SizedBox(width: 6),
+                Text(statusLabel),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(trackSummary),
+            const SizedBox(height: 4),
+            Text(durationSummary),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/frontend/lib/admin/widgets/sortable_data_table.dart
+++ b/frontend/lib/admin/widgets/sortable_data_table.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+
+class SortableDataTableColumn<T> {
+  const SortableDataTableColumn({
+    required this.label,
+    required this.valueOf,
+    required this.cellBuilder,
+  });
+
+  final String label;
+  final Comparable<dynamic>? Function(T item) valueOf;
+  final Widget Function(T item) cellBuilder;
+}
+
+/// 관리자 목록 화면의 정렬 헤더, 필터 바, 건수 표시를 통일한다.
+class SortableDataTable<T> extends StatefulWidget {
+  const SortableDataTable({
+    required this.items,
+    required this.columns,
+    required this.filterBar,
+    super.key,
+  });
+
+  final List<T> items;
+  final List<SortableDataTableColumn<T>> columns;
+  final Widget filterBar;
+
+  @override
+  State<SortableDataTable<T>> createState() => _SortableDataTableState<T>();
+}
+
+class _SortableDataTableState<T> extends State<SortableDataTable<T>> {
+  int? _sortColumnIndex;
+  bool _ascending = true;
+
+  @override
+  Widget build(BuildContext context) {
+    final items = [...widget.items];
+    if (_sortColumnIndex case final index?) {
+      final column = widget.columns[index];
+      items.sort((left, right) {
+        final result =
+            (column.valueOf(left)?.compareTo(column.valueOf(right)) ?? 0);
+        return _ascending ? result : -result;
+      });
+    }
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        widget.filterBar,
+        const SizedBox(height: 12),
+        Text('${items.length}/${widget.items.length}건'),
+        const SizedBox(height: 8),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: DataTable(
+            sortColumnIndex: _sortColumnIndex,
+            sortAscending: _ascending,
+            columns: [
+              for (var index = 0; index < widget.columns.length; index++)
+                DataColumn(
+                  label: Text(widget.columns[index].label),
+                  onSort: (_, ascending) => setState(() {
+                    _sortColumnIndex = index;
+                    _ascending = ascending;
+                  }),
+                ),
+            ],
+            rows: [
+              for (final item in items)
+                DataRow(
+                  cells: [
+                    for (final column in widget.columns)
+                      DataCell(column.cellBuilder(item)),
+                  ],
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/test/admin/router/admin_router_test.dart
+++ b/frontend/test/admin/router/admin_router_test.dart
@@ -197,6 +197,27 @@ void main() {
     expect(find.text('조건에 맞는 코너가 없습니다'), findsOneWidget);
   });
 
+  testWidgets('ShouldAllowPreparingRoutesWhenCampIsActive', (tester) async {
+    // arrange
+    final campId = CampId('camp-1');
+    final container = _container(
+      session: authenticated,
+      campId: campId,
+      camp: _camp(CampStatus.ACTIVE),
+      camps: [_camp(CampStatus.ACTIVE)],
+    );
+    addTearDown(container.dispose);
+    await _pumpApp(tester, container);
+
+    // act
+    container.read(adminRouterProvider).go('/groups');
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(find.text('A5 조 현황'), findsOneWidget);
+    expect(find.byType(AdminSidebar), findsOneWidget);
+  });
+
   testWidgets('ShouldNavigateToDashboardWhenStartCampSucceeds', (tester) async {
     // arrange
     final campId = CampId('camp-1');


### PR DESCRIPTION
## 변경 사항
- 누락된 A2, A5~A11, A14 화면 스텁과 관리자 공통 상태 카드·정렬 테이블을 추가했습니다.
- ACTIVE 캠프에서 준비 모드 경로를 대시보드로 강제 이동시키던 가드를 제거했습니다.
- A0-e는 준비 모드 AdminScaffold의 시작 버튼으로 유지하고, PENDING 허용 라우트를 A2B/A5/A8/A15로 제한했습니다.

## 종료 조건
- PENDING/ENDED 차단과 ACTIVE 허용은 Riverpod override 기반 라우터 테스트로 검증했습니다.
- 사이드바 예외와 캠프 상태 변경 시 모드 전환은 기존 관리자 라우터 테스트로 검증했습니다.
- A2에 전체 PIN 내보내기 진입점을 추가하지 않았습니다.
- 수동 flutter run 검증은 사용자 결정으로 제외했고, 계획 문서에 자동 검증 대체 근거를 기록했습니다.

## 검증
- flutter analyze lib/admin test integration_test 통과
- flutter test 통과 (111건)
- git diff --check 통과