### PR TITLE
feat: CreateCampRequest에 startAt/endAt 필드 반영

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -318,7 +318,13 @@ definitions:
     type: object
   CreateCampRequest:
     properties:
+      endAt:
+        format: date-time
+        type: string
       name:
+        type: string
+      startAt:
+        format: date-time
         type: string
     type: object
   CreateCornerRequest:

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
@@ -102,22 +102,6 @@ class SetupWizard extends _$SetupWizard {
       return false;
     }
 
-    if (state.startAt != null || state.endAt != null) {
-      try {
-        await ref.read(
-          updateCampProvider(
-            campId,
-            startAt: state.startAt,
-            endAt: state.endAt,
-          ).future,
-        );
-      } catch (_) {
-        state = state.copyWith(
-          submitError: '캠프 기간은 저장하지 못했습니다. 설정에서 다시 지정할 수 있습니다.',
-        );
-      }
-    }
-
     for (var index = 0; index < state.corners.length; index++) {
       final row = state.corners[index];
       if (row.status == SetupWizardCornerStatus.created) continue;
@@ -174,7 +158,18 @@ class SetupWizard extends _$SetupWizard {
   }
 
   Future<CampId> _createCamp() async {
-    final camp = await ref.read(createCampProvider(state.campName).future);
+    final startAt = state.startAt;
+    final endAt = state.endAt;
+    if (startAt == null || endAt == null) {
+      throw StateError('캠프 시작일/종료일이 설정되지 않았습니다.');
+    }
+    final camp = await ref.read(
+      createCampProvider(
+        state.campName,
+        startAt: startAt,
+        endAt: endAt,
+      ).future,
+    );
     final id = camp.id;
     if (id == null) throw StateError('생성된 캠프 ID가 없습니다.');
     return CampId(id);

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.g.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.g.dart
@@ -41,7 +41,7 @@ final class SetupWizardProvider
   }
 }
 
-String _$setupWizardHash() => r'a31e8ce615fa73aa2b31ce87bcaab9413a62b356';
+String _$setupWizardHash() => r'bf1f18e0b8eee43e06769013847c3eaa7b72874e';
 
 abstract class _$SetupWizard extends $Notifier<SetupWizardState> {
   SetupWizardState build();

--- a/frontend/lib/admin/features/setup_wizard/steps/camp_info_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/camp_info_step.dart
@@ -47,7 +47,10 @@ class _CampInfoStepState extends ConsumerState<CampInfoStep> {
 
   @override
   Widget build(BuildContext context) {
-    final valid = _nameController.text.trim().isNotEmpty;
+    final valid =
+        _nameController.text.trim().isNotEmpty &&
+        _startAt != null &&
+        _endAt != null;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
@@ -66,13 +69,13 @@ class _CampInfoStepState extends ConsumerState<CampInfoStep> {
             OutlinedButton(
               onPressed: () => _selectDate(true),
               child: Text(
-                _startAt == null ? '시작일 선택 (선택)' : '시작일 ${_date(_startAt!)}',
+                _startAt == null ? '시작일 선택' : '시작일 ${_date(_startAt!)}',
               ),
             ),
             OutlinedButton(
               onPressed: () => _selectDate(false),
               child: Text(
-                _endAt == null ? '종료일 선택 (선택)' : '종료일 ${_date(_endAt!)}',
+                _endAt == null ? '종료일 선택' : '종료일 ${_date(_endAt!)}',
               ),
             ),
           ],
@@ -85,7 +88,7 @@ class _CampInfoStepState extends ConsumerState<CampInfoStep> {
           child: AppButton(
             variant: AppButtonVariant.primary,
             label: '다음',
-            disabledReason: '캠프 이름을 입력하면 다음 단계로 이동할 수 있습니다.',
+            disabledReason: '캠프 이름과 시작일·종료일을 입력하면 다음 단계로 이동할 수 있습니다.',
             onPressed: valid
                 ? () {
                     ref

--- a/frontend/lib/shared/api/gen/doc/CreateCampRequest.md
+++ b/frontend/lib/shared/api/gen/doc/CreateCampRequest.md
@@ -8,7 +8,9 @@ import 'package:cornermon_api_gen/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**endAt** | [**DateTime**](DateTime.md) |  | [optional] 
 **name** | **String** |  | [optional] 
+**startAt** | [**DateTime**](DateTime.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/frontend/lib/shared/api/gen/lib/src/model/create_camp_request.dart
+++ b/frontend/lib/shared/api/gen/lib/src/model/create_camp_request.dart
@@ -1,4 +1,3 @@
-// @dart=2.18
 //
 // AUTO-GENERATED FILE, DO NOT MODIFY!
 //
@@ -12,11 +11,19 @@ part 'create_camp_request.g.dart';
 /// CreateCampRequest
 ///
 /// Properties:
+/// * [endAt] 
 /// * [name] 
+/// * [startAt] 
 @BuiltValue()
 abstract class CreateCampRequest implements Built<CreateCampRequest, CreateCampRequestBuilder> {
+  @BuiltValueField(wireName: r'endAt')
+  DateTime? get endAt;
+
   @BuiltValueField(wireName: r'name')
   String? get name;
+
+  @BuiltValueField(wireName: r'startAt')
+  DateTime? get startAt;
 
   CreateCampRequest._();
 
@@ -41,11 +48,25 @@ class _$CreateCampRequestSerializer implements PrimitiveSerializer<CreateCampReq
     CreateCampRequest object, {
     FullType specifiedType = FullType.unspecified,
   }) sync* {
+    if (object.endAt != null) {
+      yield r'endAt';
+      yield serializers.serialize(
+        object.endAt,
+        specifiedType: const FullType(DateTime),
+      );
+    }
     if (object.name != null) {
       yield r'name';
       yield serializers.serialize(
         object.name,
         specifiedType: const FullType(String),
+      );
+    }
+    if (object.startAt != null) {
+      yield r'startAt';
+      yield serializers.serialize(
+        object.startAt,
+        specifiedType: const FullType(DateTime),
       );
     }
   }
@@ -71,12 +92,26 @@ class _$CreateCampRequestSerializer implements PrimitiveSerializer<CreateCampReq
       final key = serializedList[i] as String;
       final value = serializedList[i + 1];
       switch (key) {
+        case r'endAt':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(DateTime),
+          ) as DateTime;
+          result.endAt = valueDes;
+          break;
         case r'name':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType(String),
           ) as String;
           result.name = valueDes;
+          break;
+        case r'startAt':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(DateTime),
+          ) as DateTime;
+          result.startAt = valueDes;
           break;
         default:
           unhandled.add(key);
@@ -106,3 +141,4 @@ class _$CreateCampRequestSerializer implements PrimitiveSerializer<CreateCampReq
     return result.build();
   }
 }
+

--- a/frontend/lib/shared/api/gen/lib/src/model/create_camp_request.g.dart
+++ b/frontend/lib/shared/api/gen/lib/src/model/create_camp_request.g.dart
@@ -1,4 +1,3 @@
-// @dart=2.18
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
 part of 'create_camp_request.dart';
@@ -9,13 +8,17 @@ part of 'create_camp_request.dart';
 
 class _$CreateCampRequest extends CreateCampRequest {
   @override
+  final DateTime? endAt;
+  @override
   final String? name;
+  @override
+  final DateTime? startAt;
 
   factory _$CreateCampRequest(
           [void Function(CreateCampRequestBuilder)? updates]) =>
       (CreateCampRequestBuilder()..update(updates))._build();
 
-  _$CreateCampRequest._({this.name}) : super._();
+  _$CreateCampRequest._({this.endAt, this.name, this.startAt}) : super._();
   @override
   CreateCampRequest rebuild(void Function(CreateCampRequestBuilder) updates) =>
       (toBuilder()..update(updates)).build();
@@ -27,13 +30,18 @@ class _$CreateCampRequest extends CreateCampRequest {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is CreateCampRequest && name == other.name;
+    return other is CreateCampRequest &&
+        endAt == other.endAt &&
+        name == other.name &&
+        startAt == other.startAt;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, endAt.hashCode);
     _$hash = $jc(_$hash, name.hashCode);
+    _$hash = $jc(_$hash, startAt.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -41,7 +49,9 @@ class _$CreateCampRequest extends CreateCampRequest {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'CreateCampRequest')
-          ..add('name', name))
+          ..add('endAt', endAt)
+          ..add('name', name)
+          ..add('startAt', startAt))
         .toString();
   }
 }
@@ -50,9 +60,17 @@ class CreateCampRequestBuilder
     implements Builder<CreateCampRequest, CreateCampRequestBuilder> {
   _$CreateCampRequest? _$v;
 
+  DateTime? _endAt;
+  DateTime? get endAt => _$this._endAt;
+  set endAt(DateTime? endAt) => _$this._endAt = endAt;
+
   String? _name;
   String? get name => _$this._name;
   set name(String? name) => _$this._name = name;
+
+  DateTime? _startAt;
+  DateTime? get startAt => _$this._startAt;
+  set startAt(DateTime? startAt) => _$this._startAt = startAt;
 
   CreateCampRequestBuilder() {
     CreateCampRequest._defaults(this);
@@ -61,7 +79,9 @@ class CreateCampRequestBuilder
   CreateCampRequestBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _endAt = $v.endAt;
       _name = $v.name;
+      _startAt = $v.startAt;
       _$v = null;
     }
     return this;
@@ -83,7 +103,9 @@ class CreateCampRequestBuilder
   _$CreateCampRequest _build() {
     final _$result = _$v ??
         _$CreateCampRequest._(
+          endAt: endAt,
           name: name,
+          startAt: startAt,
         );
     replace(_$result);
     return _$result;

--- a/frontend/lib/shared/api/providers/camp_providers.dart
+++ b/frontend/lib/shared/api/providers/camp_providers.dart
@@ -9,7 +9,7 @@ part 'camp_providers.g.dart';
 @riverpod
 BResourceManagementAdminApi campApi(Ref ref) {
   final dio = ref.watch(apiClientProvider);
-  return BResourceManagementAdminApi(dio, serializers);
+  return BResourceManagementAdminApi(dio, standardSerializers);
 }
 
 @riverpod
@@ -31,10 +31,18 @@ Future<Camp> campDetail(Ref ref, CampId id) async {
 }
 
 @riverpod
-Future<Camp> createCamp(Ref ref, String name) async {
+Future<Camp> createCamp(
+  Ref ref,
+  String name, {
+  required DateTime startAt,
+  required DateTime endAt,
+}) async {
   final apiInstance = ref.watch(campApiProvider);
   final response = await apiInstance.campsPost(
-    request: CreateCampRequest((b) => b..name = name),
+    request: CreateCampRequest((b) => b
+      ..name = name
+      ..startAt = startAt
+      ..endAt = endAt),
   );
   final data = response.data;
   if (data == null) {

--- a/frontend/lib/shared/api/providers/camp_providers.g.dart
+++ b/frontend/lib/shared/api/providers/camp_providers.g.dart
@@ -54,7 +54,7 @@ final class CampApiProvider
   }
 }
 
-String _$campApiHash() => r'65ecb5f892b27813d989fb747515363de2027955';
+String _$campApiHash() => r'da566b484cc615fa8a649ca24939cf6d58a6ae6b';
 
 @ProviderFor(campList)
 final campListProvider = CampListProvider._();
@@ -171,7 +171,7 @@ final class CreateCampProvider
     with $FutureModifier<Camp>, $FutureProvider<Camp> {
   CreateCampProvider._({
     required CreateCampFamily super.from,
-    required String super.argument,
+    required (String, {DateTime startAt, DateTime endAt}) super.argument,
   }) : super(
          retry: null,
          name: r'createCampProvider',
@@ -187,7 +187,7 @@ final class CreateCampProvider
   String toString() {
     return r'createCampProvider'
         ''
-        '($argument)';
+        '$argument';
   }
 
   @$internal
@@ -197,8 +197,14 @@ final class CreateCampProvider
 
   @override
   FutureOr<Camp> create(Ref ref) {
-    final argument = this.argument as String;
-    return createCamp(ref, argument);
+    final argument =
+        this.argument as (String, {DateTime startAt, DateTime endAt});
+    return createCamp(
+      ref,
+      argument.$1,
+      startAt: argument.startAt,
+      endAt: argument.endAt,
+    );
   }
 
   @override
@@ -212,10 +218,14 @@ final class CreateCampProvider
   }
 }
 
-String _$createCampHash() => r'ac6b77f9194aa83923717dcdebb93e4a2cf9d45e';
+String _$createCampHash() => r'0a7e551d2f1cf3a5cb2ce81895876b8de7e4e354';
 
 final class CreateCampFamily extends $Family
-    with $FunctionalFamilyOverride<FutureOr<Camp>, String> {
+    with
+        $FunctionalFamilyOverride<
+          FutureOr<Camp>,
+          (String, {DateTime startAt, DateTime endAt})
+        > {
   CreateCampFamily._()
     : super(
         retry: null,
@@ -225,8 +235,14 @@ final class CreateCampFamily extends $Family
         isAutoDispose: true,
       );
 
-  CreateCampProvider call(String name) =>
-      CreateCampProvider._(argument: name, from: this);
+  CreateCampProvider call(
+    String name, {
+    required DateTime startAt,
+    required DateTime endAt,
+  }) => CreateCampProvider._(
+    argument: (name, startAt: startAt, endAt: endAt),
+    from: this,
+  );
 
   @override
   String toString() => r'createCampProvider';


### PR DESCRIPTION
## Summary
- 캠프 생성 API가 `name`뿐 아니라 `startAt`/`endAt`(date-time)을 함께 받도록 변경될 예정이어서, `api/swagger.yaml`의 `CreateCampRequest`에 두 필드를 추가하고 프론트엔드 OpenAPI 클라이언트(`frontend/lib/shared/api/gen`)를 재생성했습니다.
- `camp_providers.dart`의 `createCamp` provider가 `startAt`/`endAt`을 필수 인자로 받도록 변경했습니다.
- Setup Wizard 1단계(캠프 정보 입력)에서 시작일/종료일을 필수 입력으로 전환하고, 캠프 생성 시점에 바로 전달하도록 하여 기존에 있던 "생성 후 별도 `updateCamp` 호출" 단계를 제거했습니다.

## Test plan
- [x] `dart analyze lib` — 전체 통과, 이슈 없음
- [x] `openapi-generator generate` + `build_runner build` 로 `CreateCampRequest` 클라이언트 코드가 `startAt`/`endAt`을 포함하도록 재생성됨을 확인
- [ ] Setup Wizard 1단계에서 시작일/종료일 미선택 시 "다음" 버튼이 비활성화되는지 실제 앱에서 수동 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)