### PR TITLE
fix: 기기 등록 코드 대소문자 정규화

### DIFF
--- a/backend/internal/infrastructure/web/device_handler.go
+++ b/backend/internal/infrastructure/web/device_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 	"time"
 
 	"cornermon/backend/internal/domain"
@@ -53,6 +54,7 @@ func NewDeviceHandler(deviceTrust DeviceTrustUsecase) *DeviceHandler {
 }
 
 type DeviceRegistrationRequest struct {
+	// 각 캠프에 유일하게 부여된 등록 코드입니다. 반드시 대문자로 작성합니다.
 	RegistrationCode string `json:"registrationCode" example:"7ZQK3M2X"`
 	DeviceName       string `json:"deviceName"`
 	DeviceModel      string `json:"deviceModel" example:"iPad Pro 11 2022"`
@@ -100,7 +102,7 @@ func (h *DeviceHandler) RequestRegistration(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "invalid request"})
 	}
 
-	token, reg, err := h.deviceTrust.RequestRegistration(c.Request().Context(), req.RegistrationCode, req.DeviceName, req.DeviceModel, req.DisplayName)
+	token, reg, err := h.deviceTrust.RequestRegistration(c.Request().Context(), strings.ToUpper(req.RegistrationCode), req.DeviceName, req.DeviceModel, req.DisplayName)
 	if err != nil {
 		if errors.Is(err, domain.ErrCampNotFound) {
 			return c.JSON(http.StatusNotFound, ErrorResponse{Code: "CAMP_NOT_FOUND", Message: err.Error()})

--- a/backend/internal/infrastructure/web/device_handler_test.go
+++ b/backend/internal/infrastructure/web/device_handler_test.go
@@ -40,6 +40,28 @@ func TestShouldReturnActualCreatedAtWhenDeviceRegistrationRequested(t *testing.T
 	}
 }
 
+func TestShouldNormalizeRegistrationCodeWhenDeviceRegistrationRequestedWithLowercaseCode(t *testing.T) {
+	// Arrange
+	e := echo.New()
+	stub := &listDeviceTrustStub{requestedReg: domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1", Status: domain.DevicePending})}
+	handler := NewDeviceHandler(stub)
+	body := bytes.NewBufferString(`{"registrationCode":"7Zqk3m2x","deviceName":"iPad","deviceModel":"iPad Pro 11 2022","displayName":"1번 태블릿"}`)
+	req := httptest.NewRequest(http.MethodPost, "/device-registrations", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+
+	// Act
+	err := handler.RequestRegistration(e.NewContext(req, rec))
+
+	// Assert
+	if err != nil || rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 response, code=%d err=%v", rec.Code, err)
+	}
+	if stub.registrationCode != "7ZQK3M2X" {
+		t.Fatalf("expected uppercased registration code, got %q", stub.registrationCode)
+	}
+}
+
 func TestShouldReturnNotFoundWhenRegistrationCodeDoesNotMatchAnyCamp(t *testing.T) {
 	// Arrange
 	e := echo.New()

--- a/backend/internal/infrastructure/web/list_handlers_test.go
+++ b/backend/internal/infrastructure/web/list_handlers_test.go
@@ -15,16 +15,18 @@ import (
 )
 
 type listDeviceTrustStub struct {
-	devices         []*domain.DeviceRegistration
-	requestedReg    *domain.DeviceRegistration
-	requestErr      error
-	reviewedDevices []*domain.DeviceRegistration
+	devices          []*domain.DeviceRegistration
+	requestedReg     *domain.DeviceRegistration
+	registrationCode string
+	requestErr       error
+	reviewedDevices  []*domain.DeviceRegistration
 }
 
 func (s *listDeviceTrustStub) GetMyRegistrationStatus(context.Context, string) (*domain.DeviceRegistrationStatus, error) {
 	return nil, nil
 }
-func (s *listDeviceTrustStub) RequestRegistration(context.Context, string, string, string, string) (string, *domain.DeviceRegistration, error) {
+func (s *listDeviceTrustStub) RequestRegistration(_ context.Context, registrationCode, _, _, _ string) (string, *domain.DeviceRegistration, error) {
+	s.registrationCode = registrationCode
 	if s.requestErr != nil {
 		return "", nil, s.requestErr
 	}


### PR DESCRIPTION
## 변경 사항
- 기기 등록 요청의 registrationCode를 서버 경계에서 대문자로 정규화합니다.
- 소문자 혼합 입력이 대문자로 변환되어 유스케이스에 전달되는 핸들러 테스트를 추가했습니다.

## 변경 이유
등록 코드는 대문자 값으로 저장·비교되므로, 클라이언트 입력 대소문자에 관계없이 동일한 캠프를 찾도록 서버에서 정규화해야 합니다.

## 검증
- backend에서 GOCACHE=/tmp/cornermon-go-cache go test ./internal/infrastructure/web 통과
- git diff --check 통과