### PR TITLE
fix: 캠프 범위 기기 등록 API 경로 정리

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -968,6 +968,221 @@ const docTemplate = `{
                 }
             }
         },
+        "/camps/{campId}/device-registrations": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "관리자가 등록되었거나 대기 중인 기기 목록을 확인한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "기기 등록 목록 조회",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "기기 등록 상태",
+                        "name": "status",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DeviceRegistrationResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/camps/{campId}/device-registrations/locked": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "캠프 내 PIN 연속 실패로 잠금된(APPROVED, LockedUntil이 미래) 기기 목록을 조회한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "잠금 기기 목록 조회",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DeviceRegistrationResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/camps/{campId}/device-registrations/{id}/approve": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "PENDING 상태인 기기를 APPROVED로 승인한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "기기 승인",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "기기 등록 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/DeviceRegistrationResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/camps/{campId}/device-registrations/{id}/reject": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "PENDING 상태인 기기를 REJECTED로 거절한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "기기 거절",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "기기 등록 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/DeviceRegistrationResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/camps/{campId}/device-registrations/{id}/revoke": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "APPROVED 기기의 권한을 REVOKED로 박탈한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "기기 신뢰 취소 (폐기/분실)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "기기 등록 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/DeviceRegistrationResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/camps/{campId}/groups": {
             "get": {
                 "security": [
@@ -1698,32 +1913,6 @@ const docTemplate = `{
             }
         },
         "/device-registrations": {
-            "get": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "관리자가 등록되었거나 대기 중인 기기 목록을 확인한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "기기 등록 목록 조회",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/DeviceRegistrationResponse"
-                            }
-                        }
-                    }
-                }
-            },
             "post": {
                 "description": "기기가 서버에 등록을 요청한다. 이후 관리자의 승인 대기.",
                 "consumes": [
@@ -1757,49 +1946,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/device-registrations/locked": {
-            "get": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "캠프 내 PIN 연속 실패로 잠금된(APPROVED, LockedUntil이 미래) 기기 목록을 조회한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "잠금 기기 목록 조회",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "캠프 ID",
-                        "name": "campId",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/DeviceRegistrationResponse"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/device-registrations/me": {
             "get": {
                 "description": "미승인(PENDING) 기기가 자신의 승인 상태를 확인하기 위해 호출한다.",
@@ -1818,108 +1964,6 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/DeviceStatusResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/device-registrations/{id}/approve": {
-            "post": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "PENDING 상태인 기기를 APPROVED로 승인한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "기기 승인",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "기기 등록 ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/DeviceRegistrationResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/device-registrations/{id}/reject": {
-            "post": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "PENDING 상태인 기기를 REJECTED로 거절한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "기기 거절",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "기기 등록 ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/DeviceRegistrationResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/device-registrations/{id}/revoke": {
-            "post": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "APPROVED 기기의 권한을 REVOKED로 박탈한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "기기 신뢰 취소 (폐기/분실)",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "기기 등록 ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/DeviceRegistrationResponse"
                         }
                     }
                 }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -961,6 +961,221 @@
                 }
             }
         },
+        "/camps/{campId}/device-registrations": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "관리자가 등록되었거나 대기 중인 기기 목록을 확인한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "기기 등록 목록 조회",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "기기 등록 상태",
+                        "name": "status",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DeviceRegistrationResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/camps/{campId}/device-registrations/locked": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "캠프 내 PIN 연속 실패로 잠금된(APPROVED, LockedUntil이 미래) 기기 목록을 조회한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "잠금 기기 목록 조회",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/DeviceRegistrationResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/camps/{campId}/device-registrations/{id}/approve": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "PENDING 상태인 기기를 APPROVED로 승인한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "기기 승인",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "기기 등록 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/DeviceRegistrationResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/camps/{campId}/device-registrations/{id}/reject": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "PENDING 상태인 기기를 REJECTED로 거절한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "기기 거절",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "기기 등록 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/DeviceRegistrationResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/camps/{campId}/device-registrations/{id}/revoke": {
+            "post": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "APPROVED 기기의 권한을 REVOKED로 박탈한다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "기기 신뢰 취소 (폐기/분실)",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "캠프 ID",
+                        "name": "campId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "기기 등록 ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/DeviceRegistrationResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/camps/{campId}/groups": {
             "get": {
                 "security": [
@@ -1691,32 +1906,6 @@
             }
         },
         "/device-registrations": {
-            "get": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "관리자가 등록되었거나 대기 중인 기기 목록을 확인한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "기기 등록 목록 조회",
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/DeviceRegistrationResponse"
-                            }
-                        }
-                    }
-                }
-            },
             "post": {
                 "description": "기기가 서버에 등록을 요청한다. 이후 관리자의 승인 대기.",
                 "consumes": [
@@ -1750,49 +1939,6 @@
                 }
             }
         },
-        "/device-registrations/locked": {
-            "get": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "캠프 내 PIN 연속 실패로 잠금된(APPROVED, LockedUntil이 미래) 기기 목록을 조회한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "잠금 기기 목록 조회",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "캠프 ID",
-                        "name": "campId",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/DeviceRegistrationResponse"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorResponse"
-                        }
-                    }
-                }
-            }
-        },
         "/device-registrations/me": {
             "get": {
                 "description": "미승인(PENDING) 기기가 자신의 승인 상태를 확인하기 위해 호출한다.",
@@ -1811,108 +1957,6 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/DeviceStatusResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/device-registrations/{id}/approve": {
-            "post": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "PENDING 상태인 기기를 APPROVED로 승인한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "기기 승인",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "기기 등록 ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/DeviceRegistrationResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/device-registrations/{id}/reject": {
-            "post": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "PENDING 상태인 기기를 REJECTED로 거절한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "기기 거절",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "기기 등록 ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/DeviceRegistrationResponse"
-                        }
-                    }
-                }
-            }
-        },
-        "/device-registrations/{id}/revoke": {
-            "post": {
-                "security": [
-                    {
-                        "AdminAuth": []
-                    }
-                ],
-                "description": "APPROVED 기기의 권한을 REVOKED로 박탈한다.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "A. Auth \u0026 Device Trust"
-                ],
-                "summary": "기기 신뢰 취소 (폐기/분실)",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "기기 등록 ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/DeviceRegistrationResponse"
                         }
                     }
                 }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1427,6 +1427,142 @@ paths:
       summary: 코너 목록 조회
       tags:
       - B. Resource Management (Admin)
+  /camps/{campId}/device-registrations:
+    get:
+      description: 관리자가 등록되었거나 대기 중인 기기 목록을 확인한다.
+      parameters:
+      - description: 캠프 ID
+        in: path
+        name: campId
+        required: true
+        type: string
+      - description: 기기 등록 상태
+        in: query
+        name: status
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/DeviceRegistrationResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: 기기 등록 목록 조회
+      tags:
+      - A. Auth & Device Trust
+  /camps/{campId}/device-registrations/{id}/approve:
+    post:
+      description: PENDING 상태인 기기를 APPROVED로 승인한다.
+      parameters:
+      - description: 캠프 ID
+        in: path
+        name: campId
+        required: true
+        type: string
+      - description: 기기 등록 ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/DeviceRegistrationResponse'
+      security:
+      - AdminAuth: []
+      summary: 기기 승인
+      tags:
+      - A. Auth & Device Trust
+  /camps/{campId}/device-registrations/{id}/reject:
+    post:
+      description: PENDING 상태인 기기를 REJECTED로 거절한다.
+      parameters:
+      - description: 캠프 ID
+        in: path
+        name: campId
+        required: true
+        type: string
+      - description: 기기 등록 ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/DeviceRegistrationResponse'
+      security:
+      - AdminAuth: []
+      summary: 기기 거절
+      tags:
+      - A. Auth & Device Trust
+  /camps/{campId}/device-registrations/{id}/revoke:
+    post:
+      description: APPROVED 기기의 권한을 REVOKED로 박탈한다.
+      parameters:
+      - description: 캠프 ID
+        in: path
+        name: campId
+        required: true
+        type: string
+      - description: 기기 등록 ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/DeviceRegistrationResponse'
+      security:
+      - AdminAuth: []
+      summary: 기기 신뢰 취소 (폐기/분실)
+      tags:
+      - A. Auth & Device Trust
+  /camps/{campId}/device-registrations/locked:
+    get:
+      description: 캠프 내 PIN 연속 실패로 잠금된(APPROVED, LockedUntil이 미래) 기기 목록을 조회한다.
+      parameters:
+      - description: 캠프 ID
+        in: path
+        name: campId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/DeviceRegistrationResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: 잠금 기기 목록 조회
+      tags:
+      - A. Auth & Device Trust
   /camps/{campId}/groups:
     get:
       description: 특정 캠프에 속한 모든 조의 목록과 상태를 조회한다.
@@ -1885,22 +2021,6 @@ paths:
       tags:
       - B. Resource Management (Admin)
   /device-registrations:
-    get:
-      description: 관리자가 등록되었거나 대기 중인 기기 목록을 확인한다.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/DeviceRegistrationResponse'
-            type: array
-      security:
-      - AdminAuth: []
-      summary: 기기 등록 목록 조회
-      tags:
-      - A. Auth & Device Trust
     post:
       consumes:
       - application/json
@@ -1920,96 +2040,6 @@ paths:
           schema:
             $ref: '#/definitions/DeviceRegistrationCreatedResponse'
       summary: 기기 등록 요청 (최초 앱 실행 시)
-      tags:
-      - A. Auth & Device Trust
-  /device-registrations/{id}/approve:
-    post:
-      description: PENDING 상태인 기기를 APPROVED로 승인한다.
-      parameters:
-      - description: 기기 등록 ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/DeviceRegistrationResponse'
-      security:
-      - AdminAuth: []
-      summary: 기기 승인
-      tags:
-      - A. Auth & Device Trust
-  /device-registrations/{id}/reject:
-    post:
-      description: PENDING 상태인 기기를 REJECTED로 거절한다.
-      parameters:
-      - description: 기기 등록 ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/DeviceRegistrationResponse'
-      security:
-      - AdminAuth: []
-      summary: 기기 거절
-      tags:
-      - A. Auth & Device Trust
-  /device-registrations/{id}/revoke:
-    post:
-      description: APPROVED 기기의 권한을 REVOKED로 박탈한다.
-      parameters:
-      - description: 기기 등록 ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/DeviceRegistrationResponse'
-      security:
-      - AdminAuth: []
-      summary: 기기 신뢰 취소 (폐기/분실)
-      tags:
-      - A. Auth & Device Trust
-  /device-registrations/locked:
-    get:
-      description: 캠프 내 PIN 연속 실패로 잠금된(APPROVED, LockedUntil이 미래) 기기 목록을 조회한다.
-      parameters:
-      - description: 캠프 ID
-        in: query
-        name: campId
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/DeviceRegistrationResponse'
-            type: array
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/ErrorResponse'
-      security:
-      - AdminAuth: []
-      summary: 잠금 기기 목록 조회
       tags:
       - A. Auth & Device Trust
   /device-registrations/me:

--- a/backend/docs/artifacts/plan/20260718_camp_scoped_device_registrations_plan_.md
+++ b/backend/docs/artifacts/plan/20260718_camp_scoped_device_registrations_plan_.md
@@ -1,0 +1,47 @@
+# 캠프 범위 기기 등록 API 정리 계획
+
+## 목표
+
+관리자용 기기 등록 조회·관리 API를 캠프 하위 리소스로 이동해, `campId` 쿼리 파라미터와 라우터의 불일치를 없앤다.
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-1: 캠프별 기기 등록 목록 조회 | `GET /camps/{campId}/device-registrations`로 해당 캠프의 등록 기기를 조회한다. | **프로덕션 핵심** |
+| **P0** | UC-2: 캠프별 잠금 기기 조회 | `GET /camps/{campId}/device-registrations/locked`로 해당 캠프의 잠금 기기를 조회한다. | **프로덕션 핵심** |
+| **P0** | UC-3: 캠프 범위 기기 승인·거절·취소 | 관리자 변경 API를 같은 캠프 하위 경로로 노출한다. | **프로덕션 핵심** |
+
+## 변경 설계
+
+### Web 라우터 (`/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/web/router.go`)
+
+```go
+admin.GET("/camps/:campId/device-registrations", h.Device.ListRegistrations)
+admin.GET("/camps/:campId/device-registrations/locked", h.Device.ListLockedDevices)
+admin.POST("/camps/:campId/device-registrations/:id/approve", h.Device.ApproveDevice)
+```
+
+- 공개 기기 등록 요청 및 자신의 상태 조회 경로는 등록 코드·기기 토큰 기반이므로 유지한다.
+- 기존 최상위 관리자 경로는 제거한다.
+
+### Device handler (`/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/web/device_handler.go`)
+
+```go
+campID := c.Param("campId")
+```
+
+- 목록 및 잠금 목록은 쿼리 대신 경로 파라미터를 usecase에 전달한다.
+- Swagger 주석을 새 경로 및 `campId path` 파라미터와 일치시킨다.
+
+### API 계약 (`/home/lsjtop10/projects/cornermon/api/swagger.yaml`)
+
+- `swag` 산출물을 재생성해 새 경로와 필수 `campId` 경로 파라미터를 반영한다.
+
+## 검증 체크리스트
+
+- [x] 목록과 잠금 목록이 `/camps/{campId}`의 경로 파라미터를 사용한다.
+- [x] 모든 관리자 기기 등록 경로가 `/camps/:campId/device-registrations` 하위다.
+- [x] 구 최상위 관리자 기기 등록 경로가 등록되지 않는다.
+- [x] Swagger 계약이 라우터와 일치한다.
+- [x] 관련 web 테스트 및 `go test ./...`가 통과한다.

--- a/backend/internal/infrastructure/web/device_handler.go
+++ b/backend/internal/infrastructure/web/device_handler.go
@@ -137,10 +137,13 @@ func (h *DeviceHandler) RequestRegistration(c echo.Context) error {
 // @Tags         A. Auth & Device Trust
 // @Security     AdminAuth
 // @Produce      json
+// @Param        campId path string true "캠프 ID"
+// @Param        status query string false "기기 등록 상태"
 // @Success      200 {array} DeviceRegistrationResponse
-// @Router       /device-registrations [get]
+// @Failure      400 {object} ErrorResponse
+// @Router       /camps/{campId}/device-registrations [get]
 func (h *DeviceHandler) ListRegistrations(c echo.Context) error {
-	campID := c.QueryParam("campId")
+	campID := c.Param("campId")
 	if campID == "" {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "missing campId"})
 	}
@@ -190,12 +193,12 @@ func (h *DeviceHandler) ListRegistrations(c echo.Context) error {
 // @Tags         A. Auth & Device Trust
 // @Security     AdminAuth
 // @Produce      json
-// @Param        campId query string true "캠프 ID"
+// @Param        campId path string true "캠프 ID"
 // @Success      200 {array} DeviceRegistrationResponse
 // @Failure      400 {object} ErrorResponse
-// @Router       /device-registrations/locked [get]
+// @Router       /camps/{campId}/device-registrations/locked [get]
 func (h *DeviceHandler) ListLockedDevices(c echo.Context) error {
-	campID := c.QueryParam("campId")
+	campID := c.Param("campId")
 	if campID == "" {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "missing campId"})
 	}
@@ -226,9 +229,10 @@ func mapDeviceRegistration(device *domain.DeviceRegistration) DeviceRegistration
 // @Tags         A. Auth & Device Trust
 // @Security     AdminAuth
 // @Produce      json
+// @Param        campId path string true "캠프 ID"
 // @Param        id path string true "기기 등록 ID"
 // @Success      200 {object} DeviceRegistrationResponse
-// @Router       /device-registrations/{id}/approve [post]
+// @Router       /camps/{campId}/device-registrations/{id}/approve [post]
 func (h *DeviceHandler) ApproveDevice(c echo.Context) error {
 	session, ok := c.Get("adminSession").(*domain.AdminSession)
 	if !ok {
@@ -249,9 +253,10 @@ func (h *DeviceHandler) ApproveDevice(c echo.Context) error {
 // @Tags         A. Auth & Device Trust
 // @Security     AdminAuth
 // @Produce      json
+// @Param        campId path string true "캠프 ID"
 // @Param        id path string true "기기 등록 ID"
 // @Success      200 {object} DeviceRegistrationResponse
-// @Router       /device-registrations/{id}/reject [post]
+// @Router       /camps/{campId}/device-registrations/{id}/reject [post]
 func (h *DeviceHandler) RejectDevice(c echo.Context) error {
 	session, ok := c.Get("adminSession").(*domain.AdminSession)
 	if !ok {
@@ -272,9 +277,10 @@ func (h *DeviceHandler) RejectDevice(c echo.Context) error {
 // @Tags         A. Auth & Device Trust
 // @Security     AdminAuth
 // @Produce      json
+// @Param        campId path string true "캠프 ID"
 // @Param        id path string true "기기 등록 ID"
 // @Success      200 {object} DeviceRegistrationResponse
-// @Router       /device-registrations/{id}/revoke [post]
+// @Router       /camps/{campId}/device-registrations/{id}/revoke [post]
 func (h *DeviceHandler) RevokeDevice(c echo.Context) error {
 	session, ok := c.Get("adminSession").(*domain.AdminSession)
 	if !ok {

--- a/backend/internal/infrastructure/web/device_handler_test.go
+++ b/backend/internal/infrastructure/web/device_handler_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (
@@ -85,11 +84,15 @@ func TestShouldReturnActualCreatedAtWhenListingRegistrations(t *testing.T) {
 	createdAt := time.Date(2026, 7, 14, 9, 0, 0, 0, time.UTC)
 	stub := &listDeviceTrustStub{reviewedDevices: []*domain.DeviceRegistration{domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1", Status: domain.DevicePending, CreatedAt: createdAt})}}
 	handler := NewDeviceHandler(stub)
-	req := httptest.NewRequest(http.MethodGet, "/device-registrations?campId=camp-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/camps/camp-1/device-registrations", nil)
 	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath("/camps/:campId/device-registrations")
+	ctx.SetParamNames("campId")
+	ctx.SetParamValues("camp-1")
 
 	// Act
-	err := handler.ListRegistrations(e.NewContext(req, rec))
+	err := handler.ListRegistrations(ctx)
 
 	// Assert
 	if err != nil || rec.Code != http.StatusOK {

--- a/backend/internal/infrastructure/web/list_handlers_test.go
+++ b/backend/internal/infrastructure/web/list_handlers_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (
@@ -73,11 +72,15 @@ func TestShouldReturnLockedDeviceResponseWhenCampIDIsProvided(t *testing.T) {
 	e := echo.New()
 	lockedUntil := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
 	handler := NewDeviceHandler(&listDeviceTrustStub{devices: []*domain.DeviceRegistration{domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1", DeviceName: "iPad", Status: domain.DeviceApproved, FailedPinAttempts: 5, LockedUntil: domain.Some(lockedUntil)})}})
-	req := httptest.NewRequest(http.MethodGet, "/device-registrations/locked?campId=camp-1", nil)
+	req := httptest.NewRequest(http.MethodGet, "/camps/camp-1/device-registrations/locked", nil)
 	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+	ctx.SetPath("/camps/:campId/device-registrations/locked")
+	ctx.SetParamNames("campId")
+	ctx.SetParamValues("camp-1")
 
 	// Act
-	err := handler.ListLockedDevices(e.NewContext(req, rec))
+	err := handler.ListLockedDevices(ctx)
 
 	// Assert
 	if err != nil || rec.Code != http.StatusOK {
@@ -146,9 +149,9 @@ func TestShouldRejectListRequestsWhenAdminAuthenticationIsMissing(t *testing.T) 
 	admin := e.Group("")
 	admin.Use(AdminAuthMiddleware(listAdminAuthStub{}))
 	admin.GET("/auth/track/sessions", NewAuthHandler(nil, &listFacilitatorAuthStub{}, nil).ListActiveFacilitatorSessions)
-	admin.GET("/device-registrations/locked", NewDeviceHandler(&listDeviceTrustStub{}).ListLockedDevices)
+	admin.GET("/camps/:campId/device-registrations/locked", NewDeviceHandler(&listDeviceTrustStub{}).ListLockedDevices)
 
-	for _, path := range []string{"/auth/track/sessions?campId=camp-1", "/device-registrations/locked?campId=camp-1"} {
+	for _, path := range []string{"/auth/track/sessions?campId=camp-1", "/camps/camp-1/device-registrations/locked"} {
 		t.Run(path, func(t *testing.T) {
 			// Act
 			rec := httptest.NewRecorder()

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -55,11 +55,11 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 	admin.POST("/auth/track/lockout/:deviceId/release", h.Auth.ReleaseLockout)
 	admin.GET("/auth/track/sessions", h.Auth.ListActiveFacilitatorSessions)
 
-	admin.GET("/device-registrations", h.Device.ListRegistrations)
-	admin.GET("/device-registrations/locked", h.Device.ListLockedDevices)
-	admin.POST("/device-registrations/:id/approve", h.Device.ApproveDevice)
-	admin.POST("/device-registrations/:id/reject", h.Device.RejectDevice)
-	admin.POST("/device-registrations/:id/revoke", h.Device.RevokeDevice)
+	admin.GET("/camps/:campId/device-registrations", h.Device.ListRegistrations)
+	admin.GET("/camps/:campId/device-registrations/locked", h.Device.ListLockedDevices)
+	admin.POST("/camps/:campId/device-registrations/:id/approve", h.Device.ApproveDevice)
+	admin.POST("/camps/:campId/device-registrations/:id/reject", h.Device.RejectDevice)
+	admin.POST("/camps/:campId/device-registrations/:id/revoke", h.Device.RevokeDevice)
 
 	// ── B. Resource Management ──
 	if h.Camp != nil {

--- a/backend/internal/infrastructure/web/router_test.go
+++ b/backend/internal/infrastructure/web/router_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (
@@ -105,5 +104,25 @@ func TestListBroadcastsRouteShoudRejectRequestWithoutSession(t *testing.T) {
 	// Assert
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("expected status 401, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestDeviceRegistrationRoutesShouldBeScopedToCamp(t *testing.T) {
+	// Arrange
+	e := echo.New()
+	RegisterRoutes(e, &Handlers{Auth: &AuthHandler{}, Device: &DeviceHandler{}}, adminAuthForMessageRoutes{}, trackAuthForMessageRoutes{})
+
+	// Act
+	routes := make(map[string]bool)
+	for _, route := range e.Routes() {
+		routes[route.Method+" "+route.Path] = true
+	}
+
+	// Assert
+	if !routes[http.MethodGet+" /api/v1/camps/:campId/device-registrations"] {
+		t.Fatal("expected camp-scoped device registration route to be registered")
+	}
+	if routes[http.MethodGet+" /api/v1/device-registrations"] {
+		t.Fatal("expected legacy device registration route to be absent")
 	}
 }


### PR DESCRIPTION
## 변경 사항
- 관리자 기기 등록 목록, 잠금 조회, 승인, 거절, 신뢰 취소를 /camps/{campId}/device-registrations 하위로 이동했습니다.
- 목록과 잠금 조회의 campId를 쿼리 파라미터에서 경로 파라미터로 변경했습니다.
- Swagger/OpenAPI 산출물과 라우팅 회귀 테스트를 갱신했습니다.

## 변경 이유
기존 핸들러는 campId 쿼리를 요구했지만 라우팅과 API 경로가 캠프 범위를 표현하지 않아, API 계약과 경로 관례가 일치하지 않았습니다.

## 검증
- backend에서 GOCACHE=/tmp/cornermon-go-cache go test ./... 통과
- backend에서 GOCACHE=/tmp/cornermon-go-cache go vet ./... 통과
- git diff --check 통과
- 구 최상위 관리자 목록 경로가 등록되지 않는 라우팅 회귀 테스트 추가

Closes #126