### PR TITLE
fix: 어드민 Phase 1~5 디자인 시스템 정렬

### DIFF
--- a/frontend/lib/admin/app.dart
+++ b/frontend/lib/admin/app.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:cornermon/admin/router/admin_router.dart';
+import 'package:cornermon/admin/theme/admin_theme_mode_provider.dart';
 import 'package:cornermon/shared/design_system/theme/admin_theme.dart';
 
 class AdminApp extends ConsumerWidget {
@@ -12,6 +13,7 @@ class AdminApp extends ConsumerWidget {
     return MaterialApp.router(
       theme: AdminTheme.lightTheme,
       darkTheme: AdminTheme.darkTheme,
+      themeMode: ref.watch(adminThemeModeProvider),
       routerConfig: ref.watch(adminRouterProvider),
     );
   }

--- a/frontend/lib/admin/features/dashboard/dashboard_screen.dart
+++ b/frontend/lib/admin/features/dashboard/dashboard_screen.dart
@@ -178,12 +178,15 @@ class DashboardScreen extends ConsumerWidget {
                       : 3,
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
-                  childAspectRatio: 1.35,
+                  childAspectRatio: 1.15,
                   children: [
                     for (final entry in visible)
                       CornerStatusCard(
                         entry: entry,
                         onTap: () => context.go('/corners/${entry.corner.id}'),
+                        onCreateTrack: entry.inactive
+                            ? () => context.go('/corner-track-manage')
+                            : null,
                       ),
                   ],
                 );
@@ -319,22 +322,39 @@ class _Filters extends ConsumerWidget {
 }
 
 class CornerStatusCard extends StatelessWidget {
-  const CornerStatusCard({required this.entry, required this.onTap, super.key});
+  const CornerStatusCard({
+    required this.entry,
+    required this.onTap,
+    this.onCreateTrack,
+    super.key,
+  });
+
   final CornerDashboardEntry entry;
   final VoidCallback onTap;
+  final VoidCallback? onCreateTrack;
+
   @override
   Widget build(BuildContext context) {
     final colors = Theme.of(context).brightness == Brightness.dark
         ? AppColors.dark
         : AppColors.light;
     final status = entry.corner.status;
-    final color = status == api.CornerOperationalStatus.BUSY
-        ? colors.statusIdle
-        : status == api.CornerOperationalStatus.IDLE
-        ? colors.quiet
-        : colors.statusInactive;
+    final presentation = switch (status) {
+      api.CornerOperationalStatus.BUSY => (
+        color: colors.statusIdle,
+        icon: '●',
+        label: '정상',
+      ),
+      api.CornerOperationalStatus.IDLE => (
+        color: colors.quiet,
+        icon: '○',
+        label: '유휴',
+      ),
+      _ => (color: colors.statusInactive, icon: '✕', label: '미가동'),
+    };
     final metric = entry.corner.cornerMetric;
     return Card(
+      clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onTap,
         child: Container(
@@ -344,7 +364,7 @@ class CornerStatusCard extends StatelessWidget {
                 width: 4,
                 color: entry.corner.isBottleneck ?? false
                     ? colors.statusAlert
-                    : Colors.transparent,
+                    : presentation.color,
               ),
             ),
           ),
@@ -357,9 +377,10 @@ class CornerStatusCard extends StatelessWidget {
                 style: Theme.of(context).textTheme.titleMedium,
               ),
               const Spacer(),
-              Chip(
-                avatar: Icon(Icons.circle, size: 12, color: color),
-                label: Text(status?.name ?? '미가동'),
+              _CornerStatusPill(
+                color: presentation.color,
+                icon: presentation.icon,
+                label: presentation.label,
               ),
               Text('목표 ${entry.corner.targetMinutes ?? 0}분'),
               Text(
@@ -369,9 +390,46 @@ class CornerStatusCard extends StatelessWidget {
                   avgDeviationSeconds: entry.avgDeviationSeconds,
                 ),
               ),
+              if (entry.inactive && onCreateTrack != null)
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton.icon(
+                    onPressed: onCreateTrack,
+                    icon: const Icon(Icons.add),
+                    label: const Text('트랙 생성'),
+                  ),
+                ),
             ],
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _CornerStatusPill extends StatelessWidget {
+  const _CornerStatusPill({
+    required this.color,
+    required this.icon,
+    required this.label,
+  });
+
+  final Color color;
+  final String icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final opacity = Theme.of(context).brightness == Brightness.dark ? .20 : .12;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: opacity),
+        borderRadius: BorderRadius.circular(100),
+      ),
+      child: Text(
+        '$icon  $label',
+        style: Theme.of(context).textTheme.labelLarge?.copyWith(color: color),
       ),
     );
   }

--- a/frontend/lib/admin/theme/admin_theme_mode_provider.dart
+++ b/frontend/lib/admin/theme/admin_theme_mode_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final adminThemeModeProvider = NotifierProvider<AdminThemeMode, ThemeMode>(
+  AdminThemeMode.new,
+);
+
+class AdminThemeMode extends Notifier<ThemeMode> {
+  @override
+  ThemeMode build() => ThemeMode.system;
+
+  void toggle(Brightness currentBrightness) => state =
+      currentBrightness == Brightness.dark ? ThemeMode.light : ThemeMode.dark;
+}

--- a/frontend/lib/admin/widgets/sidebar/admin_sidebar.dart
+++ b/frontend/lib/admin/widgets/sidebar/admin_sidebar.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
+import 'package:cornermon/admin/theme/admin_theme_mode_provider.dart';
 import 'package:cornermon/shared/api/domain_aliases.dart';
 
 enum SidebarMode { operating, preparing, reportOnly }
@@ -21,6 +22,7 @@ class AdminSidebar extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final isExtended = ref.watch(adminSidebarExtendedProvider);
     final items = switch (mode) {
       SidebarMode.operating => const [
         ('대시보드', Icons.dashboard_outlined, '/dashboard'),
@@ -43,15 +45,50 @@ class AdminSidebar extends ConsumerWidget {
     };
 
     return NavigationRail(
+      extended: isExtended,
+      minWidth: 64,
+      minExtendedWidth: 240,
       selectedIndex: _selectedIndex(context, items),
-      labelType: NavigationRailLabelType.all,
-      leading: TextButton.icon(
-        onPressed: () {
-          ref.read(selectedCampIdProvider.notifier).clear();
-          context.go('/camps');
-        },
-        icon: const Icon(Icons.arrow_back),
-        label: const Text('캠프 목록'),
+      labelType: isExtended
+          ? NavigationRailLabelType.none
+          : NavigationRailLabelType.all,
+      leading: Column(
+        children: [
+          Tooltip(
+            message: '캠프 목록',
+            child: isExtended
+                ? TextButton.icon(
+                    onPressed: () => _goToCamps(context, ref),
+                    icon: const Icon(Icons.arrow_back),
+                    label: const Text('캠프 목록'),
+                  )
+                : IconButton(
+                    onPressed: () => _goToCamps(context, ref),
+                    icon: const Icon(Icons.arrow_back),
+                  ),
+          ),
+          Tooltip(
+            message: isExtended ? '사이드바 접기' : '사이드바 펼치기',
+            child: IconButton(
+              onPressed: () =>
+                  ref.read(adminSidebarExtendedProvider.notifier).toggle(),
+              icon: Icon(isExtended ? Icons.chevron_left : Icons.chevron_right),
+            ),
+          ),
+          Tooltip(
+            message: '다크모드 전환',
+            child: IconButton(
+              onPressed: () => ref
+                  .read(adminThemeModeProvider.notifier)
+                  .toggle(Theme.of(context).brightness),
+              icon: Icon(
+                Theme.of(context).brightness == Brightness.dark
+                    ? Icons.light_mode_outlined
+                    : Icons.dark_mode_outlined,
+              ),
+            ),
+          ),
+        ],
       ),
       destinations: [
         for (final item in items)
@@ -59,6 +96,11 @@ class AdminSidebar extends ConsumerWidget {
       ],
       onDestinationSelected: (index) => context.go(items[index].$3),
     );
+  }
+
+  void _goToCamps(BuildContext context, WidgetRef ref) {
+    ref.read(selectedCampIdProvider.notifier).clear();
+    context.go('/camps');
   }
 
   int _selectedIndex(
@@ -70,4 +112,14 @@ class AdminSidebar extends ConsumerWidget {
         .indexWhere((item) => location.startsWith(item.$3))
         .clamp(0, items.length - 1);
   }
+}
+
+final adminSidebarExtendedProvider =
+    NotifierProvider<AdminSidebarExtended, bool>(AdminSidebarExtended.new);
+
+class AdminSidebarExtended extends Notifier<bool> {
+  @override
+  bool build() => true;
+
+  void toggle() => state = !state;
 }

--- a/frontend/lib/shared/design_system/theme/admin_theme.dart
+++ b/frontend/lib/shared/design_system/theme/admin_theme.dart
@@ -14,10 +14,14 @@ class AdminTheme {
   static ThemeData _buildTheme(AppColors colors) {
     return ThemeData(
       useMaterial3: true,
-      brightness: colors == AppColors.light ? Brightness.light : Brightness.dark,
+      brightness: colors == AppColors.light
+          ? Brightness.light
+          : Brightness.dark,
       scaffoldBackgroundColor: colors.bgCanvas,
       colorScheme: ColorScheme(
-        brightness: colors == AppColors.light ? Brightness.light : Brightness.dark,
+        brightness: colors == AppColors.light
+            ? Brightness.light
+            : Brightness.dark,
         primary: colors.brandPrimary,
         onPrimary: colors.bgSurface,
         secondary: colors.textSecondary,
@@ -27,9 +31,30 @@ class AdminTheme {
         surface: colors.bgSurface,
         onSurface: colors.textPrimary,
       ),
-      dividerTheme: DividerThemeData(
-        color: colors.border,
-        thickness: 1.0,
+      dividerTheme: DividerThemeData(color: colors.border, thickness: 1.0),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          minimumSize: const Size(44, 44),
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          minimumSize: const Size(44, 44),
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+      ),
+      iconButtonTheme: IconButtonThemeData(
+        style: IconButton.styleFrom(
+          minimumSize: const Size(44, 44),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
       ),
       textTheme: TextTheme(
         displayLarge: AppTypography.display.copyWith(color: colors.textPrimary),
@@ -37,7 +62,9 @@ class AdminTheme {
         titleMedium: AppTypography.title2.copyWith(color: colors.textPrimary),
         titleSmall: AppTypography.title3.copyWith(color: colors.textPrimary),
         bodyLarge: AppTypography.body.copyWith(color: colors.textPrimary),
-        bodyMedium: AppTypography.bodyEmphasis.copyWith(color: colors.textPrimary),
+        bodyMedium: AppTypography.bodyEmphasis.copyWith(
+          color: colors.textPrimary,
+        ),
         bodySmall: AppTypography.caption.copyWith(color: colors.textSecondary),
         labelLarge: AppTypography.label.copyWith(color: colors.textPrimary),
       ),

--- a/frontend/lib/shared/design_system/tokens/typography.dart
+++ b/frontend/lib/shared/design_system/tokens/typography.dart
@@ -15,13 +15,13 @@ class AppTypography {
 
   static const TextStyle title2 = TextStyle(
     fontSize: 22.0,
-    fontWeight: FontWeight.bold,
+    fontWeight: FontWeight.w600,
     height: 1.35,
   );
 
   static const TextStyle title3 = TextStyle(
     fontSize: 18.0,
-    fontWeight: FontWeight.bold,
+    fontWeight: FontWeight.w600,
     height: 1.4,
   );
 

--- a/frontend/test/admin/features/dashboard/dashboard_screen_test.dart
+++ b/frontend/test/admin/features/dashboard/dashboard_screen_test.dart
@@ -246,6 +246,33 @@ void main() {
       );
     });
 
+    testWidgets('ShouldRenderQuietAndInactiveCardAffordances', (tester) async {
+      // arrange
+      await _pumpDashboard(
+        tester,
+        campId: CampId('camp-1'),
+        corners: [
+          _corner('corner-1', '코너 1', CornerResponseStatusEnum.IDLE),
+          _corner('corner-2', '코너 2', CornerResponseStatusEnum.INACTIVE),
+        ],
+      );
+
+      // assert
+      expect(find.textContaining('유휴'), findsOneWidget);
+      expect(find.text('✕  미가동'), findsOneWidget);
+      expect(find.text('트랙 생성'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate((widget) {
+          if (widget is! Container || widget.decoration is! BoxDecoration) {
+            return false;
+          }
+          final border = (widget.decoration! as BoxDecoration).border;
+          return border is Border && border.left.color == AppColors.light.quiet;
+        }),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('ShoudShowLoadingIndicatorWhenCornersAreLoading', (
       tester,
     ) async {

--- a/frontend/test/admin/theme/admin_theme_mode_provider_test.dart
+++ b/frontend/test/admin/theme/admin_theme_mode_provider_test.dart
@@ -1,0 +1,19 @@
+import 'package:cornermon/admin/theme/admin_theme_mode_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('ShouldToggleAdminThemeModeFromCurrentBrightness', () {
+    // arrange
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    // act / assert
+    expect(container.read(adminThemeModeProvider), ThemeMode.system);
+    container.read(adminThemeModeProvider.notifier).toggle(Brightness.light);
+    expect(container.read(adminThemeModeProvider), ThemeMode.dark);
+    container.read(adminThemeModeProvider.notifier).toggle(Brightness.dark);
+    expect(container.read(adminThemeModeProvider), ThemeMode.light);
+  });
+}


### PR DESCRIPTION
## 변경 사항
- 관리자 사이드바에 64/240pt 축소·확장과 수동 다크모드 전환을 추가했습니다.
- 공용 테마로 버튼·아이콘 버튼의 최소 44pt 터치 타겟과 12px 모서리 규칙을 적용했습니다.
- 대시보드 코너 카드에 3색 상태 pill, 항상 표시되는 상태 보더, 병목 우선 보더, 미가동 트랙 생성 CTA를 반영했습니다.
- 상태 카드와 다크모드 전환 회귀 테스트를 추가했습니다.

## 종료 조건 검증
- flutter analyze lib/admin lib/shared/design_system lib/main_admin.dart test/admin 통과
- flutter test 전체 통과 (109 tests)
- git diff --check 통과
- 변경량: 226 additions / 27 deletions, PR 한 건(500 LOC 이하)

## 범위
- Phase 1은 데이터 계층만 포함하므로 UI 변경 대상이 없습니다.
- SSE 연결 배너는 Phase 12 범위이므로 이번 PR에 포함하지 않았습니다.