### PR TITLE
초기 설정 마법사 UI를 목업 레이아웃에 맞춰 재정비

### DIFF
--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
@@ -164,11 +164,7 @@ class SetupWizard extends _$SetupWizard {
       throw StateError('캠프 시작일/종료일이 설정되지 않았습니다.');
     }
     final camp = await ref.read(
-      createCampProvider(
-        state.campName,
-        startAt: startAt,
-        endAt: endAt,
-      ).future,
+      createCampProvider(state.campName, startAt: startAt, endAt: endAt).future,
     );
     final id = camp.id;
     if (id == null) throw StateError('생성된 캠프 ID가 없습니다.');

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_screen.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_screen.dart
@@ -1,52 +1,66 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_state.dart';
 import 'package:cornermon/admin/features/setup_wizard/steps/camp_info_step.dart';
 import 'package:cornermon/admin/features/setup_wizard/steps/corner_track_step.dart';
 import 'package:cornermon/admin/features/setup_wizard/steps/review_step.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/tokens/colors.dart';
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 
 class SetupWizardScreen extends ConsumerWidget {
   const SetupWizardScreen({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final step = ref.watch(setupWizardProvider.select((value) => value.step));
-    final content = switch (step) {
+    final state = ref.watch(setupWizardProvider);
+    final colors = Theme.of(context).brightness == Brightness.dark
+        ? AppColors.dark
+        : AppColors.light;
+    final content = switch (state.step) {
       0 => const CampInfoStep(),
       1 => const CornerTrackStep(),
       _ => const ReviewStep(),
     };
     return Scaffold(
       body: SafeArea(
-        child: LayoutBuilder(
-          builder: (context, constraints) => Center(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(AppSpacing.space6),
             child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 840),
-              child: Card(
-                margin: const EdgeInsets.all(AppSpacing.space6),
-                child: SizedBox(
-                  height: (constraints.maxHeight - AppSpacing.space12).clamp(
-                    520.0,
-                    720.0,
+              constraints: const BoxConstraints(maxWidth: 640),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    '코너학습 초기 설정',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.title1,
                   ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(AppSpacing.space6),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.stretch,
-                      children: [
-                        Text('초기 설정', style: AppTypography.title1),
-                        const SizedBox(height: AppSpacing.space4),
-                        _StepIndicator(currentStep: step),
-                        const SizedBox(height: AppSpacing.space6),
-                        Expanded(child: content),
-                      ],
+                  const SizedBox(height: AppSpacing.space1),
+                  Text(
+                    '캠프 정보와 코너·트랙을 한 번에 준비합니다',
+                    textAlign: TextAlign.center,
+                    style: AppTypography.caption.copyWith(
+                      color: colors.textSecondary,
                     ),
                   ),
-                ),
+                  const SizedBox(height: AppSpacing.space5),
+                  _StepIndicator(currentStep: state.step, colors: colors),
+                  const SizedBox(height: AppSpacing.space4),
+                  Card(
+                    child: Padding(
+                      padding: const EdgeInsets.all(AppSpacing.space5),
+                      child: content,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.space4),
+                  _WizardFooter(state: state),
+                ],
               ),
             ),
           ),
@@ -57,31 +71,34 @@ class SetupWizardScreen extends ConsumerWidget {
 }
 
 class _StepIndicator extends StatelessWidget {
-  const _StepIndicator({required this.currentStep});
+  const _StepIndicator({required this.currentStep, required this.colors});
   final int currentStep;
+  final AppColors colors;
 
   @override
   Widget build(BuildContext context) {
-    final colors = Theme.of(context).brightness == Brightness.dark
-        ? AppColors.dark
-        : AppColors.light;
     const labels = ['캠프 정보', '코너·트랙', '검토'];
     return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
       children: [
         for (var index = 0; index < labels.length; index++) ...[
-          Expanded(
-            child: _StepPill(
-              label: labels[index],
-              state: index < currentStep
-                  ? _StepState.complete
-                  : index == currentStep
-                  ? _StepState.current
-                  : _StepState.upcoming,
-              colors: colors,
-            ),
+          _StepPill(
+            number: index + 1,
+            label: labels[index],
+            state: index < currentStep
+                ? _StepState.complete
+                : index == currentStep
+                ? _StepState.current
+                : _StepState.upcoming,
+            colors: colors,
           ),
           if (index < labels.length - 1)
-            const SizedBox(width: AppSpacing.space2),
+            Container(
+              width: 20,
+              height: 1,
+              margin: const EdgeInsets.symmetric(horizontal: AppSpacing.space1),
+              color: colors.border,
+            ),
         ],
       ],
     );
@@ -92,43 +109,152 @@ enum _StepState { complete, current, upcoming }
 
 class _StepPill extends StatelessWidget {
   const _StepPill({
+    required this.number,
     required this.label,
     required this.state,
     required this.colors,
   });
 
+  final int number;
   final String label;
   final _StepState state;
   final AppColors colors;
 
   @override
   Widget build(BuildContext context) {
-    final (background, foreground, icon) = switch (state) {
-      _StepState.complete => (colors.success, colors.bgSurface, Icons.check),
-      _StepState.current => (colors.brandPrimary, colors.bgSurface, null),
-      _StepState.upcoming => (colors.bgSurface, colors.textSecondary, null),
+    final (background, foreground, numBackground) = switch (state) {
+      _StepState.complete => (
+        colors.brandPrimary.withValues(alpha: .1),
+        colors.brandPrimary,
+        colors.success,
+      ),
+      _StepState.current => (
+        colors.brandPrimary.withValues(alpha: .1),
+        colors.brandPrimary,
+        colors.brandPrimary,
+      ),
+      _StepState.upcoming => (
+        colors.bgCanvas,
+        colors.textDisabled,
+        colors.border,
+      ),
     };
     return Container(
-      height: 44,
-      alignment: Alignment.center,
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
       decoration: BoxDecoration(
         color: background,
-        border: Border.all(
-          color: state == _StepState.upcoming ? colors.border : background,
-        ),
         borderRadius: BorderRadius.circular(100),
       ),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (icon != null) ...[
-            Icon(icon, size: 16, color: foreground),
-            const SizedBox(width: AppSpacing.space1),
-          ],
+          Container(
+            width: 18,
+            height: 18,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: numBackground,
+              shape: BoxShape.circle,
+            ),
+            child: state == _StepState.complete
+                ? Icon(Icons.check, size: 12, color: colors.bgSurface)
+                : Text(
+                    '$number',
+                    style: AppTypography.label.copyWith(
+                      fontSize: 10.5,
+                      color: colors.bgSurface,
+                    ),
+                  ),
+          ),
+          const SizedBox(width: AppSpacing.space1),
           Text(label, style: AppTypography.label.copyWith(color: foreground)),
         ],
       ),
+    );
+  }
+}
+
+class _WizardFooter extends ConsumerWidget {
+  const _WizardFooter({required this.state});
+  final SetupWizardState state;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notifier = ref.read(setupWizardProvider.notifier);
+    final hasFailures = state.corners.any(
+      (row) => row.status == SetupWizardCornerStatus.failed,
+    );
+
+    final VoidCallback? onPrev = switch (state.step) {
+      2 => state.isSubmitting ? null : () => notifier.goToStep(1),
+      _ => () => notifier.goToStep(0),
+    };
+
+    final String nextLabel = switch (state.step) {
+      2 => hasFailures ? '실패한 코너 재시도' : '설정 완료 → 코너·트랙 준비로',
+      _ => '다음',
+    };
+
+    VoidCallback? onNext;
+    switch (state.step) {
+      case 0:
+        final valid =
+            state.campName.trim().isNotEmpty &&
+            state.startAt != null &&
+            state.endAt != null;
+        onNext = valid ? () => notifier.goToStep(1) : null;
+      case 1:
+        onNext = () {
+          if (state.corners.isEmpty) {
+            ScaffoldMessenger.of(
+              context,
+            ).showSnackBar(const SnackBar(content: Text('코너를 1개 이상 추가하세요')));
+            return;
+          }
+          notifier.goToStep(2);
+        };
+      default:
+        onNext = state.isSubmitting
+            ? null
+            : () async {
+                final completed = await notifier.submit();
+                if (completed && context.mounted) {
+                  context.go('/corner-track-manage');
+                }
+              };
+    }
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Visibility(
+          visible: state.step != 0,
+          maintainSize: true,
+          maintainAnimation: true,
+          maintainState: true,
+          child: AppButton(
+            variant: AppButtonVariant.secondary,
+            label: '이전',
+            onPressed: onPrev,
+          ),
+        ),
+        Stack(
+          alignment: Alignment.center,
+          children: [
+            AppButton(
+              variant: AppButtonVariant.primary,
+              label: nextLabel,
+              onPressed: onNext,
+            ),
+            if (state.isSubmitting)
+              const SizedBox(
+                width: 16,
+                height: 16,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/frontend/lib/admin/features/setup_wizard/steps/camp_info_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/camp_info_step.dart
@@ -2,8 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
-import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
 
 class CampInfoStep extends ConsumerStatefulWidget {
   const CampInfoStep({super.key});
@@ -14,16 +15,13 @@ class CampInfoStep extends ConsumerStatefulWidget {
 
 class _CampInfoStepState extends ConsumerState<CampInfoStep> {
   late final TextEditingController _nameController;
-  DateTime? _startAt;
-  DateTime? _endAt;
 
   @override
   void initState() {
     super.initState();
-    final state = ref.read(setupWizardProvider);
-    _nameController = TextEditingController(text: state.campName);
-    _startAt = state.startAt;
-    _endAt = state.endAt;
+    _nameController = TextEditingController(
+      text: ref.read(setupWizardProvider).campName,
+    );
   }
 
   @override
@@ -32,76 +30,93 @@ class _CampInfoStepState extends ConsumerState<CampInfoStep> {
     super.dispose();
   }
 
+  void _updateInfo({DateTime? startAt, DateTime? endAt}) {
+    final state = ref.read(setupWizardProvider);
+    ref
+        .read(setupWizardProvider.notifier)
+        .setCampInfo(
+          _nameController.text,
+          startAt ?? state.startAt,
+          endAt ?? state.endAt,
+        );
+  }
+
   Future<void> _selectDate(bool isStart) async {
-    final current = isStart ? _startAt : _endAt;
+    final state = ref.read(setupWizardProvider);
+    final current = isStart ? state.startAt : state.endAt;
     final selected = await showDatePicker(
       context: context,
       initialDate: current ?? DateTime.now(),
       firstDate: DateTime(2020),
       lastDate: DateTime(2100),
     );
-    if (selected != null) {
-      setState(() => isStart ? _startAt = selected : _endAt = selected);
-    }
+    if (selected == null) return;
+    _updateInfo(
+      startAt: isStart ? selected : null,
+      endAt: isStart ? null : selected,
+    );
   }
 
   @override
   Widget build(BuildContext context) {
-    final valid =
-        _nameController.text.trim().isNotEmpty &&
-        _startAt != null &&
-        _endAt != null;
+    final state = ref.watch(setupWizardProvider);
+    final colors = Theme.of(context).brightness == Brightness.dark
+        ? AppColors.dark
+        : AppColors.light;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const Text('캠프 정보를 입력하세요.'),
-        const SizedBox(height: AppSpacing.space4),
         TextField(
           controller: _nameController,
-          onChanged: (_) => setState(() {}),
+          onChanged: (_) => _updateInfo(),
           decoration: const InputDecoration(labelText: '캠프 이름'),
         ),
         const SizedBox(height: AppSpacing.space3),
-        Wrap(
-          spacing: AppSpacing.space3,
-          runSpacing: AppSpacing.space2,
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            OutlinedButton(
-              onPressed: () => _selectDate(true),
-              child: Text(
-                _startAt == null ? '시작일 선택' : '시작일 ${_date(_startAt!)}',
+            Expanded(
+              child: _DateField(
+                label: '시작일',
+                value: state.startAt,
+                onTap: () => _selectDate(true),
               ),
             ),
-            OutlinedButton(
-              onPressed: () => _selectDate(false),
-              child: Text(
-                _endAt == null ? '종료일 선택' : '종료일 ${_date(_endAt!)}',
+            const SizedBox(width: AppSpacing.space3),
+            Expanded(
+              child: _DateField(
+                label: '종료일',
+                value: state.endAt,
+                onTap: () => _selectDate(false),
               ),
             ),
           ],
         ),
-        const Spacer(),
-        const Divider(),
         const SizedBox(height: AppSpacing.space3),
-        Align(
-          alignment: Alignment.centerRight,
-          child: AppButton(
-            variant: AppButtonVariant.primary,
-            label: '다음',
-            disabledReason: '캠프 이름과 시작일·종료일을 입력하면 다음 단계로 이동할 수 있습니다.',
-            onPressed: valid
-                ? () {
-                    ref
-                        .read(setupWizardProvider.notifier)
-                        .setCampInfo(_nameController.text, _startAt, _endAt);
-                    ref.read(setupWizardProvider.notifier).goToStep(1);
-                  }
-                : null,
-          ),
+        Text(
+          '코너학습 프로그램은 이 캠프 기간 중 정확히 1회 운영됩니다.',
+          style: AppTypography.caption.copyWith(color: colors.textSecondary),
         ),
       ],
     );
   }
+}
+
+class _DateField extends StatelessWidget {
+  const _DateField({required this.label, required this.value, this.onTap});
+  final String label;
+  final DateTime? value;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) => InkWell(
+    onTap: onTap,
+    borderRadius: BorderRadius.circular(8),
+    child: InputDecorator(
+      decoration: InputDecoration(labelText: label),
+      child: Text(value == null ? '선택' : _date(value!)),
+    ),
+  );
 }
 
 String _date(DateTime value) =>

--- a/frontend/lib/admin/features/setup_wizard/steps/corner_track_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/corner_track_step.dart
@@ -4,7 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_state.dart';
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_templates.dart';
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 
 class CornerTrackStep extends ConsumerStatefulWidget {
@@ -27,7 +29,7 @@ class _CornerTrackStepState extends ConsumerState<CornerTrackStep> {
     super.dispose();
   }
 
-  void _apply() {
+  void _reparse() {
     final notifier = ref.read(setupWizardProvider.notifier);
     notifier.setDefaults(
       targetMinutes: int.tryParse(_minutesController.text),
@@ -39,41 +41,19 @@ class _CornerTrackStepState extends ConsumerState<CornerTrackStep> {
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(setupWizardProvider);
+    final colors = Theme.of(context).brightness == Brightness.dark
+        ? AppColors.dark
+        : AppColors.light;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        const Text('코너 이름을 줄바꿈으로 입력하세요.'),
-        const SizedBox(height: AppSpacing.space3),
-        TextField(
-          controller: _pasteController,
-          maxLines: 3,
-          decoration: const InputDecoration(hintText: '1코너\n2코너'),
-        ),
-        const SizedBox(height: AppSpacing.space3),
-        Wrap(
-          spacing: AppSpacing.space3,
-          runSpacing: AppSpacing.space2,
+        Row(
           children: [
-            SizedBox(
-              width: 140,
-              child: TextField(
-                controller: _minutesController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: '기본 목표 시간(분)'),
+            Expanded(
+              child: Text(
+                '코너 목록 (한 줄에 하나씩)',
+                style: AppTypography.bodyEmphasis,
               ),
-            ),
-            SizedBox(
-              width: 140,
-              child: TextField(
-                controller: _trackController,
-                keyboardType: TextInputType.number,
-                decoration: const InputDecoration(labelText: '코너당 트랙 수'),
-              ),
-            ),
-            AppButton(
-              variant: AppButtonVariant.secondary,
-              label: '입력 적용',
-              onPressed: _apply,
             ),
             AppButton(
               variant: AppButtonVariant.secondary,
@@ -87,36 +67,50 @@ class _CornerTrackStepState extends ConsumerState<CornerTrackStep> {
             ),
           ],
         ),
-        const SizedBox(height: AppSpacing.space4),
-        Expanded(
+        const SizedBox(height: AppSpacing.space3),
+        TextField(
+          controller: _pasteController,
+          maxLines: 5,
+          onChanged: (_) => _reparse(),
+          decoration: const InputDecoration(hintText: '성경 퀴즈\n보드게임 마스터\n...'),
+        ),
+        const SizedBox(height: AppSpacing.space3),
+        Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _minutesController,
+                keyboardType: TextInputType.number,
+                onChanged: (_) => _reparse(),
+                decoration: const InputDecoration(labelText: '기본 목표시간(분)'),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.space3),
+            Expanded(
+              child: TextField(
+                controller: _trackController,
+                keyboardType: TextInputType.number,
+                onChanged: (_) => _reparse(),
+                decoration: const InputDecoration(labelText: '코너당 기본 트랙 수'),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: AppSpacing.space3),
+        Text(
+          '코너별로 다르게 조정하고 싶으면 아래 목록에서 개별 수정하세요. 트랙마다 PIN은 자동 발급됩니다.',
+          style: AppTypography.caption.copyWith(color: colors.textSecondary),
+        ),
+        const SizedBox(height: AppSpacing.space3),
+        SizedBox(
+          height: 220,
           child: state.corners.isEmpty
               ? const Center(child: Text('붙여넣거나 예시 템플릿을 사용하세요'))
               : ListView.builder(
-                  padding: const EdgeInsets.only(top: AppSpacing.space2),
                   itemCount: state.corners.length,
                   itemBuilder: (context, index) =>
                       _CornerRow(index: index, row: state.corners[index]),
                 ),
-        ),
-        const Divider(),
-        const SizedBox(height: AppSpacing.space3),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            AppButton(
-              variant: AppButtonVariant.secondary,
-              label: '이전',
-              onPressed: () =>
-                  ref.read(setupWizardProvider.notifier).goToStep(0),
-            ),
-            AppButton(
-              variant: AppButtonVariant.primary,
-              label: '다음',
-              onPressed: () => ref
-                  .read(setupWizardProvider.notifier)
-                  .tryAdvanceFromCornerStep(),
-            ),
-          ],
         ),
       ],
     );

--- a/frontend/lib/admin/features/setup_wizard/steps/review_step.dart
+++ b/frontend/lib/admin/features/setup_wizard/steps/review_step.dart
@@ -1,12 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
 
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_state.dart';
 import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
-import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
 
 class ReviewStep extends ConsumerWidget {
   const ReviewStep({super.key});
@@ -27,9 +26,45 @@ class ReviewStep extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text('캠프: ${state.campName}'),
-        Text('기간: ${_dateRange(state.startAt, state.endAt)}'),
-        Text('코너 ${state.corners.length}개 · 트랙 총 $tracks개'),
+        Text('설정 내용을 확인하세요', style: AppTypography.bodyEmphasis),
+        const SizedBox(height: AppSpacing.space2),
+        _SummaryRow(
+          label: '캠프',
+          value: state.campName.isEmpty ? '(이름 없음)' : state.campName,
+          colors: colors,
+        ),
+        _SummaryRow(
+          label: '기간',
+          value: _dateRange(state.startAt, state.endAt),
+          colors: colors,
+        ),
+        _SummaryRow(
+          label: '코너 수',
+          value: '${state.corners.length}개',
+          colors: colors,
+        ),
+        _SummaryRow(
+          label: '생성될 트랙 수',
+          value: '총 $tracks개 (PIN 자동 발급)',
+          colors: colors,
+          showDivider: false,
+        ),
+        const SizedBox(height: AppSpacing.space3),
+        Container(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSpacing.space3,
+            vertical: AppSpacing.space2,
+          ),
+          decoration: BoxDecoration(
+            color: colors.brandPrimary.withValues(alpha: .1),
+            borderRadius: BorderRadius.circular(9),
+          ),
+          child: Text(
+            '완료 즉시 "준비 중" 상태로 캠프 목록에 추가되며, 곧장 코너·트랙 준비 화면으로 이동합니다. '
+            '트랙 PIN은 지금 바로 발급되지만, "코너학습 시작"을 확정하기 전까지는 로그인이 열리지 않습니다.',
+            style: AppTypography.caption.copyWith(color: colors.brandPrimary),
+          ),
+        ),
         if (state.submitError != null) ...[
           const SizedBox(height: AppSpacing.space3),
           Container(
@@ -43,8 +78,9 @@ class ReviewStep extends ConsumerWidget {
         ],
         if (state.isSubmitting || hasFailures) ...[
           const SizedBox(height: AppSpacing.space4),
-          const Text('생성 상태'),
-          Expanded(
+          Text('생성 상태', style: AppTypography.bodyEmphasis),
+          SizedBox(
+            height: 180,
             child: ListView(
               children: [
                 for (final row in state.corners)
@@ -59,50 +95,44 @@ class ReviewStep extends ConsumerWidget {
               ],
             ),
           ),
-        ] else
-          const Spacer(),
-        const Divider(),
-        const SizedBox(height: AppSpacing.space3),
-        Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            AppButton(
-              variant: AppButtonVariant.secondary,
-              label: '이전',
-              onPressed: state.isSubmitting
-                  ? null
-                  : () => ref.read(setupWizardProvider.notifier).goToStep(1),
-            ),
-            Stack(
-              alignment: Alignment.center,
-              children: [
-                AppButton(
-                  variant: AppButtonVariant.primary,
-                  label: hasFailures ? '실패한 코너 재시도' : '설정 완료 → 코너·트랙 준비로',
-                  onPressed: state.isSubmitting
-                      ? null
-                      : () async {
-                          final completed = await ref
-                              .read(setupWizardProvider.notifier)
-                              .submit();
-                          if (completed && context.mounted) {
-                            context.go('/corner-track-manage');
-                          }
-                        },
-                ),
-                if (state.isSubmitting)
-                  const SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  ),
-              ],
-            ),
-          ],
-        ),
+        ],
       ],
     );
   }
+}
+
+class _SummaryRow extends StatelessWidget {
+  const _SummaryRow({
+    required this.label,
+    required this.value,
+    required this.colors,
+    this.showDivider = true,
+  });
+
+  final String label;
+  final String value;
+  final AppColors colors;
+  final bool showDivider;
+
+  @override
+  Widget build(BuildContext context) => Container(
+    padding: const EdgeInsets.symmetric(vertical: AppSpacing.space2),
+    decoration: showDivider
+        ? BoxDecoration(
+            border: Border(bottom: BorderSide(color: colors.border)),
+          )
+        : null,
+    child: Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: AppTypography.caption.copyWith(color: colors.textSecondary),
+        ),
+        Text(value, style: AppTypography.bodyEmphasis),
+      ],
+    ),
+  );
 }
 
 class _StatusLabel extends StatelessWidget {

--- a/frontend/test/admin/features/setup_wizard/setup_wizard_screen_test.dart
+++ b/frontend/test/admin/features/setup_wizard/setup_wizard_screen_test.dart
@@ -1,14 +1,17 @@
+import 'package:cornermon/admin/features/setup_wizard/setup_wizard_provider.dart';
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  Widget app() =>
-      const ProviderScope(child: MaterialApp(home: SetupWizardScreen()));
+  Widget app(ProviderContainer container) => UncontrolledProviderScope(
+    container: container,
+    child: const MaterialApp(home: SetupWizardScreen()),
+  );
 
   testWidgets('requires a camp name before advancing', (tester) async {
-    await tester.pumpWidget(app());
+    await tester.pumpWidget(app(ProviderContainer()));
     final next = find.widgetWithText(OutlinedButton, '다음');
     expect(tester.widget<OutlinedButton>(next).onPressed, isNull);
   });
@@ -16,10 +19,14 @@ void main() {
   testWidgets('applies the example corners and renders their preview', (
     tester,
   ) async {
-    await tester.pumpWidget(app());
+    final container = ProviderContainer();
+    await tester.pumpWidget(app(container));
     await tester.enterText(find.byType(TextField).first, '테스트 캠프');
     await tester.pump();
-    await tester.tap(find.widgetWithText(OutlinedButton, '다음'));
+    container
+        .read(setupWizardProvider.notifier)
+        .setCampInfo('테스트 캠프', DateTime(2026, 8, 1), DateTime(2026, 8, 3));
+    container.read(setupWizardProvider.notifier).goToStep(1);
     await tester.pumpAndSettle();
     await tester.tap(find.text('예시 10개로 빠르게 시작'));
     await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary
- 관리자 앱 초기 설정 마법사(A0-b)를 리뷰용 HTML 목업(`saved_resource.html` ASETUP 화면) 레이아웃에 맞춰 재정비
- 카드 폭 640pt(스펙 일치), 중앙 정렬 타이틀/서브타이틀, 컴팩트 스텝 인디케이터, 공통 하단 이전/다음 푸터로 통합
- 목업/기존 코드의 불필요한 안내 문구 제거, 2단계는 실시간 파싱으로 변경("입력 적용" 버튼 제거)
- 코너 미입력 시 다음 단계 진행을 막는 안내 토스트 추가(스펙 §A0-b 상태 규칙 반영)

## Test plan
- [x] `flutter analyze lib/admin/features/setup_wizard/` — no issues
- [x] `flutter test test/admin/features/setup_wizard/` — 7 passed
- [x] `flutter test` (전체) — 113 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)