### PR TITLE
feat: 관리자 계정 관리 API 제공

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -24,7 +24,7 @@ const docTemplate = `{
                         "AdminAuth": []
                     }
                 ],
-                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 역할은 SYSTEM_ADMIN 또는 CORNER_OPERATOR만 허용하며, 동일한 username은 생성할 수 없습니다.",
+                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 생성할 역할은 CORNER_OPERATOR로 고정되며, SYSTEM_ADMIN은 다른 SYSTEM_ADMIN을 생성할 수 없습니다. 동일한 username은 생성할 수 없습니다.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3178,7 +3178,6 @@ const docTemplate = `{
                 "role": {
                     "type": "string",
                     "enum": [
-                        "SYSTEM_ADMIN",
                         "CORNER_OPERATOR"
                     ]
                 },

--- a/api/docs.go
+++ b/api/docs.go
@@ -17,6 +17,152 @@ const docTemplate = `{
     "host": "{{.Host}}",
     "basePath": "{{.BasePath}}",
     "paths": {
+        "/admins": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "관리자 생성",
+                "parameters": [
+                    {
+                        "description": "생성할 관리자",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CreateAdminRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/AdminResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admins/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "관리자 삭제",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "관리자 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admins/{id}/password": {
+            "patch": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "관리자 비밀번호 변경",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "관리자 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "새 비밀번호",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ChangeAdminPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/camps/{campId}/events/admin": {
             "get": {
                 "security": [
@@ -2595,6 +2741,24 @@ const docTemplate = `{
                 }
             }
         },
+        "AdminResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "SYSTEM_ADMIN",
+                        "CORNER_OPERATOR"
+                    ]
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "AdminSessionResponse": {
             "type": "object",
             "properties": {
@@ -2903,6 +3067,14 @@ const docTemplate = `{
                 }
             }
         },
+        "ChangeAdminPasswordRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
         "CornerMetricResponse": {
             "type": "object",
             "properties": {
@@ -2991,6 +3163,24 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/UnvisitedGroupResponse"
                     }
+                }
+            }
+        },
+        "CreateAdminRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "SYSTEM_ADMIN",
+                        "CORNER_OPERATOR"
+                    ]
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         },

--- a/api/docs.go
+++ b/api/docs.go
@@ -24,6 +24,7 @@ const docTemplate = `{
                         "AdminAuth": []
                     }
                 ],
+                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 역할은 SYSTEM_ADMIN 또는 CORNER_OPERATOR만 허용하며, 동일한 username은 생성할 수 없습니다.",
                 "consumes": [
                     "application/json"
                 ],
@@ -74,6 +75,7 @@ const docTemplate = `{
                         "AdminAuth": []
                     }
                 ],
+                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 자기 자신은 삭제할 수 없으므로 마지막 SYSTEM_ADMIN 삭제 요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.",
                 "tags": [
                     "A. Auth \u0026 Device Trust"
                 ],
@@ -119,6 +121,7 @@ const docTemplate = `{
                         "AdminAuth": []
                     }
                 ],
+                "description": "대상 관리자 본인 또는 SYSTEM_ADMIN만 호출할 수 있습니다. 비밀번호 변경은 기존 세션을 즉시 무효화하지 않으며, 현재 access token은 기존 TTL까지 유효합니다.",
                 "consumes": [
                     "application/json"
                 ],

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -17,6 +17,7 @@
                         "AdminAuth": []
                     }
                 ],
+                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 역할은 SYSTEM_ADMIN 또는 CORNER_OPERATOR만 허용하며, 동일한 username은 생성할 수 없습니다.",
                 "consumes": [
                     "application/json"
                 ],
@@ -67,6 +68,7 @@
                         "AdminAuth": []
                     }
                 ],
+                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 자기 자신은 삭제할 수 없으므로 마지막 SYSTEM_ADMIN 삭제 요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.",
                 "tags": [
                     "A. Auth \u0026 Device Trust"
                 ],
@@ -112,6 +114,7 @@
                         "AdminAuth": []
                     }
                 ],
+                "description": "대상 관리자 본인 또는 SYSTEM_ADMIN만 호출할 수 있습니다. 비밀번호 변경은 기존 세션을 즉시 무효화하지 않으며, 현재 access token은 기존 TTL까지 유효합니다.",
                 "consumes": [
                     "application/json"
                 ],

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -10,6 +10,152 @@
     },
     "basePath": "/api/v1",
     "paths": {
+        "/admins": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "관리자 생성",
+                "parameters": [
+                    {
+                        "description": "생성할 관리자",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/CreateAdminRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/AdminResponse"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admins/{id}": {
+            "delete": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "관리자 삭제",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "관리자 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/admins/{id}/password": {
+            "patch": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "관리자 비밀번호 변경",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "관리자 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "새 비밀번호",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/ChangeAdminPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/camps/{campId}/events/admin": {
             "get": {
                 "security": [
@@ -2588,6 +2734,24 @@
                 }
             }
         },
+        "AdminResponse": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "SYSTEM_ADMIN",
+                        "CORNER_OPERATOR"
+                    ]
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
         "AdminSessionResponse": {
             "type": "object",
             "properties": {
@@ -2896,6 +3060,14 @@
                 }
             }
         },
+        "ChangeAdminPasswordRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                }
+            }
+        },
         "CornerMetricResponse": {
             "type": "object",
             "properties": {
@@ -2988,6 +3160,24 @@
                     "items": {
                         "$ref": "#/definitions/UnvisitedGroupResponse"
                     }
+                }
+            }
+        },
+        "CreateAdminRequest": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string",
+                    "enum": [
+                        "SYSTEM_ADMIN",
+                        "CORNER_OPERATOR"
+                    ]
+                },
+                "username": {
+                    "type": "string"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -17,7 +17,7 @@
                         "AdminAuth": []
                     }
                 ],
-                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 역할은 SYSTEM_ADMIN 또는 CORNER_OPERATOR만 허용하며, 동일한 username은 생성할 수 없습니다.",
+                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 생성할 역할은 CORNER_OPERATOR로 고정되며, SYSTEM_ADMIN은 다른 SYSTEM_ADMIN을 생성할 수 없습니다. 동일한 username은 생성할 수 없습니다.",
                 "consumes": [
                     "application/json"
                 ],
@@ -3175,7 +3175,6 @@
                 "role": {
                     "type": "string",
                     "enum": [
-                        "SYSTEM_ADMIN",
                         "CORNER_OPERATOR"
                     ]
                 },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -320,7 +320,6 @@ definitions:
         type: string
       role:
         enum:
-        - SYSTEM_ADMIN
         - CORNER_OPERATOR
         type: string
       username:
@@ -752,8 +751,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: SYSTEM_ADMIN만 호출할 수 있습니다. 역할은 SYSTEM_ADMIN 또는 CORNER_OPERATOR만
-        허용하며, 동일한 username은 생성할 수 없습니다.
+      description: SYSTEM_ADMIN만 호출할 수 있습니다. 생성할 역할은 CORNER_OPERATOR로 고정되며, SYSTEM_ADMIN은
+        다른 SYSTEM_ADMIN을 생성할 수 없습니다. 동일한 username은 생성할 수 없습니다.
       parameters:
       - description: 생성할 관리자
         in: body

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -23,6 +23,18 @@ definitions:
       expiresInSeconds:
         type: integer
     type: object
+  AdminResponse:
+    properties:
+      id:
+        type: string
+      role:
+        enum:
+        - SYSTEM_ADMIN
+        - CORNER_OPERATOR
+        type: string
+      username:
+        type: string
+    type: object
   AdminSessionResponse:
     properties:
       adminId:
@@ -231,6 +243,11 @@ definitions:
       visitCompletionRate:
         type: number
     type: object
+  ChangeAdminPasswordRequest:
+    properties:
+      password:
+        type: string
+    type: object
   CornerMetricResponse:
     properties:
       avgDurationSeconds:
@@ -296,6 +313,18 @@ definitions:
         items:
           $ref: '#/definitions/UnvisitedGroupResponse'
         type: array
+    type: object
+  CreateAdminRequest:
+    properties:
+      password:
+        type: string
+      role:
+        enum:
+        - SYSTEM_ADMIN
+        - CORNER_OPERATOR
+        type: string
+      username:
+        type: string
     type: object
   CreateCampRequest:
     properties:
@@ -719,6 +748,97 @@ info:
   title: Cornermon API
   version: 1.0.0
 paths:
+  /admins:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: 생성할 관리자
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/CreateAdminRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/AdminResponse'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: 관리자 생성
+      tags:
+      - A. Auth & Device Trust
+  /admins/{id}:
+    delete:
+      parameters:
+      - description: 관리자 ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: 관리자 삭제
+      tags:
+      - A. Auth & Device Trust
+  /admins/{id}/password:
+    patch:
+      consumes:
+      - application/json
+      parameters:
+      - description: 관리자 ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: 새 비밀번호
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/ChangeAdminPasswordRequest'
+      responses:
+        "204":
+          description: No Content
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: 관리자 비밀번호 변경
+      tags:
+      - A. Auth & Device Trust
   /api/v1/camps/{campId}/events/admin:
     get:
       description: 관리자용 실시간 변경 알림 스트림입니다. 각 event의 data는 SSENotification JSON이며 예시는

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -752,6 +752,8 @@ paths:
     post:
       consumes:
       - application/json
+      description: SYSTEM_ADMIN만 호출할 수 있습니다. 역할은 SYSTEM_ADMIN 또는 CORNER_OPERATOR만
+        허용하며, 동일한 username은 생성할 수 없습니다.
       parameters:
       - description: 생성할 관리자
         in: body
@@ -781,6 +783,8 @@ paths:
       - A. Auth & Device Trust
   /admins/{id}:
     delete:
+      description: SYSTEM_ADMIN만 호출할 수 있습니다. 자기 자신은 삭제할 수 없으므로 마지막 SYSTEM_ADMIN 삭제
+        요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.
       parameters:
       - description: 관리자 ID
         in: path
@@ -811,6 +815,8 @@ paths:
     patch:
       consumes:
       - application/json
+      description: 대상 관리자 본인 또는 SYSTEM_ADMIN만 호출할 수 있습니다. 비밀번호 변경은 기존 세션을 즉시 무효화하지
+        않으며, 현재 access token은 기존 TTL까지 유효합니다.
       parameters:
       - description: 관리자 ID
         in: path

--- a/backend/docs/artifacts/plan/20260716_admin_role_bootstrap_management_plan_.md
+++ b/backend/docs/artifacts/plan/20260716_admin_role_bootstrap_management_plan_.md
@@ -18,7 +18,7 @@
 | 우선순위 | 유즈케이스 | 설명 | 용도 |
 |---|---|---|---|
 | **P0** | UC-B1: 서버 부트스트랩 시 최초 관리자 시딩 | 서버 기동 시 `admins` 테이블이 비어있으면 ENV(`ADMIN_BOOTSTRAP_USERNAME`, `ADMIN_BOOTSTRAP_PASSWORD`)로 SYSTEM_ADMIN 1명 생성 | **프로덕션 핵심 로직** |
-| **P0** | UC-B2: 관리자 생성 | SYSTEM_ADMIN이 새 관리자(SYSTEM_ADMIN 또는 CORNER_OPERATOR)를 생성 | **프로덕션 핵심 로직** |
+| **P0** | UC-B2: 관리자 생성 | SYSTEM_ADMIN이 새 CORNER_OPERATOR를 생성 (SYSTEM_ADMIN 생성 금지) | **프로덕션 핵심 로직** |
 | **P0** | UC-B3: 관리자 비밀번호 변경 | 본인 또는 SYSTEM_ADMIN이 임의 관리자의 비밀번호를 변경 | **프로덕션 핵심 로직** |
 | **P0** | UC-B4: 관리자 삭제 | SYSTEM_ADMIN이 임의 관리자를 삭제(세션도 함께 무효화) | **프로덕션 핵심 로직** |
 | **P0** | UC-B6: 삭제 엣지케이스 가드 | 자기 자신 삭제 방지, 마지막 SYSTEM_ADMIN 삭제 방지 | 운영 사고 방지 |
@@ -26,6 +26,7 @@
 
 **정책 확정 사항** (사용자 확답):
 - 역할은 `SYSTEM_ADMIN`(시스템 관리자), `CORNER_OPERATOR`(코너 운용 관리자) 2종.
+- SYSTEM_ADMIN은 다른 SYSTEM_ADMIN을 생성할 수 없으며, 관리자 생성 API는 CORNER_OPERATOR 생성만 허용한다.
 - 관리자 생성/비밀번호변경/삭제는 전부 **SYSTEM_ADMIN 전용**.
 - **(사용자 피드백 반영)** 자기 자신 삭제 방지, 마지막 SYSTEM_ADMIN 삭제 방지는 이번 계획 범위에 **포함**한다 (UC-B6). 아래 §2.2~2.4, §3, §5에 반영됨.
 - **(사용자 피드백 반영)** 비밀번호 변경(UC-B3)은 SYSTEM_ADMIN 전용이 아니라 **본인 또는 SYSTEM_ADMIN**이 수행 가능하다 (생성/삭제는 여전히 SYSTEM_ADMIN 전용). 아래 §2.4, §2.8, §5에 반영됨.
@@ -124,7 +125,7 @@ func (s *AdminAuthService) authorizeSystemAdmin(ctx context.Context, actorAdminI
 ```
 
 책임:
-- `CreateAdmin`: `authorizeSystemAdmin` 호출 → role 유효성 검사(`ErrAdminInvalidRole`) → username 중복 확인 → `hashPassword` → `AdminRepository.Save` (트랜잭션 내) → 감사 로그(`recordAuditLog`, action `ADMIN_CREATE`)
+- `CreateAdmin`: `authorizeSystemAdmin` 호출 → CORNER_OPERATOR 역할만 허용(SYSTEM_ADMIN 요청은 `ErrAdminForbidden`, 그 외 값은 `ErrAdminInvalidRole`) → username 중복 확인 → `hashPassword` → `AdminRepository.Save` (트랜잭션 내) → 감사 로그(`recordAuditLog`, action `ADMIN_CREATE`)
 - `ChangeAdminPassword` (UC-B3, 사용자 피드백 반영): `authorizeSelfOrSystemAdmin(actorAdminID, targetAdminID)` 호출(`actorAdminID == targetAdminID`이면 통과, 아니면 actor가 SYSTEM_ADMIN인지 확인 후 실패 시 `ErrAdminForbidden`) → 대상 조회 → `hashPassword` → `Save` → 감사 로그 `ADMIN_PASSWORD_CHANGE`(본인 변경/타인 변경 여부를 필드로 구분 기록)
 - `DeleteAdmin` (UC-B4 + UC-B6 가드 포함): `authorizeSystemAdmin` 호출 →
   1. `actorAdminID == targetAdminID` → `ErrAdminSelfDeleteForbidden` (자기 자신 삭제 방지)
@@ -273,7 +274,7 @@ func (h *AdminManagementHandler) DeleteAdmin(c echo.Context) error       // DELE
 ### 5.2 유즈케이스 검증
 - [x] UC-B1: 빈 테이블 + ENV 설정 → 서버 기동 시 SYSTEM_ADMIN 1명 생성, 재기동해도 중복 생성 안 됨
 - [x] UC-B1: ENV 미설정 + 빈 테이블 → 서버 기동 실패(Fatal)
-- [x] UC-B2: SYSTEM_ADMIN이 CORNER_OPERATOR/SYSTEM_ADMIN 생성 가능
+- [x] UC-B2: SYSTEM_ADMIN이 CORNER_OPERATOR를 생성할 수 있고, SYSTEM_ADMIN 생성 요청은 403 + `ErrAdminForbidden`
 - [x] UC-B3: SYSTEM_ADMIN이 임의 관리자 비밀번호 변경 후 새 비밀번호로 로그인 성공, 기존 세션 access token은 TTL 만료 전까지 유효(재로그인 강제 아님 — 범위 확인됨)
 - [x] UC-B3: CORNER_OPERATOR가 본인 비밀번호 변경 가능
 - [x] UC-B3: CORNER_OPERATOR가 타인(다른 CORNER_OPERATOR/SYSTEM_ADMIN) 비밀번호 변경 시도 시 403 + `ErrAdminForbidden`

--- a/backend/docs/artifacts/plan/20260716_admin_role_bootstrap_management_plan_.md
+++ b/backend/docs/artifacts/plan/20260716_admin_role_bootstrap_management_plan_.md
@@ -1,0 +1,299 @@
+# 관리자 역할(Role) 도입 + 초기 관리자 부트스트랩 + 관리자 계정 관리 API
+
+## 배경
+
+`admins` 테이블과 로그인/세션 로직은 존재하지만, 최초 관리자 계정을 만들 방법이 시스템 어디에도 없다
+(`AdminRepository`에 `Save` 없음, seed 없음, 회원가입 API 없음). 이 계획은:
+
+1. 서버 최초 기동 시 ENV 기반으로 시스템 관리자 1명을 시딩
+2. 관리자 역할(SYSTEM_ADMIN / CORNER_OPERATOR) 도입
+3. 관리자 생성/비밀번호 변경/삭제 API를 유즈케이스로 노출 (모두 SYSTEM_ADMIN 전용)
+
+를 다룬다.
+
+---
+
+## 1. 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| **P0** | UC-B1: 서버 부트스트랩 시 최초 관리자 시딩 | 서버 기동 시 `admins` 테이블이 비어있으면 ENV(`ADMIN_BOOTSTRAP_USERNAME`, `ADMIN_BOOTSTRAP_PASSWORD`)로 SYSTEM_ADMIN 1명 생성 | **프로덕션 핵심 로직** |
+| **P0** | UC-B2: 관리자 생성 | SYSTEM_ADMIN이 새 관리자(SYSTEM_ADMIN 또는 CORNER_OPERATOR)를 생성 | **프로덕션 핵심 로직** |
+| **P0** | UC-B3: 관리자 비밀번호 변경 | 본인 또는 SYSTEM_ADMIN이 임의 관리자의 비밀번호를 변경 | **프로덕션 핵심 로직** |
+| **P0** | UC-B4: 관리자 삭제 | SYSTEM_ADMIN이 임의 관리자를 삭제(세션도 함께 무효화) | **프로덕션 핵심 로직** |
+| **P0** | UC-B6: 삭제 엣지케이스 가드 | 자기 자신 삭제 방지, 마지막 SYSTEM_ADMIN 삭제 방지 | 운영 사고 방지 |
+| **P1** | UC-B5: 권한 통제 | CORNER_OPERATOR가 B2~B4 호출 시 403 | 보안 가드 |
+
+**정책 확정 사항** (사용자 확답):
+- 역할은 `SYSTEM_ADMIN`(시스템 관리자), `CORNER_OPERATOR`(코너 운용 관리자) 2종.
+- 관리자 생성/비밀번호변경/삭제는 전부 **SYSTEM_ADMIN 전용**.
+- **(사용자 피드백 반영)** 자기 자신 삭제 방지, 마지막 SYSTEM_ADMIN 삭제 방지는 이번 계획 범위에 **포함**한다 (UC-B6). 아래 §2.2~2.4, §3, §5에 반영됨.
+- **(사용자 피드백 반영)** 비밀번호 변경(UC-B3)은 SYSTEM_ADMIN 전용이 아니라 **본인 또는 SYSTEM_ADMIN**이 수행 가능하다 (생성/삭제는 여전히 SYSTEM_ADMIN 전용). 아래 §2.4, §2.8, §5에 반영됨.
+
+
+---
+
+## 2. 객체 설계
+
+### 2.1 Domain Layer (`internal/domain/admin.go`)
+
+```go
+type AdminRole string
+
+const (
+    AdminRoleSystemAdmin    AdminRole = "SYSTEM_ADMIN"
+    AdminRoleCornerOperator AdminRole = "CORNER_OPERATOR"
+)
+
+type Admin struct {
+    ID           AdminID
+    Username     string
+    PasswordHash string
+    Role         AdminRole
+}
+
+// IsSystemAdmin은 해당 관리자가 시스템 관리자 권한을 가지는지 반환합니다.
+func (a *Admin) IsSystemAdmin() bool
+```
+
+### 2.2 Domain Errors (`internal/domain/errors.go`에 추가)
+
+```go
+var (
+    ErrAdminNotFound            = errors.New("admin: not found")
+    ErrAdminUsernameTaken       = errors.New("admin: username already taken")
+    ErrAdminForbidden           = errors.New("admin: insufficient role")
+    ErrAdminInvalidRole         = errors.New("admin: invalid role")
+    ErrAdminSelfDeleteForbidden = errors.New("admin: cannot delete self")           // (신규, UC-B6)
+    ErrAdminLastSystemAdmin     = errors.New("admin: cannot delete last system admin") // (신규, UC-B6)
+)
+```
+
+### 2.3 Port 확장 (`internal/usecase/port.go`)
+
+```go
+// AdminRepository는 관리자 엔티티의 지속성을 담당하는 포트입니다.
+type AdminRepository interface {
+    Get(ctx context.Context, id domain.AdminID) (*domain.Admin, error)
+    GetByUsername(ctx context.Context, username string) (*domain.Admin, error)
+    Save(ctx context.Context, admin *domain.Admin) error   // (신규) Create/Update 겸용 upsert
+    Delete(ctx context.Context, id domain.AdminID) error   // (신규)
+    Count(ctx context.Context) (int, error)                // (신규) 부트스트랩 시 빈 테이블 판단용
+    CountByRole(ctx context.Context, role domain.AdminRole) (int, error) // (신규, UC-B6) 마지막 SYSTEM_ADMIN 삭제 방지 판단용
+}
+```
+
+기존 `AdminSessionRepository`는 변경 없음. 삭제 시 세션은 `admin_sessions.admin_id REFERENCES admins(id) ON DELETE CASCADE`(schema.sql:165)로 이미 DB 레벨에서 정리됨 — usecase에서 별도 세션 무효화 호출 불필요.
+
+### 2.4 Usecase Layer
+
+`internal/usecase/auth_admin.go`의 `AdminAuthService`에 메서드 추가 (신규 서비스 분리 대신 기존 서비스 확장 — `workflow/plan.md` 3.2 "기존 포트 활용 우선" 원칙):
+
+```go
+// CreateAdmin - UC-B2. actorAdminID는 SYSTEM_ADMIN이어야 한다.
+func (s *AdminAuthService) CreateAdmin(
+    ctx context.Context,
+    actorAdminID domain.AdminID,
+    username string,
+    password string,
+    role domain.AdminRole,
+) (*domain.Admin, error)
+
+// ChangeAdminPassword - UC-B3. actorAdminID는 targetAdminID 본인이거나 SYSTEM_ADMIN이어야 한다.
+func (s *AdminAuthService) ChangeAdminPassword(
+    ctx context.Context,
+    actorAdminID domain.AdminID,
+    targetAdminID domain.AdminID,
+    newPassword string,
+) error
+
+// authorizeSelfOrSystemAdmin은 actor가 target 본인이거나 SYSTEM_ADMIN인지 검증하는 내부 헬퍼 (UC-B3 전용).
+// 실패 시 domain.ErrAdminForbidden 반환.
+func (s *AdminAuthService) authorizeSelfOrSystemAdmin(ctx context.Context, actorAdminID, targetAdminID domain.AdminID) error
+
+// DeleteAdmin - UC-B4. actorAdminID는 SYSTEM_ADMIN이어야 한다.
+func (s *AdminAuthService) DeleteAdmin(
+    ctx context.Context,
+    actorAdminID domain.AdminID,
+    targetAdminID domain.AdminID,
+) error
+
+// authorizeSystemAdmin은 actor가 SYSTEM_ADMIN인지 조회 후 검증하는 내부 헬퍼.
+// 실패 시 domain.ErrAdminForbidden 반환.
+func (s *AdminAuthService) authorizeSystemAdmin(ctx context.Context, actorAdminID domain.AdminID) (*domain.Admin, error)
+```
+
+책임:
+- `CreateAdmin`: `authorizeSystemAdmin` 호출 → role 유효성 검사(`ErrAdminInvalidRole`) → username 중복 확인 → `hashPassword` → `AdminRepository.Save` (트랜잭션 내) → 감사 로그(`recordAuditLog`, action `ADMIN_CREATE`)
+- `ChangeAdminPassword` (UC-B3, 사용자 피드백 반영): `authorizeSelfOrSystemAdmin(actorAdminID, targetAdminID)` 호출(`actorAdminID == targetAdminID`이면 통과, 아니면 actor가 SYSTEM_ADMIN인지 확인 후 실패 시 `ErrAdminForbidden`) → 대상 조회 → `hashPassword` → `Save` → 감사 로그 `ADMIN_PASSWORD_CHANGE`(본인 변경/타인 변경 여부를 필드로 구분 기록)
+- `DeleteAdmin` (UC-B4 + UC-B6 가드 포함): `authorizeSystemAdmin` 호출 →
+  1. `actorAdminID == targetAdminID` → `ErrAdminSelfDeleteForbidden` (자기 자신 삭제 방지)
+  2. 대상 조회(`ErrAdminNotFound`)
+  3. 대상 `Role == SYSTEM_ADMIN`이면 `AdminRepository.CountByRole(SYSTEM_ADMIN)` 확인 → 1 이하면 `ErrAdminLastSystemAdmin` (마지막 시스템 관리자 삭제 방지)
+  4. `AdminRepository.Delete` → 감사 로그 `ADMIN_DELETE`
+- `CreateAdmin`/`DeleteAdmin`은 시작부에 `authorizeSystemAdmin` 호출 (UC-B5, SYSTEM_ADMIN 전용 유지). `ChangeAdminPassword`만 `authorizeSelfOrSystemAdmin`으로 대체(UC-B3 정책 변경).
+
+### 2.5 부트스트랩 (`cmd/server/main.go`)
+
+기존 코드 흐름 재사용 원칙에 따라 별도 서비스 신설 없이 `main()` 내 `adminRepo` 생성 직후 인라인 처리:
+
+```go
+// bootstrapAdmin은 admins 테이블이 비어있을 때 ENV로 최초 SYSTEM_ADMIN을 생성한다.
+// 책임: adminRepo.Count 확인 → 0이면 ENV(ADMIN_BOOTSTRAP_USERNAME/PASSWORD) 필수값 검증 후 저장.
+func bootstrapAdmin(ctx context.Context, adminRepo usecase.AdminRepository, uuidFn func() string) error
+```
+
+- `main()`에서 `pool` 초기화 직후, `adminRepo` 생성 직후 호출.
+- ENV 누락 & 테이블이 비어있으면 `log.Fatalf`로 서버 기동 중단 (운영 실수 방지 — 조용히 넘어가면 "관리자 없는 서버"가 배포될 위험).
+- 이미 관리자가 1명 이상 있으면 아무 것도 하지 않고 통과 (idempotent, 재기동 시 중복 생성 안 됨).
+- 비밀번호 해싱은 `usecase.hashPassword`를 그대로 쓸 수 없음(비공개) → `usecase` 패키지에 **exported wrapper 추가**:
+  ```go
+  // internal/usecase/utils.go
+  func HashPasswordForBootstrap(password string) (string, error) { return hashPassword(password) }
+  ```
+  또는 더 깔끔하게, `bootstrapAdmin` 자체를 `internal/usecase` 패키지에 두어 비공개 `hashPassword`를 직접 쓰게 한다. **후자를 채택** (신규 export 최소화 원칙).
+
+```go
+// internal/usecase/admin_bootstrap.go (신규 파일)
+// BootstrapAdmin은 admins 테이블이 비어있을 때 ENV 값으로 최초 SYSTEM_ADMIN을 생성한다.
+func BootstrapAdmin(ctx context.Context, admins AdminRepository, username, password string, uuidFn func() string) error
+```
+
+### 2.6 Infrastructure Layer
+
+`internal/infrastructure/postgres/admin_repo.go`:
+
+```go
+func (r *pgAdminRepository) Save(ctx context.Context, admin *domain.Admin) error   // (신규) INSERT ... ON CONFLICT (id) DO UPDATE
+func (r *pgAdminRepository) Delete(ctx context.Context, id domain.AdminID) error   // (신규) DELETE FROM admins WHERE id = $1
+func (r *pgAdminRepository) Count(ctx context.Context) (int, error)                // (신규) SELECT COUNT(*) FROM admins
+func (r *pgAdminRepository) CountByRole(ctx context.Context, role domain.AdminRole) (int, error) // (신규, UC-B6) SELECT COUNT(*) FROM admins WHERE role = $1
+```
+
+sqlc를 쓰는 구조(`db.Queries`)이므로 `backend/db/query.sql`에 대응 쿼리 추가 후 `sqlc generate` 필요 (기존 관례 확인 필요 — Makefile/Dockerfile이 방금 추가된 `db/` 디렉토리에 있으므로 sqlc 생성 명령 확인 필수, 구현 착수 전 확인).
+
+`mapAdmin`에 `Role: domain.AdminRole(row.Role)` 매핑 추가.
+
+### 2.7 DB Schema (`backend/db/schema.sql`)
+
+```sql
+ALTER TABLE admins ADD COLUMN role VARCHAR(30) NOT NULL DEFAULT 'CORNER_OPERATOR';
+-- 기존 스키마 파일 자체가 초기 생성 스크립트이므로(마이그레이션 이력 없음),
+-- CREATE TABLE admins 문에 컬럼을 직접 추가하는 것으로 확인 필요 (마이그레이션 디렉토리 유무 확인 선행)
+```
+
+### 2.8 HTTP Layer (`internal/infrastructure/web/auth_handler.go` 또는 신규 `admin_handler.go`)
+
+기존 파일 패턴(`AuthHandler`)을 따라 관리자 CRUD는 별도 핸들러로 분리 (`AdminManagementHandler`) — 책임 분리, `auth_handler.go`가 이미 400줄 넘음.
+
+```go
+type AdminManagementUsecase interface {
+    CreateAdmin(ctx context.Context, actorAdminID domain.AdminID, username, password string, role domain.AdminRole) (*domain.Admin, error)
+    ChangeAdminPassword(ctx context.Context, actorAdminID, targetAdminID domain.AdminID, newPassword string) error
+    DeleteAdmin(ctx context.Context, actorAdminID, targetAdminID domain.AdminID) error
+}
+
+type AdminManagementHandler struct {
+    admins AdminManagementUsecase
+}
+
+func (h *AdminManagementHandler) CreateAdmin(c echo.Context) error       // POST   /admins
+func (h *AdminManagementHandler) ChangeAdminPassword(c echo.Context) error // PATCH  /admins/{id}/password
+func (h *AdminManagementHandler) DeleteAdmin(c echo.Context) error       // DELETE /admins/{id}
+```
+
+- 인증: 기존 `AdminAuthMiddleware` 그룹에 등록 (세션 존재 확인까지만).
+- **역할 인가는 usecase 레이어(`authorizeSystemAdmin`/`authorizeSelfOrSystemAdmin`)에서 강제** — 핸들러가 아니라 유즈케이스를 반드시 거치도록 하라는 요구사항 반영. 핸들러는 `session.AdminID`를 `actorAdminID`로, URL 경로의 `{id}`를 `targetAdminID`로 넘기기만 하고 role/본인 여부 분기 로직을 갖지 않는다 (`ChangeAdminPassword`도 동일 — 본인/SYSTEM_ADMIN 판별은 usecase에서 수행).
+- 에러 매핑: `domain.ErrAdminForbidden` → 403, `domain.ErrAdminNotFound` → 404, `domain.ErrAdminUsernameTaken` → 409, `domain.ErrAdminSelfDeleteForbidden` → 409, `domain.ErrAdminLastSystemAdmin` → 409 (UC-B6).
+
+라우팅은 `router.go`의 `RegisterRoutes` 내 admin 그룹에 추가 (기존 `/auth/admin/*` 그룹과 별개로 `/admins` 리소스 그룹 신설).
+
+### 2.9 API 문서 (swaggo)
+
+- 각 핸들러에 기존 패턴과 동일한 `@Summary/@Tags/@Security AdminAuth/@Router` 주석 추가.
+- 구현 완료 후 `swag init` (또는 프로젝트에서 쓰는 정확한 생성 명령 확인) 실행 → `api/docs.go`, `api/swagger.yaml` 갱신. **PR에 반드시 포함** (`workflow/Collaborate.md`).
+
+---
+
+## 3. Phase 구성
+
+### Phase A: 도메인 + 에러 + 포트 (예상 0.5시간)
+| 순서 | 작업 | 파일 |
+|---|---|---|
+| A-1 | `AdminRole` 타입 + `Admin.Role` 필드 + `IsSystemAdmin()` (신규 필드/메서드) | `internal/domain/admin.go` |
+| A-2 | 에러 6종 추가 (UC-B6 가드용 2종 포함) | `internal/domain/errors.go` |
+| A-3 | `AdminRepository`에 `Save/Delete/Count/CountByRole` 추가 (기존 파일 확장) | `internal/usecase/port.go` |
+
+### Phase B: 인프라 (예상 1시간)
+| 순서 | 작업 | 파일 |
+|---|---|---|
+| B-1 | schema에 `role` 컬럼 추가 (또는 마이그레이션 파일 — 선행 확인 필요) | `backend/db/schema.sql` |
+| B-2 | sqlc 쿼리 추가 (`CreateAdmin`/`UpdateAdmin`/`DeleteAdmin`/`CountAdmins`/`CountAdminsByRole`) + generate | `backend/db/query.sql` |
+| B-3 | `pgAdminRepository`에 `Save/Delete/Count/CountByRole` 구현, `mapAdmin`에 role 매핑 | `internal/infrastructure/postgres/admin_repo.go` |
+
+### Phase C: 유즈케이스 (예상 1시간)
+| 순서 | 작업 | 파일 |
+|---|---|---|
+| C-1 | `authorizeSystemAdmin` / `authorizeSelfOrSystemAdmin` 헬퍼 | `internal/usecase/auth_admin.go` |
+| C-2 | `CreateAdmin` / `ChangeAdminPassword`(본인 또는 SYSTEM_ADMIN, UC-B3) / `DeleteAdmin`(자기 자신·마지막 SYSTEM_ADMIN 삭제 가드 포함, UC-B6) | `internal/usecase/auth_admin.go` |
+| C-3 | `BootstrapAdmin` (신규 파일) | `internal/usecase/admin_bootstrap.go` |
+
+### Phase D: HTTP + 부트스트랩 연결 (예상 1시간)
+| 순서 | 작업 | 파일 |
+|---|---|---|
+| D-1 | `AdminManagementHandler` (신규) | `internal/infrastructure/web/admin_handler.go` |
+| D-2 | 라우팅 등록 (`AdminAuthMiddleware` 그룹) | `internal/infrastructure/web/router.go` |
+| D-3 | `main()`에서 `usecase.BootstrapAdmin` 호출, ENV 로드/검증 | `cmd/server/main.go` |
+| D-4 | swaggo 주석 + 문서 재생성 | `internal/infrastructure/web/admin_handler.go`, `api/docs.go`, `api/swagger.yaml` |
+
+### Phase E: 테스트
+| 순서 | 작업 |
+|---|---|
+| E-1 | `AdminAuthService` 유닛 테스트: `ShouldCreateAdminWhenActorIsSystemAdmin`, `ShouldReturnForbiddenWhenActorIsCornerOperator`, `ShouldReturnConflictWhenUsernameTaken`, `ShouldChangePasswordWhenActorIsSystemAdmin`, `ShouldChangeOwnPasswordWhenActorIsCornerOperator`(UC-B3), `ShouldReturnForbiddenWhenCornerOperatorChangesAnothersPassword`(UC-B3), `ShouldDeleteAdminWhenActorIsSystemAdmin`, `ShouldReturnConflictWhenDeletingSelf`(UC-B6), `ShouldReturnConflictWhenDeletingLastSystemAdmin`(UC-B6), `ShouldAllowDeletingSystemAdminWhenAnotherSystemAdminRemains`(UC-B6) |
+| E-2 | `BootstrapAdmin` 유닛 테스트: `ShouldCreateAdminWhenTableEmpty`, `ShouldSkipWhenAdminExists` |
+| E-3 | 핸들러 레벨 테스트(선택, 기존 router_test.go 관례 확인 후): 403/404/409 응답 코드 |
+
+---
+
+## 4. 구현 전 확인 필요 사항 (착수 전 반드시 확인)
+
+1. **sqlc 생성 명령**: `db/Makefile`, `db/Dockerfile`이 방금 추가된 상태 — sqlc 설정 파일(`sqlc.yaml`) 위치와 `make gen` 여부 확인.
+2. **마이그레이션 이력 유무**: `backend/db/schema.sql` 하나로 관리되는지, 별도 migration 디렉토리가 있는지 확인 후 role 컬럼 추가 방식 결정.
+3. **ENV 변수명**: `ADMIN_BOOTSTRAP_USERNAME` / `ADMIN_BOOTSTRAP_PASSWORD` (가칭) — `.env.docker.example`, `.env` 예시 파일에도 추가.
+
+---
+
+## 5. 검증 체크리스트
+
+### 5.1 아키텍처 검증
+- [x] `domain` 패키지에 `infrastructure`/`usecase` import 없음
+- [x] `AdminManagementHandler`가 `AdminManagementUsecase` 인터페이스에만 의존 (구현체 `AdminAuthService` 직접 참조 안 함)
+- [x] 역할 인가 로직이 핸들러가 아닌 `usecase.AdminAuthService.authorizeSystemAdmin`/`authorizeSelfOrSystemAdmin`에만 존재 (요구사항: "유즈케이스를 반드시 거치도록")
+
+### 5.2 유즈케이스 검증
+- [x] UC-B1: 빈 테이블 + ENV 설정 → 서버 기동 시 SYSTEM_ADMIN 1명 생성, 재기동해도 중복 생성 안 됨
+- [x] UC-B1: ENV 미설정 + 빈 테이블 → 서버 기동 실패(Fatal)
+- [x] UC-B2: SYSTEM_ADMIN이 CORNER_OPERATOR/SYSTEM_ADMIN 생성 가능
+- [x] UC-B3: SYSTEM_ADMIN이 임의 관리자 비밀번호 변경 후 새 비밀번호로 로그인 성공, 기존 세션 access token은 TTL 만료 전까지 유효(재로그인 강제 아님 — 범위 확인됨)
+- [x] UC-B3: CORNER_OPERATOR가 본인 비밀번호 변경 가능
+- [x] UC-B3: CORNER_OPERATOR가 타인(다른 CORNER_OPERATOR/SYSTEM_ADMIN) 비밀번호 변경 시도 시 403 + `ErrAdminForbidden`
+- [x] UC-B4: SYSTEM_ADMIN이 관리자 삭제 시 해당 관리자의 `admin_sessions`도 CASCADE로 제거됨
+- [x] UC-B5: CORNER_OPERATOR가 B2/B3/B4 호출 시 403 + `ErrAdminForbidden`
+- [x] UC-B6: SYSTEM_ADMIN이 자기 자신을 삭제 시도 시 409 + `ErrAdminSelfDeleteForbidden`
+- [x] UC-B6: 마지막 SYSTEM_ADMIN은 자기 자신 삭제 차단으로 삭제 요청 자체가 성립하지 않음 (사용자 확인 완료)
+- [x] UC-B6: SYSTEM_ADMIN이 2명 이상일 때는 SYSTEM_ADMIN 삭제 가능
+
+### 5.3 회귀 검증
+- [x] 기존 `Login`/`RefreshToken`/`ValidateAccessToken` 동작 불변 (Admin 구조체에 필드만 추가, 기존 로직 미변경)
+- [x] `go test ./...` 전체 통과
+
+## 자체 리뷰
+
+- [x] 역할 인가가 핸들러를 우회하지 않고 유즈케이스에서 강제되는지 확인했다.
+- [x] 비밀번호는 bcrypt 해시만 저장·감사 로그에는 저장하지 않음을 확인했다.
+- [x] 관리자 삭제는 DB foreign key `ON DELETE CASCADE`에 의해 세션을 함께 제거함을 확인했다.
+- [x] `go build ./...`, `go vet ./...`, `go test ./...`, 관련 패키지 race 테스트 및 Swagger 재생성을 완료했다.
+
+---
+
+**사용자 확인 필요 (구현 착수 전)**: Phase B의 sqlc 생성 명령과 마이그레이션 방식(§4-1, §4-2)은 `backend/db/` 디렉토리가 최근 막 추가된 상태라 관례가 아직 확정되지 않았을 수 있음 — 실제 착수 시 재확인.

--- a/backend/internal/infrastructure/web/admin_management_handler.go
+++ b/backend/internal/infrastructure/web/admin_management_handler.go
@@ -39,6 +39,7 @@ type AdminResponse struct {
 } // @name AdminResponse
 
 // @Summary      관리자 생성
+// @Description  SYSTEM_ADMIN만 호출할 수 있습니다. 역할은 SYSTEM_ADMIN 또는 CORNER_OPERATOR만 허용하며, 동일한 username은 생성할 수 없습니다.
 // @Tags         A. Auth & Device Trust
 // @Security     AdminAuth
 // @Accept       json
@@ -64,6 +65,7 @@ func (h *AdminManagementHandler) CreateAdmin(c echo.Context) error {
 }
 
 // @Summary      관리자 비밀번호 변경
+// @Description  대상 관리자 본인 또는 SYSTEM_ADMIN만 호출할 수 있습니다. 비밀번호 변경은 기존 세션을 즉시 무효화하지 않으며, 현재 access token은 기존 TTL까지 유효합니다.
 // @Tags         A. Auth & Device Trust
 // @Security     AdminAuth
 // @Accept       json
@@ -88,6 +90,7 @@ func (h *AdminManagementHandler) ChangeAdminPassword(c echo.Context) error {
 }
 
 // @Summary      관리자 삭제
+// @Description  SYSTEM_ADMIN만 호출할 수 있습니다. 자기 자신은 삭제할 수 없으므로 마지막 SYSTEM_ADMIN 삭제 요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.
 // @Tags         A. Auth & Device Trust
 // @Security     AdminAuth
 // @Param        id path string true "관리자 ID"

--- a/backend/internal/infrastructure/web/admin_management_handler.go
+++ b/backend/internal/infrastructure/web/admin_management_handler.go
@@ -25,7 +25,7 @@ func NewAdminManagementHandler(admins AdminManagementUsecase) *AdminManagementHa
 type CreateAdminRequest struct {
 	Username string `json:"username"`
 	Password string `json:"password"`
-	Role     string `json:"role" enums:"SYSTEM_ADMIN,CORNER_OPERATOR"`
+	Role     string `json:"role" enums:"CORNER_OPERATOR"`
 } // @name CreateAdminRequest
 
 type ChangeAdminPasswordRequest struct {
@@ -39,7 +39,7 @@ type AdminResponse struct {
 } // @name AdminResponse
 
 // @Summary      관리자 생성
-// @Description  SYSTEM_ADMIN만 호출할 수 있습니다. 역할은 SYSTEM_ADMIN 또는 CORNER_OPERATOR만 허용하며, 동일한 username은 생성할 수 없습니다.
+// @Description  SYSTEM_ADMIN만 호출할 수 있습니다. 생성할 역할은 CORNER_OPERATOR로 고정되며, SYSTEM_ADMIN은 다른 SYSTEM_ADMIN을 생성할 수 없습니다. 동일한 username은 생성할 수 없습니다.
 // @Tags         A. Auth & Device Trust
 // @Security     AdminAuth
 // @Accept       json

--- a/backend/internal/infrastructure/web/admin_management_handler.go
+++ b/backend/internal/infrastructure/web/admin_management_handler.go
@@ -1,0 +1,121 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"cornermon/backend/internal/domain"
+
+	"github.com/labstack/echo/v4"
+)
+
+type AdminManagementUsecase interface {
+	CreateAdmin(ctx context.Context, actorAdminID domain.AdminID, username, password string, role domain.AdminRole) (*domain.Admin, error)
+	ChangeAdminPassword(ctx context.Context, actorAdminID, targetAdminID domain.AdminID, newPassword string) error
+	DeleteAdmin(ctx context.Context, actorAdminID, targetAdminID domain.AdminID) error
+}
+
+type AdminManagementHandler struct{ admins AdminManagementUsecase }
+
+func NewAdminManagementHandler(admins AdminManagementUsecase) *AdminManagementHandler {
+	return &AdminManagementHandler{admins: admins}
+}
+
+type CreateAdminRequest struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Role     string `json:"role" enums:"SYSTEM_ADMIN,CORNER_OPERATOR"`
+} // @name CreateAdminRequest
+
+type ChangeAdminPasswordRequest struct {
+	Password string `json:"password"`
+} // @name ChangeAdminPasswordRequest
+
+type AdminResponse struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+	Role     string `json:"role" enums:"SYSTEM_ADMIN,CORNER_OPERATOR"`
+} // @name AdminResponse
+
+// @Summary      관리자 생성
+// @Tags         A. Auth & Device Trust
+// @Security     AdminAuth
+// @Accept       json
+// @Produce      json
+// @Param        request body CreateAdminRequest true "생성할 관리자"
+// @Success      201 {object} AdminResponse
+// @Failure      403,409 {object} ErrorResponse
+// @Router       /admins [post]
+func (h *AdminManagementHandler) CreateAdmin(c echo.Context) error {
+	actor, ok := c.Get("adminSession").(*domain.AdminSession)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "unauthorized"})
+	}
+	var req CreateAdminRequest
+	if err := c.Bind(&req); err != nil || req.Username == "" || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "username and password are required"})
+	}
+	admin, err := h.admins.CreateAdmin(c.Request().Context(), actor.AdminID, req.Username, req.Password, domain.AdminRole(req.Role))
+	if err != nil {
+		return adminManagementError(c, err)
+	}
+	return c.JSON(http.StatusCreated, AdminResponse{ID: string(admin.ID), Username: admin.Username, Role: string(admin.Role)})
+}
+
+// @Summary      관리자 비밀번호 변경
+// @Tags         A. Auth & Device Trust
+// @Security     AdminAuth
+// @Accept       json
+// @Param        id path string true "관리자 ID"
+// @Param        request body ChangeAdminPasswordRequest true "새 비밀번호"
+// @Success      204
+// @Failure      403,404 {object} ErrorResponse
+// @Router       /admins/{id}/password [patch]
+func (h *AdminManagementHandler) ChangeAdminPassword(c echo.Context) error {
+	actor, ok := c.Get("adminSession").(*domain.AdminSession)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "unauthorized"})
+	}
+	var req ChangeAdminPasswordRequest
+	if err := c.Bind(&req); err != nil || req.Password == "" {
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "password is required"})
+	}
+	if err := h.admins.ChangeAdminPassword(c.Request().Context(), actor.AdminID, domain.AdminID(c.Param("id")), req.Password); err != nil {
+		return adminManagementError(c, err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+// @Summary      관리자 삭제
+// @Tags         A. Auth & Device Trust
+// @Security     AdminAuth
+// @Param        id path string true "관리자 ID"
+// @Success      204
+// @Failure      403,404,409 {object} ErrorResponse
+// @Router       /admins/{id} [delete]
+func (h *AdminManagementHandler) DeleteAdmin(c echo.Context) error {
+	actor, ok := c.Get("adminSession").(*domain.AdminSession)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "unauthorized"})
+	}
+	if err := h.admins.DeleteAdmin(c.Request().Context(), actor.AdminID, domain.AdminID(c.Param("id"))); err != nil {
+		return adminManagementError(c, err)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func adminManagementError(c echo.Context, err error) error {
+	switch {
+	case errors.Is(err, domain.ErrAdminForbidden):
+		return c.JSON(http.StatusForbidden, ErrorResponse{Code: "FORBIDDEN", Message: err.Error()})
+	case errors.Is(err, domain.ErrAdminNotFound):
+		return c.JSON(http.StatusNotFound, ErrorResponse{Code: "NOT_FOUND", Message: err.Error()})
+	case errors.Is(err, domain.ErrAdminUsernameTaken), errors.Is(err, domain.ErrAdminSelfDeleteForbidden), errors.Is(err, domain.ErrAdminLastSystemAdmin):
+		return c.JSON(http.StatusConflict, ErrorResponse{Code: "CONFLICT", Message: err.Error()})
+	case errors.Is(err, domain.ErrAdminInvalidRole):
+		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: err.Error()})
+	default:
+		return c.JSON(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()})
+	}
+}

--- a/backend/internal/infrastructure/web/admin_management_handler_test.go
+++ b/backend/internal/infrastructure/web/admin_management_handler_test.go
@@ -1,0 +1,57 @@
+package web
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"cornermon/backend/internal/domain"
+
+	"github.com/labstack/echo/v4"
+)
+
+type adminManagementUsecaseStub struct{ err error }
+
+func (s adminManagementUsecaseStub) CreateAdmin(context.Context, domain.AdminID, string, string, domain.AdminRole) (*domain.Admin, error) {
+	return nil, s.err
+}
+func (s adminManagementUsecaseStub) ChangeAdminPassword(context.Context, domain.AdminID, domain.AdminID, string) error {
+	return s.err
+}
+func (s adminManagementUsecaseStub) DeleteAdmin(context.Context, domain.AdminID, domain.AdminID) error {
+	return s.err
+}
+
+func TestAdminManagementHandlerShouldMapDomainErrorsToHTTPStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "forbidden", err: domain.ErrAdminForbidden, want: http.StatusForbidden},
+		{name: "not found", err: domain.ErrAdminNotFound, want: http.StatusNotFound},
+		{name: "conflict", err: domain.ErrAdminUsernameTaken, want: http.StatusConflict},
+		{name: "bad request", err: domain.ErrAdminInvalidRole, want: http.StatusBadRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Arrange
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/admins", strings.NewReader(`{"username":"new","password":"password","role":"CORNER_OPERATOR"}`))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.Set("adminSession", &domain.AdminSession{AdminID: "actor"})
+			handler := NewAdminManagementHandler(adminManagementUsecaseStub{err: tc.err})
+
+			// Act
+			err := handler.CreateAdmin(c)
+
+			// Assert
+			if err != nil || rec.Code != tc.want {
+				t.Fatalf("expected status %d, got status=%d err=%v", tc.want, rec.Code, err)
+			}
+		})
+	}
+}

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -5,18 +5,19 @@ import (
 )
 
 type Handlers struct {
-	Auth    *AuthHandler
-	Device  *DeviceHandler
-	Camp    *CampHandler
-	Corner  *CornerHandler
-	Track   *TrackHandler
-	Group   *GroupHandler
-	Badge   *BadgeHandler
-	Visit   *VisitHandler
-	Event   *EventHandler
-	Message *MessageHandler
-	Report  *ReportHandler
-	Audit   *AuditHandler
+	Auth            *AuthHandler
+	Device          *DeviceHandler
+	Camp            *CampHandler
+	Corner          *CornerHandler
+	Track           *TrackHandler
+	Group           *GroupHandler
+	Badge           *BadgeHandler
+	Visit           *VisitHandler
+	Event           *EventHandler
+	Message         *MessageHandler
+	Report          *ReportHandler
+	Audit           *AuditHandler
+	AdminManagement *AdminManagementHandler
 }
 
 func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, trackAuth AuthFacilitatorUsecase) {
@@ -40,6 +41,11 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 	admin.POST("/auth/admin/logout", h.Auth.AdminLogout)
 	admin.GET("/auth/admin/sessions", h.Auth.ListAdminSessions)
 	admin.POST("/auth/admin/sessions/:id/revoke", h.Auth.RevokeAdminSession)
+	if h.AdminManagement != nil {
+		admin.POST("/admins", h.AdminManagement.CreateAdmin)
+		admin.PATCH("/admins/:id/password", h.AdminManagement.ChangeAdminPassword)
+		admin.DELETE("/admins/:id", h.AdminManagement.DeleteAdmin)
+	}
 	admin.POST("/auth/track/:trackId/force-logout", h.Auth.ForceTrackLogout)
 	admin.POST("/auth/track/lockout/:deviceId/release", h.Auth.ReleaseLockout)
 	admin.GET("/auth/track/sessions", h.Auth.ListActiveFacilitatorSessions)

--- a/backend/internal/usecase/admin_bootstrap.go
+++ b/backend/internal/usecase/admin_bootstrap.go
@@ -8,6 +8,12 @@ import (
 )
 
 // BootstrapAdmin creates the initial system administrator exactly once.
+//
+// It intentionally remains a small package-level use case instead of an
+// AdminAuthService method: bootstrap runs before the service graph is built
+// and only needs AdminRepository, password hashing, and UUID generation.
+// Keeping it here avoids constructing unrelated session, track, SSE, and
+// audit-log dependencies during server startup without exporting hashPassword.
 func BootstrapAdmin(ctx context.Context, admins AdminRepository, username, password string, uuidFn func() string) error {
 	count, err := admins.Count(ctx)
 	if err != nil {

--- a/backend/internal/usecase/admin_management_test.go
+++ b/backend/internal/usecase/admin_management_test.go
@@ -1,0 +1,169 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"cornermon/backend/internal/domain"
+)
+
+func newAdminManagementService(admins *MockAdminRepository) *AdminAuthService {
+	service := NewAdminAuthService(admins, NewMockAdminSessionRepository(), nil, nil, nil, nil, &MockAuditLogRepository{}, &MockTxManager{})
+	service.uuidFn = func() string { return "created-admin" }
+	return service
+}
+
+func TestAdminAuthService_AdminManagement(t *testing.T) {
+	t.Run("ShouldCreateAdminWhenActorIsSystemAdmin", func(t *testing.T) {
+		for _, role := range []domain.AdminRole{domain.AdminRoleCornerOperator, domain.AdminRoleSystemAdmin} {
+			// Arrange
+			admins := NewMockAdminRepository()
+			admins.Admins["system"] = &domain.Admin{ID: "system", Username: "system", Role: domain.AdminRoleSystemAdmin}
+
+			// Act
+			created, err := newAdminManagementService(admins).CreateAdmin(context.Background(), "system", "new", "password", role)
+
+			// Assert
+			if err != nil || created.Role != role {
+				t.Fatalf("expected %s creation, got admin=%+v err=%v", role, created, err)
+			}
+		}
+	})
+
+	t.Run("ShouldReturnForbiddenWhenActorIsCornerOperator", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["operator"] = &domain.Admin{ID: "operator", Role: domain.AdminRoleCornerOperator}
+
+		// Act
+		_, err := newAdminManagementService(admins).CreateAdmin(context.Background(), "operator", "new", "password", domain.AdminRoleCornerOperator)
+
+		// Assert
+		if !errors.Is(err, domain.ErrAdminForbidden) {
+			t.Fatalf("expected forbidden, got %v", err)
+		}
+	})
+
+	t.Run("ShouldReturnConflictWhenUsernameTaken", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["system"] = &domain.Admin{ID: "system", Role: domain.AdminRoleSystemAdmin}
+		admins.Admins["existing"] = &domain.Admin{ID: "existing", Username: "taken", Role: domain.AdminRoleCornerOperator}
+
+		// Act
+		_, err := newAdminManagementService(admins).CreateAdmin(context.Background(), "system", "taken", "password", domain.AdminRoleCornerOperator)
+
+		// Assert
+		if !errors.Is(err, domain.ErrAdminUsernameTaken) {
+			t.Fatalf("expected username taken, got %v", err)
+		}
+	})
+
+	t.Run("ShouldChangeOwnPasswordWhenActorIsCornerOperator", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		oldHash, _ := hashPassword("old")
+		admins.Admins["operator"] = &domain.Admin{ID: "operator", PasswordHash: oldHash, Role: domain.AdminRoleCornerOperator}
+
+		// Act
+		err := newAdminManagementService(admins).ChangeAdminPassword(context.Background(), "operator", "operator", "new")
+
+		// Assert
+		if err != nil || verifyPassword(admins.Admins["operator"].PasswordHash, "new") != nil {
+			t.Fatalf("expected own password change, got %v", err)
+		}
+	})
+
+	t.Run("ShouldChangePasswordWhenActorIsSystemAdmin", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		oldHash, _ := hashPassword("old")
+		admins.Admins["system"] = &domain.Admin{ID: "system", Role: domain.AdminRoleSystemAdmin}
+		admins.Admins["operator"] = &domain.Admin{ID: "operator", Username: "operator", PasswordHash: oldHash, Role: domain.AdminRoleCornerOperator}
+		service := newAdminManagementService(admins)
+
+		// Act
+		err := service.ChangeAdminPassword(context.Background(), "system", "operator", "new")
+		_, _, _, loginErr := service.Login(context.Background(), "operator", "new", "test")
+
+		// Assert
+		if err != nil || loginErr != nil {
+			t.Fatalf("expected system administrator password change and login, got change=%v login=%v", err, loginErr)
+		}
+	})
+
+	t.Run("ShouldReturnForbiddenWhenCornerOperatorChangesAnothersPassword", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["operator"] = &domain.Admin{ID: "operator", Role: domain.AdminRoleCornerOperator}
+		admins.Admins["other"] = &domain.Admin{ID: "other", Role: domain.AdminRoleCornerOperator}
+
+		// Act
+		err := newAdminManagementService(admins).ChangeAdminPassword(context.Background(), "operator", "other", "new")
+
+		// Assert
+		if !errors.Is(err, domain.ErrAdminForbidden) {
+			t.Fatalf("expected forbidden, got %v", err)
+		}
+	})
+
+	t.Run("ShouldPreventDeletingSelfAndAllowDeletingAnotherSystemAdmin", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["system"] = &domain.Admin{ID: "system", Role: domain.AdminRoleSystemAdmin}
+		service := newAdminManagementService(admins)
+
+		// Act & Assert
+		admins.Admins["other-system"] = &domain.Admin{ID: "other-system", Role: domain.AdminRoleSystemAdmin}
+		if err := service.DeleteAdmin(context.Background(), "system", "other-system"); err != nil {
+			t.Fatalf("expected deleting non-last system admin, got %v", err)
+		}
+		if err := service.DeleteAdmin(context.Background(), "system", "system"); !errors.Is(err, domain.ErrAdminSelfDeleteForbidden) {
+			t.Fatalf("expected self-delete forbidden, got %v", err)
+		}
+	})
+}
+
+func TestBootstrapAdmin(t *testing.T) {
+	t.Run("ShouldCreateAdminWhenTableEmpty", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+
+		// Act
+		err := BootstrapAdmin(context.Background(), admins, "bootstrap", "password", func() string { return "bootstrap-id" })
+
+		// Assert
+		admin := admins.Admins["bootstrap-id"]
+		if err != nil || admin == nil || !admin.IsSystemAdmin() || verifyPassword(admin.PasswordHash, "password") != nil {
+			t.Fatalf("expected system administrator bootstrap, got admin=%+v err=%v", admin, err)
+		}
+	})
+
+	t.Run("ShouldSkipWhenAdminExists", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["existing"] = &domain.Admin{ID: "existing", Role: domain.AdminRoleSystemAdmin}
+
+		// Act
+		err := BootstrapAdmin(context.Background(), admins, "bootstrap", "password", func() string { return "new" })
+
+		// Assert
+		if err != nil || len(admins.Admins) != 1 {
+			t.Fatalf("expected idempotent bootstrap, got count=%d err=%v", len(admins.Admins), err)
+		}
+	})
+
+	t.Run("ShouldFailWhenTableEmptyAndBootstrapCredentialsMissing", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+
+		// Act
+		err := BootstrapAdmin(context.Background(), admins, "", "", func() string { return "unused" })
+
+		// Assert
+		if err == nil {
+			t.Fatal("expected missing bootstrap credentials error")
+		}
+	})
+}

--- a/backend/internal/usecase/admin_management_test.go
+++ b/backend/internal/usecase/admin_management_test.go
@@ -16,18 +16,30 @@ func newAdminManagementService(admins *MockAdminRepository) *AdminAuthService {
 
 func TestAdminAuthService_AdminManagement(t *testing.T) {
 	t.Run("ShouldCreateAdminWhenActorIsSystemAdmin", func(t *testing.T) {
-		for _, role := range []domain.AdminRole{domain.AdminRoleCornerOperator, domain.AdminRoleSystemAdmin} {
-			// Arrange
-			admins := NewMockAdminRepository()
-			admins.Admins["system"] = &domain.Admin{ID: "system", Username: "system", Role: domain.AdminRoleSystemAdmin}
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["system"] = &domain.Admin{ID: "system", Username: "system", Role: domain.AdminRoleSystemAdmin}
 
-			// Act
-			created, err := newAdminManagementService(admins).CreateAdmin(context.Background(), "system", "new", "password", role)
+		// Act
+		created, err := newAdminManagementService(admins).CreateAdmin(context.Background(), "system", "new", "password", domain.AdminRoleCornerOperator)
 
-			// Assert
-			if err != nil || created.Role != role {
-				t.Fatalf("expected %s creation, got admin=%+v err=%v", role, created, err)
-			}
+		// Assert
+		if err != nil || created.Role != domain.AdminRoleCornerOperator {
+			t.Fatalf("expected corner operator creation, got admin=%+v err=%v", created, err)
+		}
+	})
+
+	t.Run("ShouldReturnForbiddenWhenSystemAdminCreatesAnotherSystemAdmin", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["system"] = &domain.Admin{ID: "system", Role: domain.AdminRoleSystemAdmin}
+
+		// Act
+		_, err := newAdminManagementService(admins).CreateAdmin(context.Background(), "system", "new-system", "password", domain.AdminRoleSystemAdmin)
+
+		// Assert
+		if !errors.Is(err, domain.ErrAdminForbidden) {
+			t.Fatalf("expected forbidden, got %v", err)
 		}
 	})
 

--- a/backend/internal/usecase/auth_admin.go
+++ b/backend/internal/usecase/auth_admin.go
@@ -181,7 +181,10 @@ func (s *AdminAuthService) CreateAdmin(
 	if _, err := s.authorizeSystemAdmin(ctx, actorAdminID); err != nil {
 		return nil, err
 	}
-	if role != domain.AdminRoleSystemAdmin && role != domain.AdminRoleCornerOperator {
+	if role != domain.AdminRoleCornerOperator {
+		if role == domain.AdminRoleSystemAdmin {
+			return nil, domain.ErrAdminForbidden
+		}
 		return nil, domain.ErrAdminInvalidRole
 	}
 	existing, err := s.admins.GetByUsername(ctx, username)


### PR DESCRIPTION
## 변경 사항
- SYSTEM_ADMIN 전용 관리자 생성·삭제 API와 본인 또는 SYSTEM_ADMIN의 비밀번호 변경 API를 추가했습니다.
- 403/404/409 오류 계약과 관리자 API Swagger 생성 문서를 동기화했습니다.
- 역할별 유즈케이스, bootstrap, 삭제 가드를 테스트하고 계획 체크리스트 및 자체 리뷰를 완료했습니다.

## 변경 이유
초기 관리자 생성 경로와 역할 기반 계정 관리 수단이 없어 운영자가 관리자 계정을 관리할 수 없었습니다.

## 종료 조건 증명
- cd backend && go build ./... 통과
- cd backend && go vet ./... 통과
- cd backend && go test ./... 통과
- cd backend && go test -race ./internal/domain ./internal/usecase ./internal/infrastructure/web 통과
- make swag 실행 후 api/docs.go, api/swagger.yaml, api/swagger.json 동기화 확인
- 사용자 결정에 따라 마지막 SYSTEM_ADMIN은 자기 삭제 금지로 삭제 요청 자체가 성립하지 않음

Base PR: #89