### PR TITLE
docs: CLAUDE.md를 개요/전역 원칙만 남기고 파트별 가이드로 분리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,12 +2,18 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Part-specific implementation patterns (commands, layer structure, known pitfalls) live in
+each part's developer guide — **read the relevant one before working there**:
+- `backend/docs/DEVELOPER_GUIDE.md`
+- `frontend/docs/DEVELOPER_GUIDE.md`
+
 ## Workflow Rules
 
 **Before starting any task**, read the relevant files in `./workflow/`:
 - `workflow/implement.md` — implementation constraints
 - `workflow/plan.md` — plan document format and guidelines
 - `workflow/Collaborate.md` — API change protocol
+- `workflow/pr.md` — PR/commit conventions
 - `workflow/repo.md` — monorepo management rules
 
 **After finishing**, verify nothing violates the workflow guidelines.
@@ -16,94 +22,35 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ---
 
-## Commands
-
-### Backend (Go)
-
-```bash
-cd backend
-
-# Run all tests
-go test ./...
-
-# Run tests for a single package
-go test ./internal/domain/...
-
-# Run a single test
-go test ./internal/domain/... -run TestCampActivate
-
-# Run the server
-go run ./cmd/server/main.go
-
-# Format
-gofmt -w .
-
-# Vet
-go vet ./...
-```
-
-No Makefile exists yet — `make gen`, `make dev-server`, `make dev-app` are planned but not implemented.
-
----
-
-## Architecture
-
-### Monorepo Structure
+## Monorepo Structure
 
 ```
 /api/               # OpenAPI 3.0 contract (source of truth for REST API)
-/backend/           # Go backend
-/docs/              # Domain model, technical design, screen specs
+/backend/           # Go backend (see backend/docs/DEVELOPER_GUIDE.md)
+/frontend/          # Flutter app, two entry points: lib/main_admin.dart, lib/main_facilitator.dart
+                     # (see frontend/docs/DEVELOPER_GUIDE.md)
+/docs/               # Domain model, technical design, screen specs
 /workflow/          # Process guidelines (must read before working)
 ```
 
-The frontend (Flutter) directory is not yet created. Per `docs/technical-design.md §0-d`, it will use a single Flutter project with two entry points (`lib/main_admin.dart`, `lib/main_facilitator.dart`).
+---
 
-### Backend Package Layout
+## Global Architecture Principles
 
-```
-backend/
-  cmd/server/main.go
-  internal/
-    domain/         # Pure Go structs + business rules. NO external imports.
-    usecase/        # Application services. Defines ports (interfaces) here.
-    adapter/
-      postgres/     # Repository implementations
-      http/         # REST handlers
-      sse/          # SSE broadcaster (Broadcaster interface impl)
-```
+These constrain the contract between frontend and backend and are non-negotiable regardless
+of which part you're working in. Implementation detail for each lives in the respective
+developer guide.
 
-**Two non-negotiable architecture rules** (`docs/technical-design.md §1.1`):
-1. `domain` package imports nothing external — pure Go types and methods only.
-2. Dependency inversion: `domain`/`usecase` declare interfaces; `adapter` provides implementations injected at startup.
-
-### Domain Layer Pattern
-
-Business invariants are enforced by domain methods, not the usecase layer. The usecase layer owns transaction boundaries and persistence orchestration.
-
-```go
-// Business rule enforcement lives on the struct method
-func (t *Track) StartVisit(group GroupID, now time.Time, method InputMethod) (*Visit, error)
-
-// Usecase owns: begin tx → call domain method → persist → commit → broadcast
-```
-
-All domain sentinel errors are in `backend/internal/domain/errors.go`. Use `errors.Is()` for error checking — do not add string-matching error checks.
-
-### SSE Real-time Push
-
-- State changes → `usecase` emits domain event → `adapter/sse.Broadcaster` pushes to connected clients.
-- **Broadcast only after commit** — never before. Rolled-back changes must never reach clients.
-- Events carry full snapshots (not deltas). On (re)connect, server immediately sends current full state.
-- Clients handle reconnect = resync. Server does stateless broadcast only.
-
-### Authentication
-
-All tokens (facilitator track PIN sessions, device trust tokens, admin access/refresh tokens) are **opaque tokens** (not JWT). Stored as hashes in DB. This is a finalized decision — do not propose JWT.
-
-### API Change Protocol
-
-Per `workflow/Collaborate.md`: frontend opens a PR first, then backend implements and **must update `api/openapi.yaml`** before merging.
+- **Layered dependency direction** (backend): `domain` imports nothing external; `usecase`
+  declares ports (interfaces); `adapter`/`infrastructure` implements them and is injected at
+  startup. Business invariants live on domain methods, not the usecase layer.
+- **Authentication**: all tokens (facilitator track PIN sessions, device trust tokens, admin
+  access/refresh) are **opaque tokens**, not JWT, stored as hashes. This is a finalized
+  decision — do not propose JWT.
+- **SSE real-time push**: broadcast only after commit (rolled-back changes must never reach
+  clients); events carry full snapshots, never deltas; clients treat reconnect as resync.
+- **API Change Protocol**: per `workflow/Collaborate.md`, frontend opens a PR first, then
+  backend implements and **must update `api/openapi.yaml`** before merging.
 
 ---
 

--- a/backend/docs/DEVELOPER_GUIDE.md
+++ b/backend/docs/DEVELOPER_GUIDE.md
@@ -5,6 +5,21 @@
 어떻게 그 의도를 구현하고 있는지"를 다룹니다. 새 유스케이스/리포지토리/핸들러를 추가할 때
 이 문서의 패턴을 따르세요.
 
+## 0. 실행 명령어
+
+```bash
+cd backend
+
+go test ./...                                   # 전체 테스트
+go test ./internal/domain/...                    # 패키지 단위
+go test ./internal/domain/... -run TestCampActivate  # 단일 테스트
+go run ./cmd/server/main.go                       # 서버 실행
+gofmt -w .                                        # 포맷
+go vet ./...                                      # vet
+```
+
+`make gen`/`make dev-server`/`make dev-app` 최상위 Makefile 명령은 아직 구현되어 있지 않다.
+
 ## 1. 레이어 구조
 
 ```

--- a/frontend/docs/DEVELOPER_GUIDE.md
+++ b/frontend/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,142 @@
+# Frontend Developer Guide
+
+이 문서는 `frontend/` (Flutter) 코드베이스의 실제 구현 패턴과, 디버깅 과정에서 확인된
+Riverpod/직렬화 관련 함정을 정리한 가이드입니다. 새 provider나 화면을 추가할 때 참고하세요.
+
+## 1. 실행 명령어
+
+```bash
+cd frontend
+
+# 관리자 앱 실행
+make run-admin
+# 진행자 앱 실행
+make run-app-facilitator
+
+# 코드 생성 (riverpod_generator 등)
+dart run build_runner build
+
+# 테스트
+flutter test
+flutter test test/admin/features/setup_wizard/   # 디렉터리 단위
+
+# 정적분석
+dart analyze lib/
+```
+
+### `lib/shared/api/gen`을 건드리지 않도록 주의
+
+`lib/shared/api/gen`은 `api/swagger.yaml`에서 `openapi-generator`로 생성되는 별도 패키지
+(`cornermon_api_gen`, `frontend/openapitools.json` 참고)이지만, `dart run build_runner build`를
+돌리면 **가끔 이 안의 `.g.dart` 파일들을 삭제**하는 현상이 있다(원인 미상, riverpod_generator와
+무관한 별개 이슈로 추정). `build_runner` 실행 직후에는 항상 확인하고 필요하면 복구한다:
+
+```bash
+git status --porcelain lib/shared/api/gen
+git checkout -- lib/shared/api/gen   # 삭제/변경됐으면 복구
+```
+
+`build.yaml`에서 `lib/shared/api/gen/**`을 riverpod_generator 대상에서 명시적으로 제외하고
+있지만 이 현상 자체는 막지 못한다.
+
+### git worktree 여러 개일 때: 코드 수정이 반영 안 되는 것처럼 보이면
+
+이 저장소는 `.claude/worktrees/` 밑에 여러 worktree를 쓴다(`git worktree list`로 확인).
+`make run-admin`을 실행 중인 터미널이 지금 작업 중인 worktree가 맞는지 먼저 확인한다 —
+다른 worktree에서 실행 중이면 코드를 아무리 고쳐도 반영되지 않고, print 로그도 전혀 안 찍혀서
+"빌드 캐시 문제인가?" 하고 헤매게 된다. `flutter clean` 이전에 실행 터미널에서 `pwd`부터 확인.
+
+## 2. Riverpod: "1회성 액션" provider를 만들 때 (로그인, 리소스 생성 등)
+
+`ref.watch`로 위젯이 구독하지 않고, Notifier 안에서 `ref.read(actionProvider(args).future)`로
+1회성으로만 소비하는 `@riverpod` FutureProvider(로그인, POST로 리소스 생성하는 provider 등)는
+기본 `autoDispose` 특성 때문에 실제 운영 중 재현하기 어려운 문제들이 있었다. 아래 세 가지를
+항상 같이 고려한다.
+
+### 2.1 공유 인프라(Dio 클라이언트 등)는 `keepAlive: true`로 고정한다
+
+`apiClientProvider`(Dio 인스턴스 + `AuthInterceptor`)처럼 앱 전체에서 하나만 있어야 하는
+장수 객체를 기본 `@riverpod`(autoDispose)로 두면, 지속적으로 `watch`하는 위젯이 없을 때
+네트워크 요청 도중(async gap) provider가 dispose되고, `AuthInterceptor`가 붙잡고 있던 죽은
+`ref`를 쓰려다 `Cannot use the Ref of ... after it has been disposed` 예외가 난다.
+
+```dart
+@Riverpod(keepAlive: true)
+Dio apiClient(Ref ref) { ... }
+```
+
+Dio/Client류처럼 "본질적으로 싱글턴이어야 하는" provider는 처음부터 `keepAlive: true`로
+선언한다.
+
+### 2.2 `ref.read(provider.future)` 직전에 `ref.listen`으로 잠깐 구독을 건다
+
+위 문제를 고치고 나면, 이번엔 **provider 자신이 에러로 끝날 때** 다른 문제가 생긴다:
+listener가 0개인 autoDispose provider가 에러 상태로 끝나면, Riverpod이 진짜 예외 대신
+`Bad state: The provider ... was disposed during loading state, yet no value could be
+emitted.`라는 의미 없는 내부 오류를 던진다(riverpod 3.3.2, 실제 위젯 트리+vsync 환경에서
+격리 재현 확인됨). 그러면 백엔드가 실제로 뭐라고 거절했는지(400/500/역직렬화 실패 등)를
+영영 알 수 없게 된다.
+
+읽기 직전에 임시 리스너를 걸어두면 이 문제가 사라지고 진짜 예외가 정상적으로 올라온다:
+
+```dart
+final provider = createCampProvider(name, startAt: startAt, endAt: endAt);
+final sub = ref.listen(provider, (_, _) {});
+final camp = await ref.read(provider.future).whenComplete(sub.close);
+```
+
+새 "액션성" provider를 `ref.read(...future)`로 호출하는 곳을 추가할 때마다 이 패턴을 쓴다.
+(`AdminSession.login`, `SetupWizard._createCamp`/`_createCorner` 참고.)
+
+> 부작용: 이 패턴은 provider가 error 상태에서 새 리스너를 받으면 자동으로 한 번 더
+> rebuild(재실행)하는 Riverpod 동작과 맞물려서, 실패한 요청 뒤에 listen을 걸면 내부적으로
+> 같은 요청이 한 번 더 나갈 수 있다. 성공 경로에서는 1회만 실행됨을 테스트로 확인했다 —
+> 문제는 실패가 반복될 때뿐이며, 아래 2.3의 재시도 차단과 함께 쓰면 안전하다.
+
+### 2.3 POST 등 멱등하지 않은 액션은 `retry: noRetry`로 자동 재시도를 반드시 끈다
+
+`@riverpod`에서 `retry`를 지정하지 않으면(`retry: null`) "재시도 안 함"이 아니라
+**컨테이너 기본 재시도 정책을 상속**한다는 뜻이다. 그 기본값은 **무제한 횟수, 200ms에서
+시작해 6.4초까지 배로 늘어나는 지수 백오프, 모든 실패에 대해 재시도**다
+(`riverpod_annotation`의 `Riverpod.retry` 문서 참고). 리소스 생성처럼 멱등하지 않은 POST가
+어떤 이유로든 provider 레벨에서 에러로 끝나면(2.2의 역직렬화 실패 등), 이 기본 재시도가
+**같은 리소스를 서버에 계속 중복 생성**한다 — 실제로 코너 생성이 이 문제로 같은 코너를
+수십 번 중복 생성한 적이 있다.
+
+```dart
+// lib/shared/api/providers/no_retry.dart
+Duration? noRetry(int retryCount, Object error) => null;
+
+@Riverpod(retry: noRetry)
+Future<Camp> createCamp(Ref ref, String name, {...}) async { ... }
+```
+
+생성/로그인/로그아웃처럼 부작용이 있는 모든 액션 provider에 `retry: noRetry`를 명시한다.
+목록 조회(`campListProvider` 등) 같은 순수 GET은 재시도돼도 안전하므로 그대로 둔다.
+
+## 3. `cornermon_api_gen` (built_value) 직렬화 함정
+
+### 3.1 `DateTime`은 API 경계에서 항상 `.toUtc()`
+
+생성된 클라이언트의 `Iso8601DateTimeSerializer`는 `DateTime.isUtc == true`가 아니면
+직렬화 자체를 거부한다(`Invalid argument (dateTime): Must be in utc for serialization.`).
+로컬 타임존 `DateTime`(날짜 선택 위젯에서 바로 나온 값 등)을 요청 바디에 넣기 직전에 항상
+변환한다:
+
+```dart
+..startAt = startAt.toUtc()
+..endAt = endAt.toUtc()
+```
+
+이 문제는 요청이 서버로 나가기도 전에 클라이언트에서 막히기 때문에, 백엔드 로그에는
+아무 흔적도 안 남는다 — 원인 파악이 안 될 때는 요청 바디에 `DateTime` 필드가 있는지부터
+의심한다.
+
+### 3.2 enum 필드는 서버가 실제로 보내는 값과 1:1로 맞아야 한다
+
+`CornerResponseStatusEnum`처럼 서버 DTO의 `string` enum 필드를 역직렬화할 때, 서버가 그
+필드를 안 채워서 빈 문자열이 나가면(Go의 zero value) 클라이언트가
+`Deserializing to 'X' failed due to: Invalid argument(s)`로 죽는다. 이런 예외는
+`DioExceptionType.unknown`으로 잡히고 `statusCode`는 실제 HTTP 상태(200/201)를 그대로
+보여주므로, "서버는 성공(2xx)이라는데 클라이언트는 실패로 본다"는 신호가 보이면 응답
+DTO의 enum/필수 필드가 실제로 채워지고 있는지 백엔드 핸들러부터 확인한다.


### PR DESCRIPTION
## Summary
- `CLAUDE.md`는 모노레포 구조 개요와 프론트/백엔드 공통 계약(레이어 방향, opaque token, SSE 원칙, API 변경 프로토콜, 유비쿼터스 언어)만 남기고, 파트별 구현 세부사항(커맨드, 레이어 경로 등)은 제거
- `backend/docs/DEVELOPER_GUIDE.md`: 실행 커맨드 섹션 추가 (CLAUDE.md에서 이관)
- `frontend/docs/DEVELOPER_GUIDE.md` 신규 작성: 실행 커맨드 + PR #105 디버깅 과정에서 확인된 Riverpod/직렬화 함정 정리
  - `keepAlive: true`가 필요한 경우 (공유 Dio 클라이언트 등)
  - `ref.read(provider.future)` 직전 `ref.listen`으로 "disposed during loading state" 오류 우회
  - `retry: null`이 실은 컨테이너 기본 무제한 재시도를 상속한다는 함정 → 멱등하지 않은 액션엔 `retry: noRetry`
  - `built_value` DateTime `.toUtc()` 필수, enum 필드 서버측 누락 시 증상

## Test plan
- [x] 문서 변경만 있음 — 코드 실행에 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)