### PR TITLE
fix: 코너/트랙 status 이상값으로 인한 응답 파싱 크래시 방지

### DIFF
--- a/frontend/lib/shared/api/client/api_client.dart
+++ b/frontend/lib/shared/api/client/api_client.dart
@@ -3,6 +3,7 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../config/app_env.dart';
 import 'auth_interceptor.dart';
+import 'status_fallback_interceptor.dart';
 
 part 'api_client.g.dart';
 
@@ -16,6 +17,7 @@ Dio apiClient(Ref ref) {
     ),
   );
   dio.interceptors.add(AuthInterceptor(ref));
+  dio.interceptors.add(StatusFallbackInterceptor());
 
   return dio;
 }

--- a/frontend/lib/shared/api/client/status_fallback_interceptor.dart
+++ b/frontend/lib/shared/api/client/status_fallback_interceptor.dart
@@ -1,0 +1,43 @@
+import 'package:dio/dio.dart';
+
+const _cornerStatusValues = {'INACTIVE', 'IDLE', 'BUSY'};
+const _trackStatusValues = {'ACTIVE', 'DELETED'};
+const _trackOperationalStatusValues = {'IDLE', 'BUSY'};
+
+/// 백엔드가 status를 채우지 않고 내려줄 경우(예: 빈 문자열) built_value enum 파싱이
+/// 던지는 ArgumentError가 응답 전체(리스트 포함) 디코딩을 깨뜨리는 것을 막는다.
+/// 근본 원인은 백엔드 이슈로 별도 트래킹 — 여기서는 알 수 없는 값을 안전한 기본값으로
+/// 대체해 화면이 죽지 않도록만 방어한다.
+class StatusFallbackInterceptor extends Interceptor {
+  @override
+  void onResponse(Response<dynamic> response, ResponseInterceptorHandler handler) {
+    _sanitize(response.data);
+    handler.next(response);
+  }
+
+  void _sanitize(dynamic node) {
+    if (node is List) {
+      for (final item in node) {
+        _sanitize(item);
+      }
+      return;
+    }
+    if (node is! Map) return;
+
+    if (node.containsKey('targetMinutes') && !_cornerStatusValues.contains(node['status'])) {
+      node['status'] = 'INACTIVE';
+    }
+    if (node.containsKey('trackNo')) {
+      if (!_trackStatusValues.contains(node['status'])) {
+        node['status'] = 'ACTIVE';
+      }
+      if (!_trackOperationalStatusValues.contains(node['operationalStatus'])) {
+        node['operationalStatus'] = 'IDLE';
+      }
+    }
+
+    for (final value in node.values) {
+      _sanitize(value);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- `/camps/{campId}/corners` 응답의 `status`가 빈 문자열로 내려오는 경우가 있어(#112), built_value enum 파싱이 `ArgumentError`를 던지며 코너 리스트 전체 디코딩이 깨지는 문제를 우회한다.
- Dio 인터셉터(`StatusFallbackInterceptor`)에서 코너(`targetMinutes` 보유 객체)/트랙(`trackNo` 보유 객체)의 `status`·`operationalStatus`가 허용값이 아니면 안전한 기본값으로 치환 후 `api_client.dart`에 등록.
- 근본 원인(읽기 경로 CQRS 쿼리에 상태 계산 로직 자체가 없음)은 백엔드 이슈 #112로 별도 트래킹 — 이 PR은 프론트 크래시 방지용 임시 방어책.

## Test plan
- [x] `dart analyze` 통과 (`status_fallback_interceptor.dart`, `api_client.dart`)
- [ ] 백엔드가 `status: ""`를 내려주는 캠프에서 코너 목록 화면이 크래시 없이 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)