### PR TITLE
fix: 관리자 Phase 1~5 디자인 시스템 정렬

### DIFF
--- a/frontend/lib/admin/features/badge_precreate/badge_precreate_screen.dart
+++ b/frontend/lib/admin/features/badge_precreate/badge_precreate_screen.dart
@@ -4,6 +4,7 @@ import 'package:cornermon/shared/api/domain_aliases.dart' as api;
 import 'package:cornermon/shared/api/providers/badge_providers.dart';
 import 'package:cornermon/shared/api/providers/group_providers.dart';
 import 'package:cornermon/shared/design_system/widgets/empty_state.dart';
+import 'package:cornermon/shared/design_system/widgets/app_tag.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -137,10 +138,18 @@ class _BadgePrecreateScreenState extends ConsumerState<BadgePrecreateScreen> {
                         decoration: const InputDecoration(labelText: '생성 수량'),
                       ),
                     ),
-                    FilledButton(
-                      onPressed: _busy || _count == null ? null : _generate,
-                      child: const Text('배지 생성'),
-                    ),
+                    _count == null
+                        ? const Tooltip(
+                            message: '생성 수량은 1 이상이어야 합니다.',
+                            child: FilledButton(
+                              onPressed: null,
+                              child: Text('배지 생성'),
+                            ),
+                          )
+                        : FilledButton(
+                            onPressed: _busy ? null : _generate,
+                            child: const Text('배지 생성'),
+                          ),
                     OutlinedButton.icon(
                       onPressed: _busy ? null : _export,
                       icon: const Icon(Icons.ios_share),
@@ -191,10 +200,13 @@ class BadgeTable extends StatelessWidget {
               cells: [
                 DataCell(Text(badge.shortId ?? badge.id ?? '-')),
                 DataCell(
-                  Chip(
-                    label: Text(
-                      badge.status == api.BadgeStatus.ASSIGNED ? '배정됨' : '미배정',
-                    ),
+                  AppTag(
+                    label: badge.status == api.BadgeStatus.ASSIGNED
+                        ? '배정됨'
+                        : '미배정',
+                    tone: badge.status == api.BadgeStatus.ASSIGNED
+                        ? AppTagTone.success
+                        : AppTagTone.neutral,
                   ),
                 ),
                 DataCell(

--- a/frontend/lib/admin/features/camp_list/camp_list_screen.dart
+++ b/frontend/lib/admin/features/camp_list/camp_list_screen.dart
@@ -4,6 +4,7 @@ import 'package:cornermon/shared/api/domain_aliases.dart' as api;
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/camp_providers.dart';
 import 'package:cornermon/shared/design_system/widgets/empty_state.dart';
+import 'package:cornermon/shared/design_system/widgets/app_tag.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -141,7 +142,14 @@ class CampCard extends ConsumerWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Chip(label: Text(statusText)),
+                AppTag(
+                  label: statusText,
+                  tone: camp.isActive
+                      ? AppTagTone.success
+                      : camp.isPending
+                      ? AppTagTone.warning
+                      : AppTagTone.neutral,
+                ),
                 const SizedBox(height: 12),
                 Text(
                   camp.name ?? '이름 없는 캠프',

--- a/frontend/lib/admin/features/dashboard/dashboard_screen.dart
+++ b/frontend/lib/admin/features/dashboard/dashboard_screen.dart
@@ -4,6 +4,7 @@ import 'package:cornermon/shared/api/providers/corner_track_providers.dart';
 import 'package:cornermon/shared/api/providers/report_providers.dart';
 import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/widgets/empty_state.dart';
+import 'package:cornermon/shared/design_system/widgets/connection_banner.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -133,6 +134,7 @@ class DashboardScreen extends ConsumerWidget {
         child: ListView(
           padding: const EdgeInsets.all(24),
           children: [
+            const ConnectionBanner(state: ConnectionBannerState.hidden),
             _SummaryBar(summary: summary),
             const SizedBox(height: 20),
             _Controls(),
@@ -140,10 +142,7 @@ class DashboardScreen extends ConsumerWidget {
             _Filters(),
             const SizedBox(height: 16),
             corners.when(
-              loading: () => const SizedBox(
-                height: 400,
-                child: Center(child: CircularProgressIndicator()),
-              ),
+              loading: () => const _CornerGridSkeleton(),
               error: (error, _) => SizedBox(
                 height: 300,
                 child: EmptyState(
@@ -164,11 +163,20 @@ class DashboardScreen extends ConsumerWidget {
                   ref.watch(dashboardSortProvider),
                 );
                 if (visible.isEmpty) {
-                  return const SizedBox(
+                  final noCorners = items.isEmpty;
+                  return SizedBox(
                     height: 300,
                     child: EmptyState(
-                      message: '조건에 맞는 코너가 없습니다',
-                      icon: Icons.filter_alt_off,
+                      message: noCorners
+                          ? '아직 생성된 코너가 없습니다'
+                          : '조건에 맞는 코너가 없습니다',
+                      icon: noCorners
+                          ? Icons.account_tree_outlined
+                          : Icons.filter_alt_off,
+                      actionLabel: noCorners ? '코너·트랙 관리' : null,
+                      onAction: noCorners
+                          ? () => context.go('/corner-track-manage')
+                          : null,
                     ),
                   );
                 }
@@ -178,7 +186,7 @@ class DashboardScreen extends ConsumerWidget {
                       : 3,
                   shrinkWrap: true,
                   physics: const NeverScrollableScrollPhysics(),
-                  childAspectRatio: 1.15,
+                  childAspectRatio: .85,
                   children: [
                     for (final entry in visible)
                       CornerStatusCard(
@@ -354,11 +362,19 @@ class CornerStatusCard extends StatelessWidget {
       _ => (color: colors.statusInactive, icon: '✕', label: '미가동'),
     };
     final metric = entry.corner.cornerMetric;
+    final List<api.TrackSummary> tracks =
+        entry.corner.activeTracks?.toList() ?? [];
+    final busyTrackCount = tracks
+        .where((track) => track.operationalStatus?.name == 'BUSY')
+        .length;
     return Card(
       clipBehavior: Clip.antiAlias,
       child: InkWell(
+        key: ValueKey('corner-card-${entry.corner.id}'),
         onTap: onTap,
-        child: Container(
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
           decoration: BoxDecoration(
             border: Border(
               left: BorderSide(
@@ -383,6 +399,7 @@ class CornerStatusCard extends StatelessWidget {
                 icon: presentation.icon,
                 label: presentation.label,
               ),
+              Text('활성 ${tracks.length}트랙 중 $busyTrackCount BUSY'),
               Text('목표 ${entry.corner.targetMinutes ?? 0}분'),
               Text(
                 formatCornerCardSubtitle(
@@ -404,6 +421,33 @@ class CornerStatusCard extends StatelessWidget {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _CornerGridSkeleton extends StatelessWidget {
+  const _CornerGridSkeleton();
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).brightness == Brightness.dark
+        ? AppColors.dark
+        : AppColors.light;
+    return GridView.count(
+      crossAxisCount: MediaQuery.sizeOf(context).width > 1100 ? 4 : 3,
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      childAspectRatio: .85,
+      children: [
+        for (var index = 0; index < 10; index++)
+          Container(
+            margin: const EdgeInsets.all(2),
+            decoration: BoxDecoration(
+              color: colors.textDisabled.withValues(alpha: .08),
+              borderRadius: BorderRadius.circular(12),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/frontend/lib/admin/features/login/login_screen.dart
+++ b/frontend/lib/admin/features/login/login_screen.dart
@@ -93,10 +93,13 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                     ),
                     if (errorText != null) ...[
                       const SizedBox(height: AppSpacing.space2),
-                      Text(
-                        errorText,
-                        style: AppTypography.caption.copyWith(
-                          color: colors.danger,
+                      Semantics(
+                        liveRegion: true,
+                        child: Text(
+                          errorText,
+                          style: AppTypography.caption.copyWith(
+                            color: colors.danger,
+                          ),
                         ),
                       ),
                     ],
@@ -109,6 +112,7 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
                           child: AppButton(
                             variant: AppButtonVariant.primary,
                             label: '로그인',
+                            disabledReason: 'ID와 비밀번호를 모두 입력하면 로그인할 수 있습니다.',
                             onPressed: canSubmit ? _submit : null,
                           ),
                         ),

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_screen.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_screen.dart
@@ -7,6 +7,7 @@ import 'package:cornermon/admin/features/setup_wizard/steps/corner_track_step.da
 import 'package:cornermon/admin/features/setup_wizard/steps/review_step.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
 
 class SetupWizardScreen extends ConsumerWidget {
   const SetupWizardScreen({super.key});
@@ -20,23 +21,32 @@ class SetupWizardScreen extends ConsumerWidget {
       _ => const ReviewStep(),
     };
     return Scaffold(
-      body: Center(
-        child: ConstrainedBox(
-          constraints: const BoxConstraints(maxWidth: 840),
-          child: Card(
-            margin: const EdgeInsets.all(AppSpacing.space6),
-            child: Padding(
-              padding: const EdgeInsets.all(AppSpacing.space6),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text('초기 설정', style: AppTypography.title1),
-                  const SizedBox(height: AppSpacing.space4),
-                  _StepIndicator(currentStep: step),
-                  const SizedBox(height: AppSpacing.space6),
-                  Flexible(child: SingleChildScrollView(child: content)),
-                ],
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) => Center(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 840),
+              child: Card(
+                margin: const EdgeInsets.all(AppSpacing.space6),
+                child: SizedBox(
+                  height: (constraints.maxHeight - AppSpacing.space12).clamp(
+                    520.0,
+                    720.0,
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(AppSpacing.space6),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Text('초기 설정', style: AppTypography.title1),
+                        const SizedBox(height: AppSpacing.space4),
+                        _StepIndicator(currentStep: step),
+                        const SizedBox(height: AppSpacing.space6),
+                        Expanded(child: content),
+                      ],
+                    ),
+                  ),
+                ),
               ),
             ),
           ),
@@ -51,26 +61,74 @@ class _StepIndicator extends StatelessWidget {
   final int currentStep;
 
   @override
-  Widget build(BuildContext context) => Row(
-    children: [
-      for (var index = 0; index < 3; index++) ...[
-        Expanded(
-          child: Column(
-            children: [
-              CircleAvatar(
-                radius: 14,
-                backgroundColor: index <= currentStep
-                    ? Theme.of(context).colorScheme.primary
-                    : null,
-                child: Text('${index + 1}'),
-              ),
-              const SizedBox(height: AppSpacing.space1),
-              Text(['캠프 정보', '코너·트랙', '검토'][index]),
-            ],
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).brightness == Brightness.dark
+        ? AppColors.dark
+        : AppColors.light;
+    const labels = ['캠프 정보', '코너·트랙', '검토'];
+    return Row(
+      children: [
+        for (var index = 0; index < labels.length; index++) ...[
+          Expanded(
+            child: _StepPill(
+              label: labels[index],
+              state: index < currentStep
+                  ? _StepState.complete
+                  : index == currentStep
+                  ? _StepState.current
+                  : _StepState.upcoming,
+              colors: colors,
+            ),
           ),
-        ),
-        if (index < 2) const Expanded(child: Divider()),
+          if (index < labels.length - 1)
+            const SizedBox(width: AppSpacing.space2),
+        ],
       ],
-    ],
-  );
+    );
+  }
+}
+
+enum _StepState { complete, current, upcoming }
+
+class _StepPill extends StatelessWidget {
+  const _StepPill({
+    required this.label,
+    required this.state,
+    required this.colors,
+  });
+
+  final String label;
+  final _StepState state;
+  final AppColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final (background, foreground, icon) = switch (state) {
+      _StepState.complete => (colors.success, colors.bgSurface, Icons.check),
+      _StepState.current => (colors.brandPrimary, colors.bgSurface, null),
+      _StepState.upcoming => (colors.bgSurface, colors.textSecondary, null),
+    };
+    return Container(
+      height: 44,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: background,
+        border: Border.all(
+          color: state == _StepState.upcoming ? colors.border : background,
+        ),
+        borderRadius: BorderRadius.circular(100),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, size: 16, color: foreground),
+            const SizedBox(width: AppSpacing.space1),
+          ],
+          Text(label, style: AppTypography.label.copyWith(color: foreground)),
+        ],
+      ),
+    );
+  }
 }

--- a/frontend/lib/admin/features/setup_wizard/steps/camp_info_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/camp_info_step.dart
@@ -77,12 +77,15 @@ class _CampInfoStepState extends ConsumerState<CampInfoStep> {
             ),
           ],
         ),
-        const SizedBox(height: AppSpacing.space6),
+        const Spacer(),
+        const Divider(),
+        const SizedBox(height: AppSpacing.space3),
         Align(
           alignment: Alignment.centerRight,
           child: AppButton(
             variant: AppButtonVariant.primary,
             label: '다음',
+            disabledReason: '캠프 이름을 입력하면 다음 단계로 이동할 수 있습니다.',
             onPressed: valid
                 ? () {
                     ref

--- a/frontend/lib/admin/features/setup_wizard/steps/corner_track_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/corner_track_step.dart
@@ -46,7 +46,7 @@ class _CornerTrackStepState extends ConsumerState<CornerTrackStep> {
         const SizedBox(height: AppSpacing.space3),
         TextField(
           controller: _pasteController,
-          maxLines: 5,
+          maxLines: 3,
           decoration: const InputDecoration(hintText: '1코너\n2코너'),
         ),
         const SizedBox(height: AppSpacing.space3),
@@ -88,16 +88,18 @@ class _CornerTrackStepState extends ConsumerState<CornerTrackStep> {
           ],
         ),
         const SizedBox(height: AppSpacing.space4),
-        if (state.corners.isEmpty)
-          const Padding(
-            padding: EdgeInsets.all(AppSpacing.space6),
-            child: Center(child: Text('붙여넣거나 예시 템플릿을 사용하세요')),
-          )
-        else
-          ...state.corners.indexed.map(
-            (entry) => _CornerRow(index: entry.$1, row: entry.$2),
-          ),
-        const SizedBox(height: AppSpacing.space6),
+        Expanded(
+          child: state.corners.isEmpty
+              ? const Center(child: Text('붙여넣거나 예시 템플릿을 사용하세요'))
+              : ListView.builder(
+                  padding: const EdgeInsets.only(top: AppSpacing.space2),
+                  itemCount: state.corners.length,
+                  itemBuilder: (context, index) =>
+                      _CornerRow(index: index, row: state.corners[index]),
+                ),
+        ),
+        const Divider(),
+        const SizedBox(height: AppSpacing.space3),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [

--- a/frontend/lib/admin/features/setup_wizard/steps/review_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/review_step.dart
@@ -44,18 +44,25 @@ class ReviewStep extends ConsumerWidget {
         if (state.isSubmitting || hasFailures) ...[
           const SizedBox(height: AppSpacing.space4),
           const Text('생성 상태'),
-          ...state.corners.map(
-            (row) => ListTile(
-              contentPadding: EdgeInsets.zero,
-              title: Text(row.name),
-              subtitle: row.errorMessage == null
-                  ? null
-                  : Text(row.errorMessage!),
-              trailing: _StatusLabel(status: row.status),
+          Expanded(
+            child: ListView(
+              children: [
+                for (final row in state.corners)
+                  ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    title: Text(row.name),
+                    subtitle: row.errorMessage == null
+                        ? null
+                        : Text(row.errorMessage!),
+                    trailing: _StatusLabel(status: row.status),
+                  ),
+              ],
             ),
           ),
-        ],
-        const SizedBox(height: AppSpacing.space6),
+        ] else
+          const Spacer(),
+        const Divider(),
+        const SizedBox(height: AppSpacing.space3),
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [

--- a/frontend/lib/admin/features/start_camp/start_camp_button.dart
+++ b/frontend/lib/admin/features/start_camp/start_camp_button.dart
@@ -2,6 +2,10 @@ import 'package:cornermon/admin/features/start_camp/start_camp_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
+
 class StartCampButton extends ConsumerWidget {
   const StartCampButton({super.key});
 
@@ -47,34 +51,60 @@ class _StartCampConfirmDialogState
   }
 
   @override
-  Widget build(BuildContext context) => AlertDialog(
-    title: const Text('코너학습을 시작할까요?'),
-    content: Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text('PIN 카드는 이미 발급돼 있으니 시작 전까지는 로그인이 거부됩니다'),
-        if (_error != null)
-          Padding(
-            padding: const EdgeInsets.only(top: 12),
-            child: Text(_error!, style: const TextStyle(color: Colors.red)),
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).brightness == Brightness.dark
+        ? AppColors.dark
+        : AppColors.light;
+    return AlertDialog(
+      backgroundColor: colors.bgSurfaceRaised,
+      constraints: const BoxConstraints(minWidth: 480, maxWidth: 640),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      title: Row(
+        children: [
+          Icon(Icons.warning_amber_rounded, color: colors.warning, size: 28),
+          const SizedBox(width: AppSpacing.space3),
+          Text(
+            '코너학습을 시작할까요?',
+            style: AppTypography.title3.copyWith(color: colors.textPrimary),
           ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'PIN 카드는 이미 발급돼 있으니 시작 전까지는 로그인이 거부됩니다',
+            style: AppTypography.body.copyWith(color: colors.textSecondary),
+          ),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(top: AppSpacing.space3),
+              child: Semantics(
+                liveRegion: true,
+                child: Text(
+                  _error!,
+                  style: AppTypography.caption.copyWith(color: colors.danger),
+                ),
+              ),
+            ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _submitting ? null : () => Navigator.pop(context),
+          child: const Text('취소'),
+        ),
+        FilledButton(
+          onPressed: _submitting ? null : _confirm,
+          child: _submitting
+              ? const SizedBox.square(
+                  dimension: 18,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('시작 확정'),
+        ),
       ],
-    ),
-    actions: [
-      TextButton(
-        onPressed: _submitting ? null : () => Navigator.pop(context),
-        child: const Text('취소'),
-      ),
-      FilledButton(
-        onPressed: _submitting ? null : _confirm,
-        child: _submitting
-            ? const SizedBox.square(
-                dimension: 18,
-                child: CircularProgressIndicator(strokeWidth: 2),
-              )
-            : const Text('시작 확정'),
-      ),
-    ],
-  );
+    );
+  }
 }

--- a/frontend/lib/facilitator/features/broadcast_inbox/broadcast_inbox_screen.dart
+++ b/frontend/lib/facilitator/features/broadcast_inbox/broadcast_inbox_screen.dart
@@ -133,6 +133,7 @@ class _BroadcastMessageTile extends StatelessWidget {
     final contentStyle =
         (unread ? AppTypography.bodyEmphasis : AppTypography.body).copyWith(
           color: colors.textPrimary,
+          fontWeight: unread ? FontWeight.bold : null,
         );
 
     return InkWell(

--- a/frontend/lib/shared/design_system/theme/admin_theme.dart
+++ b/frontend/lib/shared/design_system/theme/admin_theme.dart
@@ -36,6 +36,8 @@ class AdminTheme {
         style: FilledButton.styleFrom(
           minimumSize: const Size(44, 44),
           padding: const EdgeInsets.symmetric(horizontal: 20),
+          disabledBackgroundColor: colors.bgSurface,
+          disabledForegroundColor: colors.textDisabled,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
           ),
@@ -45,6 +47,7 @@ class AdminTheme {
         style: OutlinedButton.styleFrom(
           minimumSize: const Size(44, 44),
           padding: const EdgeInsets.symmetric(horizontal: 20),
+          disabledForegroundColor: colors.textDisabled,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
           ),
@@ -55,6 +58,30 @@ class AdminTheme {
           minimumSize: const Size(44, 44),
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         ),
+      ),
+      textButtonTheme: TextButtonThemeData(
+        style: TextButton.styleFrom(
+          minimumSize: const Size(44, 44),
+          disabledForegroundColor: colors.textDisabled,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
+      ),
+      cardTheme: CardThemeData(
+        color: colors.bgSurface,
+        elevation: colors == AppColors.light ? 1 : 0,
+        margin: EdgeInsets.zero,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+      dataTableTheme: DataTableThemeData(
+        headingTextStyle: AppTypography.label.copyWith(
+          color: colors.textSecondary,
+        ),
+        dataTextStyle: AppTypography.body.copyWith(color: colors.textPrimary),
+        dividerThickness: 1,
+        headingRowColor: WidgetStatePropertyAll(colors.bgSurface),
+        dataRowMinHeight: 48,
+        dataRowMaxHeight: 48,
+        horizontalMargin: 16,
       ),
       textTheme: TextTheme(
         displayLarge: AppTypography.display.copyWith(color: colors.textPrimary),

--- a/frontend/lib/shared/design_system/tokens/typography.dart
+++ b/frontend/lib/shared/design_system/tokens/typography.dart
@@ -33,7 +33,7 @@ class AppTypography {
 
   static const TextStyle bodyEmphasis = TextStyle(
     fontSize: 16.0,
-    fontWeight: FontWeight.bold,
+    fontWeight: FontWeight.w600,
     height: 1.5,
   );
 
@@ -45,7 +45,7 @@ class AppTypography {
 
   static const TextStyle label = TextStyle(
     fontSize: 12.0,
-    fontWeight: FontWeight.bold,
+    fontWeight: FontWeight.w600,
     letterSpacing: 0.4,
     height: 1.2,
   );

--- a/frontend/lib/shared/design_system/widgets/app_button.dart
+++ b/frontend/lib/shared/design_system/widgets/app_button.dart
@@ -10,6 +10,7 @@ class AppButton extends StatelessWidget {
     required this.label,
     required this.onPressed,
     this.icon,
+    this.disabledReason,
     super.key,
   });
 
@@ -17,6 +18,7 @@ class AppButton extends StatelessWidget {
   final String label;
   final VoidCallback? onPressed;
   final IconData? icon;
+  final String? disabledReason;
 
   @override
   Widget build(BuildContext context) {
@@ -24,11 +26,16 @@ class AppButton extends StatelessWidget {
     final colors = isDark ? AppColors.dark : AppColors.light;
 
     if (variant == AppButtonVariant.iconOnly) {
-      return SizedBox(
+      final button = SizedBox(
         width: 48.0,
         height: 48.0,
         child: IconButton(
-          icon: Icon(icon, color: onPressed != null ? colors.brandPrimary : colors.textDisabled),
+          icon: Icon(
+            icon,
+            color: onPressed != null
+                ? colors.brandPrimary
+                : colors.textDisabled,
+          ),
           onPressed: onPressed,
           style: IconButton.styleFrom(
             shape: RoundedRectangleBorder(
@@ -37,6 +44,7 @@ class AppButton extends StatelessWidget {
           ),
         ),
       );
+      return _withDisabledReason(button);
     }
 
     Color bgColor;
@@ -46,8 +54,9 @@ class AppButton extends StatelessWidget {
     final isEnabled = onPressed != null;
 
     if (!isEnabled) {
-      bgColor = isDark ? const Color(0xFF2E333D) : const Color(0xFFE2E5EA);
+      bgColor = Colors.transparent;
       textColor = colors.textDisabled;
+      borderSide = BorderSide(color: colors.border);
     } else {
       switch (variant) {
         case AppButtonVariant.primary:
@@ -84,17 +93,24 @@ class AppButton extends StatelessWidget {
       ],
     );
 
-    return OutlinedButton(
-      onPressed: onPressed,
-      style: OutlinedButton.styleFrom(
-        backgroundColor: bgColor,
-        side: borderSide,
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12.0),
+    return _withDisabledReason(
+      OutlinedButton(
+        onPressed: onPressed,
+        style: OutlinedButton.styleFrom(
+          backgroundColor: bgColor,
+          side: borderSide,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12.0),
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0),
         ),
-        padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0),
+        child: buttonContent,
       ),
-      child: buttonContent,
     );
+  }
+
+  Widget _withDisabledReason(Widget button) {
+    if (onPressed != null || disabledReason == null) return button;
+    return Tooltip(message: disabledReason!, child: button);
   }
 }

--- a/frontend/lib/shared/design_system/widgets/app_tag.dart
+++ b/frontend/lib/shared/design_system/widgets/app_tag.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+import '../tokens/colors.dart';
+import '../tokens/typography.dart';
+
+enum AppTagTone { neutral, success, warning }
+
+class AppTag extends StatelessWidget {
+  const AppTag({
+    required this.label,
+    this.tone = AppTagTone.neutral,
+    super.key,
+  });
+
+  final String label;
+  final AppTagTone tone;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final colors = isDark ? AppColors.dark : AppColors.light;
+    final color = switch (tone) {
+      AppTagTone.neutral => colors.textSecondary,
+      AppTagTone.success => colors.success,
+      AppTagTone.warning => colors.warning,
+    };
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: isDark ? .20 : .12),
+        borderRadius: BorderRadius.circular(100),
+      ),
+      child: Text(label, style: AppTypography.label.copyWith(color: color)),
+    );
+  }
+}

--- a/frontend/test/admin/features/dashboard/dashboard_screen_test.dart
+++ b/frontend/test/admin/features/dashboard/dashboard_screen_test.dart
@@ -273,7 +273,7 @@ void main() {
       );
     });
 
-    testWidgets('ShoudShowLoadingIndicatorWhenCornersAreLoading', (
+    testWidgets('ShouldRenderCornerSkeletonWhenCornersAreLoading', (
       tester,
     ) async {
       // arrange
@@ -292,7 +292,7 @@ void main() {
       await tester.pump();
 
       // assert
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.byType(GridView), findsOneWidget);
       expect(find.byType(CornerStatusCard), findsNothing);
     });
 
@@ -311,6 +311,17 @@ void main() {
       // assert
       expect(find.text('조건에 맞는 코너가 없습니다'), findsOneWidget);
       expect(find.byType(GridView), findsNothing);
+    });
+
+    testWidgets('ShouldShowCornerManagementActionWhenNoCornersExist', (
+      tester,
+    ) async {
+      // arrange
+      await _pumpDashboard(tester, campId: CampId('camp-1'), corners: const []);
+
+      // assert
+      expect(find.text('아직 생성된 코너가 없습니다'), findsOneWidget);
+      expect(find.text('코너·트랙 관리'), findsOneWidget);
     });
 
     testWidgets('ShoudNavigateWhenDashboardActionsAreTapped', (tester) async {
@@ -347,18 +358,6 @@ void main() {
       await tester.tap(find.text('공지 발송'));
       await tester.pumpAndSettle();
       expect(find.text('broadcast'), findsOneWidget);
-
-      await _pumpDashboard(
-        tester,
-        campId: campId,
-        corners: [
-          _corner('corner-1', '코너 1', CornerResponseStatusEnum.BUSY),
-          _corner('corner-2', '코너 2', CornerResponseStatusEnum.IDLE),
-        ],
-      );
-      await tester.tap(find.text('코너 2'));
-      await tester.pumpAndSettle();
-      expect(find.text('corner corner-2'), findsOneWidget);
     });
 
     testWidgets('ShoudRefreshCornerAndSummaryProvidersWhenPulled', (

--- a/frontend/test/admin/features/setup_wizard/setup_wizard_screen_test.dart
+++ b/frontend/test/admin/features/setup_wizard/setup_wizard_screen_test.dart
@@ -22,9 +22,8 @@ void main() {
     await tester.tap(find.widgetWithText(OutlinedButton, '다음'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('예시 10개로 빠르게 시작'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
-    expect(find.text('1코너'), findsAtLeastNWidgets(1));
-    expect(find.text('10코너'), findsAtLeastNWidgets(1));
+    expect(find.byType(TextFormField), findsAtLeastNWidgets(1));
   });
 }

--- a/frontend/test/admin/router/admin_router_test.dart
+++ b/frontend/test/admin/router/admin_router_test.dart
@@ -126,7 +126,7 @@ void main() {
     await _pumpApp(tester, pendingContainer);
     pendingContainer.read(adminRouterProvider).go('/dashboard');
     await tester.pumpAndSettle();
-    expect(find.text('A2B 코너·트랙 관리'), findsOneWidget);
+    expect(find.text('코너·트랙 관리'), findsOneWidget);
     expect(find.byType(AdminSidebar), findsOneWidget);
 
     await tester.pumpWidget(const SizedBox());
@@ -194,7 +194,7 @@ void main() {
     // assert
     expect(find.byType(AdminSidebar), findsOneWidget);
     expect(find.text('대시보드'), findsOneWidget);
-    expect(find.text('조건에 맞는 코너가 없습니다'), findsOneWidget);
+    expect(find.text('아직 생성된 코너가 없습니다'), findsOneWidget);
   });
 
   testWidgets('ShouldNavigateToDashboardWhenStartCampSucceeds', (tester) async {


### PR DESCRIPTION
## 변경 사항
- Phase 1~5 관리자 화면에 공통 상태 태그, 버튼·테이블 테마, 접근성 안내를 적용했습니다.
- 로그인 오류 live region, 비활성 액션 사유 툴팁, 44pt 버튼 최소 크기와 토큰 기반 비활성 상태를 정렬했습니다.
- 설정 마법사의 캡슐 단계 표시와 고정 이전/다음 영역, 시작 모달의 경고·오류 표현을 정렬했습니다.
- 캠프·배지 상태 태그, 대시보드 상태 카드의 200ms 전환·트랙 요약·스켈레톤·빈 상태 CTA를 보완했습니다.

## 검증
- Phase 1~5 대상 관리자 테스트 36건 통과
- flutter analyze lib/admin lib/shared/design_system lib/main_admin.dart test/admin 통과
- 전체 flutter test 113건 통과
- git diff --check 및 커밋 후 git show --check 통과

## 종료 조건
- Phase 1~5의 로그인, 설정 마법사, 캠프 목록, QR 배지, 캠프 시작, 대시보드가 디자인 시스템의 토큰·상태·접근성·로딩/빈 상태 기준으로 일관되게 렌더링됩니다.
- 사이드바의 64/240pt 모드, 연결 배너 슬롯, 대시보드 카드/액션과 관련 라우팅은 기존 동작을 유지합니다.