### PR TITLE
feat : A14 코너학습 종료 버튼/모달 구현

### DIFF
--- a/frontend/docs/artifacts/plan/관리자_앱_전체_플로우_구현_plan_20260714/11_a13_a14_a15_audit_end_settings.md
+++ b/frontend/docs/artifacts/plan/관리자_앱_전체_플로우_구현_plan_20260714/11_a13_a14_a15_audit_end_settings.md
@@ -262,8 +262,8 @@ class BottleneckThresholdSection extends ConsumerStatefulWidget {
 | K-3 | `AuditLogPageState`, `AuditLogPageNotifier`(커서 누적) | `frontend/lib/admin/features/audit_log/audit_log_page_notifier.dart` |
 | K-4 | `AuditLogScreen`, `AuditLogFilterBar`, `AuditLogTable`, `AuditLogLoadMore` | `frontend/lib/admin/features/audit_log/**` |
 | K-5 | `AuditLogScreen`을 `02`의 `/audit-log` 라우트 스텁에 배선 | `frontend/lib/admin/router/admin_router.dart` |
-| L-1 | `EndCampBarButton`, `EndCampConfirmDialog` | `frontend/lib/admin/features/end_camp/**` |
-| L-2 | 운영 모드 공용 셸(있으면 확장, 없으면 신규)에 `EndCampBarButton` 삽입 | `frontend/lib/admin/widgets/shell/admin_operating_shell.dart`(또는 `02`가 만든 기존 셸 파일) |
+| L-1 | `EndCampBarButton`, `EndCampConfirmDialog`, `EndCampController` | `frontend/lib/admin/features/end_camp/**` — 완료 |
+| L-2 | 운영 모드 공용 셸에 `EndCampBarButton` 삽입 — `02`에서 이미 `AdminScaffold`가 그 역할을 하고 있어(35~42행 `StartCampButton` 배치 참고) 새 셸 파일을 만들지 않고 기존 `AdminScaffold`를 확장함(operating 모드 분기 추가) | `frontend/lib/admin/widgets/admin_scaffold.dart` — 완료 |
 | M-1 | `updateCamp` provider가 `bottleneckRatioPct`(정수) 시그니처로 되어 있는지 확인·수정(`01` 산출물 재검증) | `frontend/lib/shared/api/providers/camp_providers.dart` |
 | M-2 | `SettingsScreen`, `CampInfoSection`, `BottleneckThresholdSection` | `frontend/lib/admin/features/settings/**` |
 | M-3 | `SettingsScreen`을 `02`의 `/settings` 라우트 스텁에 배선 | `frontend/lib/admin/router/admin_router.dart` |
@@ -284,14 +284,28 @@ class BottleneckThresholdSection extends ConsumerStatefulWidget {
 - [ ] 필터를 바꾸면 누적된 로그가 비워지고 `before` 없이 처음부터 재조회된다(이전 필터의 결과가 남아있지 않음)
 
 ### A14 코너학습 종료
-- [ ] ACTIVE 캠프의 운영 모드 어느 화면(대시보드/조현황/설정 등)에 있어도 상단 바에 "코너학습 종료" destructive 버튼이 보인다
-- [ ] PENDING/ENDED 캠프에서는 이 버튼이 보이지 않는다(준비 모드엔 "코너학습 시작"이 같은 자리에 대신 나타남)
-- [ ] 버튼 클릭 시 뜨는 확인 모달에 현재 완주/부분완주(근사) 조 수 요약이 표시된다
-- [ ] "종료 선언" 클릭 시 `POST /camps/{id}/end`가 먼저 호출되고, 성공하면 이어서 `POST /camps/{campId}/reports/generate`가 호출된다(네트워크 탭/로그로 순서 확인)
-- [ ] 종료 처리 완료 후 캠프의 대시보드(A1)로 남지 않고 캠프 목록(A0-c) 화면으로 이동한다
-- [ ] 캠프 목록에서 방금 종료한 캠프가 "종료됨" 배지로 표시된다
-- [ ] `reports/generate` 호출이 실패하도록 목업했을 때도 `/end` 성공이면 캠프 목록으로는 정상 이동하고, 경고 스낵바가 별도로 뜬다(종료 자체가 실패로 처리되지 않음)
-- [ ] `endCamp` 자체가 실패(400/409)하면 모달이 닫히지 않고 에러가 인라인 표시되며 캠프 목록으로 이동하지 않는다
+
+> **구현 노트(신규)**: `endCamp`/`generateReport` provider가 `retry: noRetry` 없이 plain `@riverpod`로
+> 정의돼 있었다(`createCamp`만 이미 `retry: noRetry`였음 — §2.3 DEVELOPER_GUIDE 기준 기존 코드베이스의
+> 누락). 실패 시 Riverpod 기본 정책(무제한 횟수, 지수 백오프 최대 6.4초, 실시간)이 적용되어
+> `endCampControllerProvider.confirm()`의 에러 처리·리포트 실패 폴백 경로가 즉시 반영되지 않고 최대
+> 수십 초 지연 후에야(또는 컨트롤러 자체가 async gap 중 dispose되어) 반영되는 문제를 실제로
+> 재현했다(`test/admin/features/end_camp/end_camp_controller_test.dart` 작성 중 발견, plain `test()`가
+> 실시간으로 재시도 backoff를 기다리다 30초 타임아웃). A14의 "실패 시 인라인 에러 즉시 표시",
+> "reports/generate 실패는 무시하고 즉시 다음 단계로 진행" 요구사항과 직접 충돌하므로
+> `frontend/lib/shared/api/providers/camp_providers.dart`의 `endCamp`와
+> `frontend/lib/shared/api/providers/report_providers.dart`의 `generateReport`에
+> `@Riverpod(retry: noRetry)`를 추가하고 `build_runner`로 재생성했다(다른 화면의 `startCamp`/`updateCamp`는
+> A14 범위 밖이라 손대지 않음 — 각 소유 worktree가 필요 시 동일 패턴 적용 필요).
+
+- [x] ACTIVE 캠프의 운영 모드 어느 화면(대시보드/조현황/설정 등)에 있어도 상단 바에 "코너학습 종료" destructive 버튼이 보인다 — `end_camp_bar_button_test.dart`의 `ShoudShowEndButtonWhenAdminScaffoldIsOperating`
+- [x] PENDING/ENDED 캠프에서는 이 버튼이 보이지 않는다(준비 모드엔 "코너학습 시작"이 같은 자리에 대신 나타남) — `ShoudHideEndButtonWhenAdminScaffoldIsPreparing`, `ShoudHideEndButtonWhenAdminScaffoldIsReportOnly`
+- [x] 버튼 클릭 시 뜨는 확인 모달에 현재 완주/부분완주(근사) 조 수 요약이 표시된다 — `ShoudShowLiveSummaryWhenConfirmDialogOpened`
+- [x] "종료 선언" 클릭 시 `POST /camps/{id}/end`가 먼저 호출되고, 성공하면 이어서 `POST /camps/{campId}/reports/generate`가 호출된다(네트워크 탭/로그로 순서 확인) — `end_camp_controller_test.dart`의 `ShoudCallEndCampBeforeGenerateReport`(호출 순서 배열로 검증)
+- [x] 종료 처리 완료 후 캠프의 대시보드(A1)로 남지 않고 캠프 목록(A0-c) 화면으로 이동한다 — `ShoudNavigateToCampsWithoutSnackbarWhenEndAndReportBothSucceed` 등에서 `context.go('/camps')` 확인
+- [x] 캠프 목록에서 방금 종료한 캠프가 "종료됨" 배지로 표시된다 — A0-c(`camp_list_screen.dart`)에 이미 구현되어 있음을 코드로 재확인(A14가 새로 만들 필요 없음)
+- [x] `reports/generate` 호출이 실패하도록 목업했을 때도 `/end` 성공이면 캠프 목록으로는 정상 이동하고, 경고 스낵바가 별도로 뜬다(종료 자체가 실패로 처리되지 않음) — `ShoudNavigateToCampsAndShowWarningSnackbarWhenReportGenerationFailsButEndSucceeds`
+- [x] `endCamp` 자체가 실패(400/409)하면 모달이 닫히지 않고 에러가 인라인 표시되며 캠프 목록으로 이동하지 않는다 — `ShoudKeepDialogOpenAndShowServerMessageWhenEndFails`, `end_camp_controller_test.dart`의 `ShoudThrowAndKeepSelectedCampIdWhenEndCampFails`
 
 ### A15 설정
 - [ ] `/settings` 진입 시 뒤로가기 버튼이 없다(사이드바 최상위 항목)

--- a/frontend/lib/admin/app.dart
+++ b/frontend/lib/admin/app.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:cornermon/admin/router/admin_router.dart';
 import 'package:cornermon/admin/theme/admin_theme_mode_provider.dart';
+import 'package:cornermon/admin/widgets/admin_scaffold_messenger_key.dart';
 import 'package:cornermon/shared/design_system/theme/admin_theme.dart';
 
 class AdminApp extends ConsumerWidget {
@@ -12,6 +13,7 @@ class AdminApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return MaterialApp.router(
+      scaffoldMessengerKey: adminScaffoldMessengerKey,
       theme: AdminTheme.lightTheme,
       darkTheme: AdminTheme.darkTheme,
       themeMode: ref.watch(adminThemeModeProvider),

--- a/frontend/lib/admin/features/end_camp/end_camp_bar_button.dart
+++ b/frontend/lib/admin/features/end_camp/end_camp_bar_button.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:cornermon/admin/features/end_camp/end_camp_confirm_dialog.dart';
+import 'package:cornermon/admin/session/selected_camp_provider.dart';
+import 'package:cornermon/shared/api/domain_aliases.dart';
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+
+/// 운영 모드(ACTIVE 캠프) 상단 바에 상주하는 "코너학습 종료" 고정 버튼.
+///
+/// 전용 라우트가 없다 — `AdminScaffold`가 `sidebarModeFor(camp.status) ==
+/// SidebarMode.operating`일 때만 이 위젯을 배치하므로 운영 모드 화면
+/// 어디서나(대시보드/조 현황/설정 등) 동일하게 보인다. 위젯 내부의 status
+/// 체크는 그 배치 조건에 대한 방어적 이중 체크일 뿐이다.
+class EndCampBarButton extends ConsumerWidget {
+  const EndCampBarButton({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final campId = ref.watch(selectedCampIdProvider);
+    final camp = ref.watch(selectedCampProvider).asData?.value;
+
+    if (campId == null || camp?.status != CampStatus.ACTIVE) {
+      return const SizedBox.shrink();
+    }
+
+    return AppButton(
+      variant: AppButtonVariant.destructive,
+      size: AppButtonSize.compact,
+      icon: Icons.stop_circle_outlined,
+      label: '코너학습 종료',
+      onPressed: () => showDialog<void>(
+        context: context,
+        builder: (_) => EndCampConfirmDialog(campId: campId),
+      ),
+    );
+  }
+}

--- a/frontend/lib/admin/features/end_camp/end_camp_confirm_dialog.dart
+++ b/frontend/lib/admin/features/end_camp/end_camp_confirm_dialog.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:cornermon/admin/features/end_camp/end_camp_controller.dart';
+import 'package:cornermon/admin/widgets/admin_scaffold_messenger_key.dart';
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/providers/report_providers.dart';
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+
+class EndCampConfirmDialog extends ConsumerStatefulWidget {
+  const EndCampConfirmDialog({required this.campId, super.key});
+
+  final CampId campId;
+
+  @override
+  ConsumerState<EndCampConfirmDialog> createState() =>
+      _EndCampConfirmDialogState();
+}
+
+class _EndCampConfirmDialogState extends ConsumerState<EndCampConfirmDialog> {
+  bool _submitting = false;
+  String? _error;
+
+  Future<void> _confirm() async {
+    setState(() {
+      _submitting = true;
+      _error = null;
+    });
+    try {
+      await ref.read(endCampControllerProvider.notifier).confirm();
+      final result = ref.read(endCampControllerProvider);
+      if (result.hasError) throw result.error!;
+      final reportGenerationFailed = ref
+          .read(endCampControllerProvider.notifier)
+          .lastReportGenerationFailed;
+      if (mounted) {
+        Navigator.pop(context);
+        context.go('/camps');
+        if (reportGenerationFailed) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            adminScaffoldMessengerKey.currentState?.showSnackBar(
+              const SnackBar(
+                content: Text('리포트 자동 생성에 실패했습니다 — 리포트 화면에서 다시 생성할 수 있습니다'),
+              ),
+            );
+          });
+        }
+      }
+    } catch (error) {
+      if (mounted) setState(() => _error = error.toString());
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).brightness == Brightness.dark
+        ? AppColors.dark
+        : AppColors.light;
+    final summary = ref.watch(liveSummaryProvider(widget.campId));
+    return AlertDialog(
+      backgroundColor: colors.bgSurfaceRaised,
+      constraints: const BoxConstraints(minWidth: 480, maxWidth: 640),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      title: Row(
+        children: [
+          Icon(Icons.warning_amber_rounded, color: colors.warning, size: 28),
+          const SizedBox(width: AppSpacing.space3),
+          Expanded(
+            child: Text(
+              '코너학습을 종료할까요?',
+              style: AppTypography.title3.copyWith(color: colors.textPrimary),
+            ),
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '종료 즉시 모든 진행자 세션이 로그아웃되며, 이후 데이터를 수정할 수 없습니다.',
+            style: AppTypography.body.copyWith(color: colors.textSecondary),
+          ),
+          const SizedBox(height: AppSpacing.space3),
+          summary.when(
+            data: (stats) {
+              final finished = stats.finishedGroupCount ?? 0;
+              final total = stats.totalGroups ?? 0;
+              final partial = (total - finished) < 0 ? 0 : total - finished;
+              return Text(
+                '완주 $finished조 / 부분완주 $partial조',
+                style: AppTypography.body.copyWith(
+                  color: colors.textPrimary,
+                  fontWeight: FontWeight.w700,
+                ),
+              );
+            },
+            loading: () => const SizedBox(
+              height: 16,
+              width: 16,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            ),
+            error: (_, _) => Text(
+              '완주/부분완주 요약을 불러올 수 없습니다',
+              style: AppTypography.caption.copyWith(
+                color: colors.textSecondary,
+              ),
+            ),
+          ),
+          if (_error != null)
+            Padding(
+              padding: const EdgeInsets.only(top: AppSpacing.space3),
+              child: Semantics(
+                liveRegion: true,
+                child: Text(
+                  _error!,
+                  style: AppTypography.caption.copyWith(color: colors.danger),
+                ),
+              ),
+            ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: _submitting ? null : () => Navigator.pop(context),
+          child: const Text('취소'),
+        ),
+        AppButton(
+          variant: AppButtonVariant.destructive,
+          size: AppButtonSize.compact,
+          label: _submitting ? '종료 처리 중…' : '종료 선언',
+          onPressed: _submitting ? null : _confirm,
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/admin/features/end_camp/end_camp_controller.dart
+++ b/frontend/lib/admin/features/end_camp/end_camp_controller.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:cornermon/admin/session/selected_camp_provider.dart';
+import 'package:cornermon/shared/api/providers/camp_providers.dart';
+import 'package:cornermon/shared/api/providers/report_providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final endCampControllerProvider =
+    AsyncNotifierProvider<EndCampController, void>(EndCampController.new);
+
+class EndCampController extends AsyncNotifier<void> {
+  @override
+  FutureOr<void> build() {}
+
+  /// 직전 [confirm] 호출에서 리포트 자동 생성(`generateReport`)이 실패했는지
+  /// 여부. `endCamp` 자체의 성공/실패와는 별개다 — 호출부(다이얼로그)가 pop 후
+  /// 캠프 목록으로 이동하고 나서 경고 스낵바를 띄울지 판단하는 데 쓴다.
+  bool lastReportGenerationFailed = false;
+
+  Future<void> confirm() async {
+    final campId = ref.read(selectedCampIdProvider);
+    if (campId == null) return;
+    state = const AsyncLoading();
+
+    final endSubscription = ref.listen(endCampProvider(campId), (_, _) {});
+    try {
+      await ref.read(endCampProvider(campId).future);
+      state = const AsyncData(null);
+    } catch (error, stackTrace) {
+      state = AsyncError(error, stackTrace);
+      Error.throwWithStackTrace(error, stackTrace);
+    } finally {
+      endSubscription.close();
+    }
+
+    // endCamp가 성공했을 때만 여기 도달한다. 리포트 자동 생성 실패는 코너학습
+    // 종료 자체의 실패로 취급하지 않는다 — A12(리포트)에서 재생성 가능하므로
+    // 실패 여부만 플래그로 남기고 무조건 다음 단계(캠프 선택 해제)로 진행한다.
+    lastReportGenerationFailed = false;
+    final reportSubscription = ref.listen(
+      generateReportProvider(campId),
+      (_, _) {},
+    );
+    try {
+      await ref.read(generateReportProvider(campId).future);
+    } catch (_) {
+      lastReportGenerationFailed = true;
+    } finally {
+      reportSubscription.close();
+    }
+
+    ref.read(selectedCampIdProvider.notifier).clear();
+  }
+}

--- a/frontend/lib/admin/widgets/admin_scaffold.dart
+++ b/frontend/lib/admin/widgets/admin_scaffold.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/admin/widgets/sidebar/admin_sidebar.dart';
+import 'package:cornermon/admin/features/end_camp/end_camp_bar_button.dart';
 import 'package:cornermon/admin/features/start_camp/start_camp_button.dart';
 
 class AdminScaffold extends ConsumerWidget {
@@ -38,6 +39,14 @@ class AdminScaffold extends ConsumerWidget {
                         child: Padding(
                           padding: const EdgeInsets.all(12),
                           child: StartCampButton(),
+                        ),
+                      ),
+                    if (sidebarModeFor(camp.status!) == SidebarMode.operating)
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: EndCampBarButton(),
                         ),
                       ),
                     Expanded(child: body),

--- a/frontend/lib/admin/widgets/admin_scaffold_messenger_key.dart
+++ b/frontend/lib/admin/widgets/admin_scaffold_messenger_key.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+/// `AdminApp`(`MaterialApp.router`)의 `scaffoldMessengerKey`로 등록되는 전역 키.
+///
+/// 코너학습 종료(A14)처럼 "다이얼로그를 닫고 다른 라우트로 이동한 뒤" 스낵바를
+/// 띄워야 하는 경우, 그 시점엔 다이얼로그를 열었던 `BuildContext`가 이미
+/// unmount되어 `ScaffoldMessenger.of(context)`를 쓸 수 없다. `MaterialApp`이
+/// 만드는 기본 `ScaffoldMessenger`는 라우트 전환과 무관하게 앱 전체에 하나만
+/// 존재하므로, 이 키로 그 인스턴스에 직접 접근해 컨텍스트 수명 문제를 피한다.
+final GlobalKey<ScaffoldMessengerState> adminScaffoldMessengerKey =
+    GlobalKey<ScaffoldMessengerState>();

--- a/frontend/lib/shared/api/providers/camp_providers.dart
+++ b/frontend/lib/shared/api/providers/camp_providers.dart
@@ -91,7 +91,7 @@ Future<Camp> startCamp(Ref ref, CampId id) async {
   return data;
 }
 
-@riverpod
+@Riverpod(retry: noRetry)
 Future<Camp> endCamp(Ref ref, CampId id) async {
   final apiInstance = ref.watch(campApiProvider);
   final response = await apiInstance.campsIdEndPost(id: id.value);

--- a/frontend/lib/shared/api/providers/camp_providers.g.dart
+++ b/frontend/lib/shared/api/providers/camp_providers.g.dart
@@ -448,7 +448,7 @@ final class EndCampProvider
     required EndCampFamily super.from,
     required CampId super.argument,
   }) : super(
-         retry: null,
+         retry: noRetry,
          name: r'endCampProvider',
          isAutoDispose: true,
          dependencies: null,
@@ -487,13 +487,13 @@ final class EndCampProvider
   }
 }
 
-String _$endCampHash() => r'ec080dfe26e119187472818f1e6695886a8bd248';
+String _$endCampHash() => r'c22d14f0bbe56455945902abe50fb1407d70190c';
 
 final class EndCampFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<Camp>, CampId> {
   EndCampFamily._()
     : super(
-        retry: null,
+        retry: noRetry,
         name: r'endCampProvider',
         dependencies: null,
         $allTransitiveDependencies: null,

--- a/frontend/lib/shared/api/providers/report_providers.dart
+++ b/frontend/lib/shared/api/providers/report_providers.dart
@@ -3,6 +3,7 @@ import 'package:cornermon_api_gen/cornermon_api_gen.dart';
 import '../client/api_client.dart';
 import '../domain_aliases.dart';
 import '../ids.dart';
+import 'no_retry.dart';
 
 part 'report_providers.g.dart';
 
@@ -23,7 +24,7 @@ Future<CampReport> currentReport(Ref ref, CampId campId) async {
   return data;
 }
 
-@riverpod
+@Riverpod(retry: noRetry)
 Future<CampReport> generateReport(Ref ref, CampId campId) async {
   final apiInstance = ref.watch(reportApiProvider);
   final response = await apiInstance.campsCampIdReportsGeneratePost(campId: campId.value);

--- a/frontend/lib/shared/api/providers/report_providers.g.dart
+++ b/frontend/lib/shared/api/providers/report_providers.g.dart
@@ -139,7 +139,7 @@ final class GenerateReportProvider
     required GenerateReportFamily super.from,
     required CampId super.argument,
   }) : super(
-         retry: null,
+         retry: noRetry,
          name: r'generateReportProvider',
          isAutoDispose: true,
          dependencies: null,
@@ -178,13 +178,13 @@ final class GenerateReportProvider
   }
 }
 
-String _$generateReportHash() => r'eeea938652213e63d05bd86f7973a81f6e6043e0';
+String _$generateReportHash() => r'07a49afe5c65e1f8c746abdb5a3fa975c9c01836';
 
 final class GenerateReportFamily extends $Family
     with $FunctionalFamilyOverride<FutureOr<CampReport>, CampId> {
   GenerateReportFamily._()
     : super(
-        retry: null,
+        retry: noRetry,
         name: r'generateReportProvider',
         dependencies: null,
         $allTransitiveDependencies: null,

--- a/frontend/test/admin/features/end_camp/end_camp_bar_button_test.dart
+++ b/frontend/test/admin/features/end_camp/end_camp_bar_button_test.dart
@@ -1,0 +1,386 @@
+import 'dart:async';
+
+import 'package:cornermon/admin/features/end_camp/end_camp_bar_button.dart';
+import 'package:cornermon/admin/session/selected_camp_provider.dart';
+import 'package:cornermon/admin/widgets/admin_scaffold.dart';
+import 'package:cornermon/admin/widgets/admin_scaffold_messenger_key.dart';
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/providers/camp_providers.dart';
+import 'package:cornermon/shared/api/providers/report_providers.dart';
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon_api_gen/cornermon_api_gen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+class _SelectedCampId extends SelectedCampId {
+  _SelectedCampId(this._id);
+  final CampId? _id;
+
+  @override
+  CampId? build() => _id;
+}
+
+CampResponse _camp(CampResponseStatusEnum status) => CampResponse(
+  (b) => b
+    ..id = 'camp-1'
+    ..name = '테스트 캠프'
+    ..status = status,
+);
+
+CampSummaryStatsResponse _summary({
+  required int finishedGroupCount,
+  required int totalGroups,
+}) => CampSummaryStatsResponse(
+  (b) => b
+    ..finishedGroupCount = finishedGroupCount
+    ..totalGroups = totalGroups,
+);
+
+CampReportResponse _report() => CampReportResponse((b) => b..campId = 'camp-1');
+
+void main() {
+  final campId = CampId('camp-1');
+
+  testWidgets('ShoudShowEndButtonWhenAdminScaffoldIsOperating', (tester) async {
+    // arrange
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => const AdminScaffold(body: Text('body')),
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
+          selectedCampProvider.overrideWith(
+            (ref) async => _camp(CampResponseStatusEnum.ACTIVE),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(find.text('코너학습 종료'), findsOneWidget);
+  });
+
+  testWidgets('ShoudHideEndButtonWhenAdminScaffoldIsPreparing', (tester) async {
+    // arrange
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => const AdminScaffold(body: Text('body')),
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
+          selectedCampProvider.overrideWith(
+            (ref) async => _camp(CampResponseStatusEnum.PENDING),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(find.text('코너학습 종료'), findsNothing);
+  });
+
+  testWidgets('ShoudHideEndButtonWhenAdminScaffoldIsReportOnly', (
+    tester,
+  ) async {
+    // arrange
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => const AdminScaffold(body: Text('body')),
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
+          selectedCampProvider.overrideWith(
+            (ref) async => _camp(CampResponseStatusEnum.ENDED),
+          ),
+        ],
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(find.text('코너학습 종료'), findsNothing);
+  });
+
+  testWidgets('ShoudShowLiveSummaryWhenConfirmDialogOpened', (tester) async {
+    // arrange
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
+          selectedCampProvider.overrideWith(
+            (ref) async => _camp(CampResponseStatusEnum.ACTIVE),
+          ),
+          liveSummaryProvider(campId).overrideWith(
+            (ref) async => _summary(finishedGroupCount: 4, totalGroups: 10),
+          ),
+        ],
+        child: const MaterialApp(home: Scaffold(body: EndCampBarButton())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // act
+    await tester.tap(find.text('코너학습 종료'));
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(find.text('코너학습을 종료할까요?'), findsOneWidget);
+    expect(find.text('완주 4조 / 부분완주 6조'), findsOneWidget);
+  });
+
+  testWidgets('ShoudShowDialogAndNotEndCampWhenCancelTapped', (tester) async {
+    // arrange
+    var endCalls = 0;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
+          selectedCampProvider.overrideWith(
+            (ref) async => _camp(CampResponseStatusEnum.ACTIVE),
+          ),
+          liveSummaryProvider(campId).overrideWith(
+            (ref) async => _summary(finishedGroupCount: 0, totalGroups: 0),
+          ),
+          endCampProvider(campId).overrideWith((ref) async {
+            endCalls++;
+            return _camp(CampResponseStatusEnum.ENDED);
+          }),
+        ],
+        child: const MaterialApp(home: Scaffold(body: EndCampBarButton())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // act
+    await tester.tap(find.text('코너학습 종료'));
+    await tester.pumpAndSettle();
+    expect(find.text('코너학습을 종료할까요?'), findsOneWidget);
+    await tester.tap(find.text('취소'));
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(endCalls, 0);
+    expect(find.text('코너학습을 종료할까요?'), findsNothing);
+  });
+
+  testWidgets('ShoudDisableDialogActionsWhenEndConfirmIsSubmitting', (
+    tester,
+  ) async {
+    // arrange
+    final completer = Completer<CampResponse>();
+    var endCalls = 0;
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
+          selectedCampProvider.overrideWith(
+            (ref) async => _camp(CampResponseStatusEnum.ACTIVE),
+          ),
+          liveSummaryProvider(campId).overrideWith(
+            (ref) async => _summary(finishedGroupCount: 0, totalGroups: 0),
+          ),
+          endCampProvider(campId).overrideWith((ref) {
+            endCalls++;
+            return completer.future;
+          }),
+        ],
+        child: const MaterialApp(home: Scaffold(body: EndCampBarButton())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // act
+    await tester.tap(find.text('코너학습 종료'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('종료 선언'));
+    await tester.pump();
+
+    // assert
+    expect(endCalls, 1);
+    expect(find.text('종료 처리 중…'), findsOneWidget);
+    expect(
+      tester
+          .widget<TextButton>(find.widgetWithText(TextButton, '취소'))
+          .onPressed,
+      isNull,
+    );
+    expect(
+      tester
+          .widget<AppButton>(find.widgetWithText(AppButton, '종료 처리 중…'))
+          .onPressed,
+      isNull,
+    );
+
+    completer.complete(_camp(CampResponseStatusEnum.ENDED));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('ShoudKeepDialogOpenAndShowServerMessageWhenEndFails', (
+    tester,
+  ) async {
+    // arrange
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
+          selectedCampProvider.overrideWith(
+            (ref) async => _camp(CampResponseStatusEnum.ACTIVE),
+          ),
+          liveSummaryProvider(campId).overrideWith(
+            (ref) async => _summary(finishedGroupCount: 0, totalGroups: 0),
+          ),
+          endCampProvider(
+            campId,
+          ).overrideWith((ref) async => throw Exception('이미 종료된 캠프')),
+        ],
+        child: const MaterialApp(home: Scaffold(body: EndCampBarButton())),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // act
+    await tester.tap(find.text('코너학습 종료'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('종료 선언'));
+    for (var i = 0; i < 60; i++) {
+      await tester.pump(const Duration(seconds: 1));
+    }
+
+    // assert
+    expect(find.text('코너학습을 종료할까요?'), findsOneWidget);
+    expect(find.textContaining('이미 종료된 캠프'), findsOneWidget);
+  });
+
+  testWidgets(
+    'ShoudNavigateToCampsAndShowWarningSnackbarWhenReportGenerationFailsButEndSucceeds',
+    (tester) async {
+      // arrange
+      final router = GoRouter(
+        initialLocation: '/dashboard',
+        routes: [
+          GoRoute(
+            path: '/dashboard',
+            builder: (_, _) => const Scaffold(body: EndCampBarButton()),
+          ),
+          GoRoute(
+            path: '/camps',
+            builder: (_, _) => const Scaffold(body: Text('캠프 목록')),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
+            selectedCampProvider.overrideWith(
+              (ref) async => _camp(CampResponseStatusEnum.ACTIVE),
+            ),
+            liveSummaryProvider(campId).overrideWith(
+              (ref) async => _summary(finishedGroupCount: 2, totalGroups: 5),
+            ),
+            endCampProvider(
+              campId,
+            ).overrideWith((ref) async => _camp(CampResponseStatusEnum.ENDED)),
+            generateReportProvider(
+              campId,
+            ).overrideWith((ref) async => throw Exception('리포트 생성 실패')),
+          ],
+          child: MaterialApp.router(
+            scaffoldMessengerKey: adminScaffoldMessengerKey,
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // act
+      await tester.tap(find.text('코너학습 종료'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('종료 선언'));
+      await tester.pumpAndSettle();
+
+      // assert
+      expect(find.text('캠프 목록'), findsOneWidget);
+      expect(find.textContaining('리포트 자동 생성에 실패했습니다'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'ShoudNavigateToCampsWithoutSnackbarWhenEndAndReportBothSucceed',
+    (tester) async {
+      // arrange
+      final router = GoRouter(
+        initialLocation: '/dashboard',
+        routes: [
+          GoRoute(
+            path: '/dashboard',
+            builder: (_, _) => const Scaffold(body: EndCampBarButton()),
+          ),
+          GoRoute(
+            path: '/camps',
+            builder: (_, _) => const Scaffold(body: Text('캠프 목록')),
+          ),
+        ],
+      );
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
+            selectedCampProvider.overrideWith(
+              (ref) async => _camp(CampResponseStatusEnum.ACTIVE),
+            ),
+            liveSummaryProvider(campId).overrideWith(
+              (ref) async => _summary(finishedGroupCount: 5, totalGroups: 5),
+            ),
+            endCampProvider(
+              campId,
+            ).overrideWith((ref) async => _camp(CampResponseStatusEnum.ENDED)),
+            generateReportProvider(
+              campId,
+            ).overrideWith((ref) async => _report()),
+          ],
+          child: MaterialApp.router(
+            scaffoldMessengerKey: adminScaffoldMessengerKey,
+            routerConfig: router,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // act
+      await tester.tap(find.text('코너학습 종료'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('종료 선언'));
+      await tester.pumpAndSettle();
+
+      // assert
+      expect(find.text('캠프 목록'), findsOneWidget);
+      expect(find.textContaining('리포트 자동 생성에 실패했습니다'), findsNothing);
+    },
+  );
+}

--- a/frontend/test/admin/features/end_camp/end_camp_controller_test.dart
+++ b/frontend/test/admin/features/end_camp/end_camp_controller_test.dart
@@ -1,0 +1,133 @@
+import 'package:cornermon/admin/features/end_camp/end_camp_controller.dart';
+import 'package:cornermon/admin/session/selected_camp_provider.dart';
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/providers/camp_providers.dart';
+import 'package:cornermon/shared/api/providers/report_providers.dart';
+import 'package:cornermon_api_gen/cornermon_api_gen.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final campId = CampId('camp-1');
+
+  CampResponse endedCamp() => CampResponse(
+    (b) => b
+      ..id = campId.value
+      ..status = CampResponseStatusEnum.ENDED,
+  );
+
+  CampReportResponse report() =>
+      CampReportResponse((b) => b..campId = campId.value);
+
+  test('ShoudClearSelectedCampIdWhenEndAndReportBothSucceed', () async {
+    // arrange
+    final container = ProviderContainer(
+      overrides: [
+        endCampProvider(campId).overrideWith((_) async => endedCamp()),
+        generateReportProvider(campId).overrideWith((_) async => report()),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(selectedCampIdProvider.notifier).select(campId);
+
+    // act
+    await container.read(endCampControllerProvider.notifier).confirm();
+
+    // assert
+    expect(container.read(selectedCampIdProvider), isNull);
+    expect(container.read(endCampControllerProvider).hasError, isFalse);
+    expect(
+      container
+          .read(endCampControllerProvider.notifier)
+          .lastReportGenerationFailed,
+      isFalse,
+    );
+  });
+
+  test(
+    'ShoudSetReportGenerationFailedFlagAndStillClearSelectedCampIdWhenReportGenerationFails',
+    () async {
+      // arrange
+      final container = ProviderContainer(
+        overrides: [
+          endCampProvider(campId).overrideWith((_) async => endedCamp()),
+          generateReportProvider(
+            campId,
+          ).overrideWith((_) async => throw Exception('리포트 생성 실패')),
+        ],
+      );
+      addTearDown(container.dispose);
+      container.read(selectedCampIdProvider.notifier).select(campId);
+
+      // act
+      await container.read(endCampControllerProvider.notifier).confirm();
+
+      // assert
+      expect(container.read(selectedCampIdProvider), isNull);
+      expect(container.read(endCampControllerProvider).hasError, isFalse);
+      expect(
+        container
+            .read(endCampControllerProvider.notifier)
+            .lastReportGenerationFailed,
+        isTrue,
+      );
+    },
+  );
+
+  test('ShoudThrowAndKeepSelectedCampIdWhenEndCampFails', () async {
+    // arrange
+    var generateReportCalls = 0;
+    final container = ProviderContainer(
+      overrides: [
+        endCampProvider(
+          campId,
+        ).overrideWith((_) async => throw Exception('종료 조건 미충족')),
+        generateReportProvider(campId).overrideWith((_) async {
+          generateReportCalls++;
+          return report();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(selectedCampIdProvider.notifier).select(campId);
+
+    // act
+    Object? caught;
+    try {
+      await container.read(endCampControllerProvider.notifier).confirm();
+    } catch (error) {
+      caught = error;
+    }
+
+    // assert
+    expect(caught, isNotNull);
+    expect(generateReportCalls, 0);
+    expect(container.read(selectedCampIdProvider), campId);
+    expect(container.read(endCampControllerProvider).hasError, isTrue);
+  });
+
+  test('ShoudCallEndCampBeforeGenerateReport', () async {
+    // arrange
+    final callOrder = <String>[];
+    final container = ProviderContainer(
+      overrides: [
+        endCampProvider(campId).overrideWith((_) async {
+          callOrder.add('end');
+          return endedCamp();
+        }),
+        generateReportProvider(campId).overrideWith((_) async {
+          callOrder.add('generateReport');
+          return report();
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(selectedCampIdProvider.notifier).select(campId);
+
+    // act
+    await container.read(endCampControllerProvider.notifier).confirm();
+
+    // assert
+    expect(callOrder, ['end', 'generateReport']);
+  });
+}


### PR DESCRIPTION
## 요약
- 운영 모드(ACTIVE 캠프) 상단 바에 상주하는 "코너학습 종료" destructive 버튼(`EndCampBarButton`) + 확인 모달(`EndCampConfirmDialog`)을 신규 구현. 전용 라우트가 없는 화면이라 `frontend/lib/admin/features/end_camp/`에 위젯 2개 + 컨트롤러 1개만 둠(plan §3.1).
- "코너학습 시작"(A0-e, `start_camp/**`)과 대칭 구조로 `EndCampController.confirm()`이 `AsyncNotifier` 액션성 provider 패턴(ref.listen 임시 구독 → ref.read(...future))을 그대로 미러링.
- 확인 시 `POST /camps/{id}/end` 성공 후 `POST /camps/{campId}/reports/generate`를 이어서 호출하고, 리포트 생성 실패는 컨트롤러의 `lastReportGenerationFailed` 플래그로만 노출한 뒤 무조건 캠프 목록(A0-c)으로 이동(§screen-spec-admin.md A14, plan §0 "확인 필요 — 해소함").
- `AdminScaffold`(기존 셸)를 확장해 `sidebarModeFor == operating`일 때 `EndCampBarButton`을 우측 상단에 배치 — plan §3.3이 "새 공용 셸을 만들라"고 했지만 실제로는 `AdminScaffold`가 이미 그 역할을 하고 있어 새 파일을 만들지 않고 기존 파일을 확장함(§3.3 자체가 "이미 있으면 확장하라"고 명시).
- 다이얼로그를 pop하고 `/camps`로 이동한 뒤에도 경고 스낵바를 띄울 수 있도록, 다이얼로그의 (곧 unmount될) `BuildContext`에 의존하지 않는 `adminScaffoldMessengerKey`(`GlobalKey<ScaffoldMessengerState>`)를 신규 도입하고 `AdminApp`(`MaterialApp.router`)에 등록.

## 발견하고 함께 고친 이슈
- `endCamp`/`generateReport` provider가 `retry: noRetry` 없이 plain `@riverpod`였다(`createCamp`만 이미 `retry: noRetry`). 실패 시 Riverpod 기본 정책(무제한 재시도, 지수 백오프 최대 6.4초, 실시간)이 적용되어 A14의 "실패 즉시 인라인 표시", "리포트 실패는 무시하고 즉시 다음 단계로" 요구사항과 충돌하는 것을 컨트롤러 테스트 작성 중 실제로 재현(plain `test()`가 30초 타임아웃). `frontend/lib/shared/api/providers/camp_providers.dart`의 `endCamp`, `frontend/lib/shared/api/providers/report_providers.dart`의 `generateReport`에 `@Riverpod(retry: noRetry)`를 추가하고 build_runner로 재생성(DEVELOPER_GUIDE §2.3 기준). A14 범위 밖인 `startCamp`/`updateCamp`는 손대지 않음.
- `build_runner` 실행 후 알려진 버그대로 `lib/shared/api/gen`이 삭제됐음을 확인하고 `git checkout --`으로 복구, 무관한 `api_client.g.dart` 해시 드리프트는 되돌려 diff를 최소화.

## 종료 조건 충족 근거
1. **기능 구현 완료(plan UC-2, work 항목 L-1/L-2)**: `end_camp_bar_button.dart`, `end_camp_confirm_dialog.dart`, `end_camp_controller.dart` 신규, `admin_scaffold.dart`에 operating 분기 추가 — plan §5 표의 L-1/L-2 갱신 완료로 표시.
2. **자체 리뷰(workflow/implement.md 4항목)**:
   - plan 내용 전부 구현(§3.2 객체 정의 그대로 미러링, §3.3 결정대로 기존 셸 확장).
   - plan §6 "A14 코너학습 종료" 8개 체크포인트 전부 테스트로 실제 확인(아래).
   - DEVELOPER_GUIDE §2.2(ref.listen 임시 구독), §2.3(retry: noRetry) 준수. `dio`/`cornermon_api_gen` 직접 import 없음(`grep -rn "package:cornermon_api_gen" lib/admin/features/end_camp` 결과 없음, `domain_aliases.dart`/`ids.dart` typedef만 사용).
   - 하드코딩된 시크릿 없음. 에러 메시지는 기존 `start_camp` 패턴과 동일하게 `error.toString()` 인라인 표시.
3. **plan 검증 체크리스트 갱신**: `frontend/docs/artifacts/plan/관리자_앱_전체_플로우_구현_plan_20260714/11_a13_a14_a15_audit_end_settings.md`의 "A14 코너학습 종료" 8개 항목을 각각 근거 테스트명과 함께 `[x]`로 갱신, 구현 노트(retry 이슈) 추가.

### plan §6 체크리스트 ↔ 테스트 매핑
- ACTIVE에서만 버튼 노출 / PENDING·ENDED에서 숨김 → `ShoudShowEndButtonWhenAdminScaffoldIsOperating`, `ShoudHideEndButtonWhenAdminScaffoldIsPreparing`, `ShoudHideEndButtonWhenAdminScaffoldIsReportOnly`
- 완주/부분완주 요약 표시 → `ShoudShowLiveSummaryWhenConfirmDialogOpened`
- end → generateReport 호출 순서 → `ShoudCallEndCampBeforeGenerateReport`(호출 순서 배열 검증)
- 종료 후 캠프 목록(A0-c)으로 이동, 대시보드에 안 남음 → `ShoudNavigateToCampsWithoutSnackbarWhenEndAndReportBothSucceed` 등
- "종료됨" 배지 → 기존 `camp_list_screen.dart`에 이미 구현돼 있음을 코드로 재확인(A14가 새로 만들 필요 없음)
- reports/generate 실패해도 end 성공이면 정상 이동 + 경고 스낵바 → `ShoudNavigateToCampsAndShowWarningSnackbarWhenReportGenerationFailsButEndSucceeds`
- endCamp 자체 실패 시 모달 유지 + 에러 인라인 + 이동 안 함 → `ShoudKeepDialogOpenAndShowServerMessageWhenEndFails`, `ShoudThrowAndKeepSelectedCampIdWhenEndCampFails`

## 검증
- `dart analyze lib/` — 0 에러
- `flutter test test/admin/features/end_camp/` — 13개 전부 통과(컨트롤러 4 + 버튼/다이얼로그 9)
- `flutter test`(frontend 전체 스위트) — 155개 전부 통과, 회귀 없음

## 스코프
- `frontend/` 폴더만 수정(`backend/`, `api/` 미변경). `admin_router.dart`는 A14가 라우트를 쓰지 않으므로 건드리지 않음(타 worktree의 병렬 작업 보호).
- LOC 500줄 제한은 이번 태스크 지시에 따라 예외 적용(전체 diff 약 800줄, 그중 테스트가 절반 이상).

🤖 Generated with [Claude Code](https://claude.com/claude-code)