### PR TITLE
test: Phase 07 테스트 인프라 추가

### DIFF
--- a/frontend/docs/artifacts/plan/프론트엔드_스캐폴딩_아키텍처_plan_20260709/07_test_infrastructure.md
+++ b/frontend/docs/artifacts/plan/프론트엔드_스캐폴딩_아키텍처_plan_20260709/07_test_infrastructure.md
@@ -1,5 +1,7 @@
 # Phase 07 — 테스트 인프라
 
+> 구현 상태: 진행 중 (`feat/admin-skeleton-test-infra`, 2026-07-16)
+
 > 선행조건: Phase 05(진행자 골격) 또는 06(관리자 골격) 중 하나 이상 완료(위젯 테스트 대상 화면이 존재해야 함).
 > 목적: Riverpod override 기반 단위·위젯 테스트 스캐폴딩과, 핵심 시나리오 1건을 검증하는 통합테스트 하네스를 갖춘다.
 > 근거: `workflow/plan.md` §5(검증 방법 명시 필수), `implement.md`(검증 중심 완료 원칙).
@@ -61,10 +63,10 @@ void main() {
 예상 소요시간: **5~7시간** (도메인/매퍼 계층이 없어져 단위테스트 대상이 provider·entities 확장으로 축소됨).
 
 ## 4. 검증
-- [ ] `flutter test`가 전체 그린(provider/entities/위젯 각 최소 1건 이상)
-- [ ] `flutter test test/facilitator/features/main_track_test.dart`가 실제 네트워크 요청 없이 provider override만으로 통과
-- [ ] `flutter test integration_test/facilitator_visit_flow_test.dart`가 에뮬레이터 또는 실기기 1대에서 통과
-- [ ] `admin/entities`, `facilitator/entities` 단위테스트가 생성 DTO fixture(JSON, openapi.yaml example 값)만으로 실행되고 네트워크·Riverpod 의존이 없다
+- [x] `flutter test`가 전체 그린(provider/entities/위젯 각 최소 1건 이상): 111건 통과(2026-07-16).
+- [x] `flutter test test/facilitator/features/main_track_test.dart`가 실제 네트워크 요청 없이 provider override만으로 통과했다.
+- [x] `flutter test integration_test/facilitator_visit_flow_test.dart` 실기기 실행은 제외한다(사용자 결정, 2026-07-16). 하네스 구현과 `integration_test` 의존성은 포함한다.
+- [x] `admin/entities`, `facilitator/entities` 단위테스트가 생성 DTO fixture(JSON, openapi.yaml example 값)만으로 실행되고 네트워크·Riverpod 의존이 없다.
 
 ## 5. 이번 Plan 전체 완료 기준
 `00_overview.md` §6 전체 검증 체크리스트와 이 Phase의 §4를 모두 통과하면, 상위 로드맵의 F-1~F-6가 "골격 수준"에서 완료된 것으로 간주하고, 화면별 실제 레이아웃 구현(§screen-spec-admin.md/screen-spec-facilitator.md 상세 반영)을 다루는 후속 Plan 착수로 넘어간다.

--- a/frontend/integration_test/facilitator_visit_flow_test.dart
+++ b/frontend/integration_test/facilitator_visit_flow_test.dart
@@ -1,0 +1,56 @@
+import 'package:cornermon/facilitator/widgets/double_tap_confirm_button.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('ShoudCompleteVisitWhenScanStartsAndEndIsConfirmedTwice', (
+    tester,
+  ) async {
+    // arrange
+    await tester.pumpWidget(const MaterialApp(home: _VisitFlowHarness()));
+
+    // act
+    await tester.tap(find.text('스캔 시작'));
+    await tester.pump();
+    await tester.tap(find.text('종료 확인'));
+    await tester.pump();
+    await tester.tap(find.text('다시 탭해 확인'));
+    await tester.pump();
+
+    // assert
+    expect(find.text('방문 완료 요약'), findsOneWidget);
+  });
+}
+
+class _VisitFlowHarness extends StatefulWidget {
+  const _VisitFlowHarness();
+
+  @override
+  State<_VisitFlowHarness> createState() => _VisitFlowHarnessState();
+}
+
+class _VisitFlowHarnessState extends State<_VisitFlowHarness> {
+  var _visitStarted = false;
+  var _visitComplete = false;
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+    body: Center(
+      child: _visitComplete
+          ? const Text('방문 완료 요약')
+          : _visitStarted
+          ? DoubleTapConfirmButton(
+              label: '종료 확인',
+              armedLabel: '다시 탭해 확인',
+              onConfirmed: () => setState(() => _visitComplete = true),
+            )
+          : FilledButton(
+              onPressed: () => setState(() => _visitStarted = true),
+              child: const Text('스캔 시작'),
+            ),
+    ),
+  );
+}

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -285,6 +285,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_driver:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -375,6 +380,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  fuchsia_remote_debug_protocol:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   glob:
     dependency: transitive
     description:
@@ -447,6 +457,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.1.6"
+  integration_test:
+    dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   io:
     dependency: transitive
     description:
@@ -735,6 +750,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: c6248e4526673988586e8c00bb22a49210c258dc91df5227d5da9748ecf79744
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.5"
   pub_semver:
     dependency: transitive
     description:
@@ -916,6 +939,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  sync_http:
+    dependency: transitive
+    description:
+      name: sync_http
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
@@ -1012,6 +1043,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
+  webdriver:
+    dependency: transitive
+    description:
+      name: webdriver
+      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -48,6 +48,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   flutter_lints: ^6.0.0
   build_runner: ^2.4.9
   riverpod_generator: ^4.0.4

--- a/frontend/test/admin/entities/group_ext_test.dart
+++ b/frontend/test/admin/entities/group_ext_test.dart
@@ -1,0 +1,34 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:cornermon/admin/entities/group_ext.dart';
+import 'package:cornermon/shared/api/domain_aliases.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Group _group(List<VisitStatusPerCorner> statuses, {required bool isFinished}) =>
+    Group(
+      (builder) => builder
+        ..isFinished = isFinished
+        ..itinerary = ListBuilder([
+          for (final status in statuses)
+            CornerProgress((progress) => progress..status = status),
+        ]),
+    );
+
+void main() {
+  test('ShoudExposeServerCompletionAndCountWhenItineraryIsProvided', () {
+    // arrange
+    final completed = _group([
+      VisitStatusPerCorner.COMPLETED,
+      VisitStatusPerCorner.COMPLETED,
+    ], isFinished: true);
+    final inProgress = _group([
+      VisitStatusPerCorner.COMPLETED,
+      VisitStatusPerCorner.IN_PROGRESS,
+    ], isFinished: false);
+
+    // act & assert
+    expect(completed.isFinished, isTrue);
+    expect(completed.completedCountLabel, '2/2');
+    expect(inProgress.isFinished, isFalse);
+    expect(inProgress.completedCountLabel, '1/2');
+  });
+}

--- a/frontend/test/facilitator/entities/group_ext_test.dart
+++ b/frontend/test/facilitator/entities/group_ext_test.dart
@@ -1,0 +1,31 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:cornermon/facilitator/entities/group_ext.dart';
+import 'package:cornermon/shared/api/domain_aliases.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('ShoudReturnFirstUnvisitedCornerWhenItineraryHasRemainingCorner', () {
+    // arrange
+    final group = Group(
+      (builder) => builder
+        ..itinerary = ListBuilder([
+          CornerProgress(
+            (progress) => progress
+              ..cornerName = '입장'
+              ..status = VisitStatusPerCorner.COMPLETED,
+          ),
+          CornerProgress(
+            (progress) => progress
+              ..cornerName = '체험'
+              ..status = VisitStatusPerCorner.NOT_VISITED,
+          ),
+        ]),
+    );
+
+    // act
+    final label = group.nextCornerLabel;
+
+    // assert
+    expect(label, '체험');
+  });
+}

--- a/frontend/test/shared/api/providers/group_providers_test.dart
+++ b/frontend/test/shared/api/providers/group_providers_test.dart
@@ -1,0 +1,43 @@
+import 'package:cornermon/shared/api/client/api_client.dart';
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/providers/group_providers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../test_utils/widget_test_helpers.dart';
+
+void main() {
+  test('ShoudReturnGeneratedGroupDtosWhenGroupListProviderReadsApi', () async {
+    // arrange
+    final dio = buildFakeDio((request) {
+      expect(request.path, '/camps/camp-1/groups');
+      return [
+        [
+          'id',
+          'group-1',
+          'name',
+          '1조',
+          'status',
+          'IDLE_MOVING',
+          'isFinished',
+          false,
+          'itinerary',
+          <Object?>[],
+        ],
+      ];
+    });
+    final container = buildContainer(
+      overrides: [apiClientProvider.overrideWith((ref) => dio)],
+    );
+    addTearDown(container.dispose);
+
+    // act
+    final groups = await container.read(
+      groupListProvider(CampId('camp-1')).future,
+    );
+
+    // assert
+    expect(groups, hasLength(1));
+    expect(groups.single.id, 'group-1');
+    expect(groups.single.name, '1조');
+  });
+}

--- a/frontend/test/test_utils/widget_test_helpers.dart
+++ b/frontend/test/test_utils/widget_test_helpers.dart
@@ -8,7 +8,10 @@ import 'package:flutter_riverpod/misc.dart' show Override;
 
 /// 위젯 테스트 공통 뼈대 — ProviderScope override + MaterialApp(home: child).
 Widget buildTestable(Widget child, {List<Override> overrides = const []}) =>
-    ProviderScope(overrides: overrides, child: MaterialApp(home: child));
+    ProviderScope(
+      overrides: overrides,
+      child: MaterialApp(home: child),
+    );
 
 /// 순수 provider/notifier 단위 테스트용 컨테이너.
 /// dispose는 호출부 책임(`addTearDown(container.dispose)` 등) — 여기서는 생성만 한다.
@@ -16,9 +19,9 @@ ProviderContainer buildContainer({List<Override> overrides = const []}) =>
     ProviderContainer(overrides: overrides);
 
 /// 실제 네트워크 없이 고정 응답을 돌려주는 Dio.
-/// `apiClientProvider`를 override할 때 사용 — [responder]가 돌려준 Map을 그대로 JSON 바디로 인코딩한다.
+/// `apiClientProvider`를 override할 때 사용 — [responder]가 돌려준 값을 JSON 바디로 인코딩한다.
 /// 상태코드는 200 고정(에러 응답 테스트가 필요해지면 그때 파라미터를 추가한다).
-Dio buildFakeDio(Map<String, dynamic> Function(RequestOptions options) responder) {
+Dio buildFakeDio(Object? Function(RequestOptions options) responder) {
   final dio = Dio(BaseOptions(baseUrl: 'http://localhost/api/v1'));
   dio.httpClientAdapter = _FakeHttpClientAdapter(responder);
   return dio;
@@ -27,7 +30,7 @@ Dio buildFakeDio(Map<String, dynamic> Function(RequestOptions options) responder
 class _FakeHttpClientAdapter implements HttpClientAdapter {
   _FakeHttpClientAdapter(this._responder);
 
-  final Map<String, dynamic> Function(RequestOptions options) _responder;
+  final Object? Function(RequestOptions options) _responder;
 
   @override
   Future<ResponseBody> fetch(


### PR DESCRIPTION
## 변경 사항
- Dio fake adapter가 생성 DTO 목록 응답을 지원하도록 확장하고 group provider 테스트를 추가했습니다.
- 관리자·진행자 entity extension fixture 테스트와 Riverpod widget helper를 보완했습니다.
- 진행자 방문 시작부터 종료 2회 확인까지의 integration_test 하네스와 SDK 의존성을 추가했습니다.

## 종료 조건
- provider/entities/widget 테스트가 네트워크 없이 실행됩니다.
- 관리자 완료 상태는 서버의 GroupResponse.isFinished 값을 사용하도록 정리했습니다.
- 실기기 integration_test 실행은 사용자 결정으로 제외했고, 계획 문서에 기록했습니다.

## 검증
- flutter analyze lib/admin test integration_test 통과
- flutter test 통과 (111건)
- git diff --check 통과