### PR TITLE
fix: 감사 로그 저장 시 메타데이터 직렬화 오류 수정

### DIFF
--- a/backend/internal/infrastructure/postgres/audit_log_repo.go
+++ b/backend/internal/infrastructure/postgres/audit_log_repo.go
@@ -28,7 +28,7 @@ func (r *pgAuditLogRepository) queries(ctx context.Context) *db.Queries {
 }
 
 func (r *pgAuditLogRepository) Save(ctx context.Context, log *domain.AuditLog) error {
-	metaJSON, err := json.Marshal(log.Metadata)
+	metaJSON, err := json.Marshal(log.Metadata())
 	if err != nil {
 		return errs.Wrap(ctx, err)
 	}


### PR DESCRIPTION
## Summary
- `AuditLogRepository.Save`에서 `json.Marshal(log.Metadata)`가 `Metadata()` 메서드를 호출하지 않고 메서드 값(`func() map[string]interface{}`) 자체를 넘겨, `json: unsupported type: func() map[string]interface {}` 오류로 감사 로그 저장이 항상 실패하던 문제 수정
- `log.Metadata()`로 호출하도록 변경

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/usecase/... ./internal/infrastructure/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)