### PR TITLE
feat: setup pgx query tracer for infrastructure logging

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,3 +12,11 @@ TRACK_PIN_ENCRYPTION_KEY=
 # Initial administrator (required only when admins table is empty)
 ADMIN_BOOTSTRAP_USERNAME=
 ADMIN_BOOTSTRAP_PASSWORD=
+
+# Application Environment (e.g., development, production)
+# Controls behavior like DB query parameter logging
+APP_ENV=development
+
+# Log Level (e.g., debug, info, warn, error)
+LOGLEVEL=info
+

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -36,6 +36,8 @@ func stringToLevel(logLevelString string) slog.Leveler {
 }
 
 func main() {
+	// Load .env if exists
+	_ = godotenv.Load()
 
 	var logLevel slog.Leveler
 	logLevelString := os.Getenv("LOGLEVEL")
@@ -52,8 +54,6 @@ func main() {
 
 	slog.Info("Cornermon Backend Starting...")
 
-	// Load .env if exists
-	_ = godotenv.Load()
 	trackPINEncryptionKey, err := loadTrackPINEncryptionKey()
 	if err != nil {
 		log.Fatalf("Invalid TRACK_PIN_ENCRYPTION_KEY: %v\n", err)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -91,8 +91,22 @@ func main() {
 
 	dbctx, cancel := context.WithTimeout(backgroundCtx, 1000*time.Millisecond)
 	defer cancel()
+	// Initialize Database Pool Config
+	config, err := pgxpool.ParseConfig(dbURL)
+	if err != nil {
+		cancel()
+		log.Fatalf("Unable to parse database config: %v\n", err)
+	}
+
+	isDev := os.Getenv("APP_ENV") == "development"
+
+	config.ConnConfig.Tracer = &postgres.SlogQueryTracer{
+		SlowQueryThreshold: 500 * time.Millisecond,
+		LogParameterValues: isDev,
+	}
+
 	// Initialize Database Pool
-	pool, err := pgxpool.New(dbctx, dbURL)
+	pool, err := pgxpool.NewWithConfig(dbctx, config)
 	if err != nil {
 		cancel()
 		log.Fatalf("Unable to connect to database: %v\n", err)

--- a/backend/cmd/server/main_test.go
+++ b/backend/cmd/server/main_test.go
@@ -1,4 +1,3 @@
-
 package main
 
 import (

--- a/backend/docs/artifacts/plan/20260720_setup_pgx_tracer_plan_/01_infra_tracer.md
+++ b/backend/docs/artifacts/plan/20260720_setup_pgx_tracer_plan_/01_infra_tracer.md
@@ -1,0 +1,57 @@
+# Phase A: 인프라스트럭처 계층 구현
+
+## 1. 유즈케이스 우선 정의
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** (최우선) | UC-1: 쿼리 및 파라미터 로깅 제어 | 환경별(개발/운영)로 파라미터(Args)의 노출 여부를 제어하고 로깅 | **프로덕션 보안 / 개발 환경 디버깅** |
+| **P1** (중요) | UC-2: 슬로우 쿼리 탐지 로깅 | 일정 시간(예: 500ms) 이상 소요된 쿼리를 `Warn` 레벨로 기록 | **프로덕션 성능 모니터링** |
+| **P2** (보통) | UC-3: 쿼리 에러 로깅 | DB 쿼리 과정에서 에러 발생 시 `Error` 레벨로 기록 | **프로덕션 장애 추적** |
+
+## 2. 객체 중심 설계 (Object-Oriented Design)
+
+### 2.1 인프라스트럭처 계층: Query Tracer
+
+```go
+package postgres
+
+import (
+	"context"
+	"time"
+	"github.com/jackc/pgx/v5"
+)
+
+// 책임: pgx 쿼리의 시작과 끝을 가로채어 slog를 통해 로깅 (슬로우 쿼리, 에러, 파라미터 마스킹 지원)
+type SlogQueryTracer struct {
+	SlowQueryThreshold time.Duration
+	LogParameterValues bool // true면 파라미터 내용 노출, false면 [HIDDEN] 처리
+}
+
+func (t *SlogQueryTracer) TraceQueryStart(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryStartData) context.Context
+
+func (t *SlogQueryTracer) TraceQueryEnd(ctx context.Context, conn *pgx.Conn, data pgx.TraceQueryEndData)
+```
+
+## 3. 아키텍처 원칙 명시
+### 3.1 헥사고날 아키텍처 준수
+- **Infrastructure Layer**: PostgreSQL 커넥션 풀을 관리하는 영역(`postgres` 패키지)에 Tracer 구체적 구현체를 추가.
+
+## 4. 계층별 책임 분리
+### Infrastructure Layer
+- `backend/internal/infrastructure/postgres/tracer.go` (신규 파일)
+  - `SlogQueryTracer` 구조체와 `pgx.QueryTracer` 인터페이스 구현.
+  - 쿼리 소요 시간 측정 및 조건(에러, 슬로우 쿼리, 디버그)에 따른 분기 처리.
+  - 파라미터(`LogParameterValues`) 플래그에 따른 마스킹 처리.
+
+## 5. 구현 단계 (Implementation Phases)
+### Phase A: 인프라스트럭처 계층 구현 (예상 소요: 1시간)
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| A-1 | `SlogQueryTracer` 생성 및 인터페이스 구현 (신규) | `/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/postgres/tracer.go` |
+| A-2 | `SlogQueryTracer` 검증을 위한 단위 테스트(AAA 형식) 작성 (신규) | `/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/postgres/tracer_test.go` |
+
+## 8. 검증 체크리스트
+### 8.1 아키텍처 검증
+- [x] `domain` 패키지에 `pgx`나 `slog` 관련 내용이 추가되지 않았는가? (헥사고날 아키텍처 준수)
+- [x] 하위 계층(Repository, Usecase)에서 비즈니스 로직 처리 중 직접 로깅하지 않는다는 원칙(DEVELOPER_GUIDE 6.2)을 위반하지 않는가? (QueryTracer는 DB 드라이버 레벨의 인프라 인터셉터로 취급하여 예외적 허용 또는 최상위 미들웨어에서 취합 로깅하도록 설계 검토)
+- [x] `SlogQueryTracer`가 Infrastructure 레이어 혹은 Application 설정 레벨에 적절히 위치했는가?
+- [x] 테스트는 AAA 패턴 및 `ShouldxxxWhenyyy` 네이밍 컨벤션을 따르는가?

--- a/backend/docs/artifacts/plan/20260720_setup_pgx_tracer_plan_/02_app_main.md
+++ b/backend/docs/artifacts/plan/20260720_setup_pgx_tracer_plan_/02_app_main.md
@@ -1,0 +1,35 @@
+# Phase B: 애플리케이션 연결 (Wiring)
+
+## 1. 유즈케이스 우선 정의
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** (최우선) | UC-1: 쿼리 및 파라미터 로깅 제어 | `APP_ENV` 값에 따라 `SlogQueryTracer`의 `LogParameterValues` 필드를 동적 할당 | **프로덕션 보안 / 개발 환경 디버깅** |
+
+## 2. 객체 중심 설계 (Object-Oriented Design)
+해당 단계는 `main.go`의 설정 주입(Wiring) 부분으로, 새로운 객체를 설계하지 않음.
+
+## 3. 아키텍처 원칙 명시
+### 3.1 헥사고날 아키텍처 준수
+- **Application Layer (Main)**: 외부 의존성과 인프라스트럭처 구현체를 조립(Wiring)하는 책임만 수행.
+
+## 4. 계층별 책임 분리
+### Application Layer (Main)
+- `backend/cmd/server/main.go` (기존 파일 수정)
+  - 환경변수(`APP_ENV`)를 바탕으로 `LogParameterValues` 설정.
+  - `pgxpool.ParseConfig`를 통해 Config 객체 생성 후 Tracer 의존성 주입.
+  - `pgxpool.NewWithConfig`를 사용해 Connection Pool 초기화.
+
+## 5. 구현 단계 (Implementation Phases)
+### Phase B: 애플리케이션 연결 (예상 소요: 30분)
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| B-1 | `APP_ENV`에 따른 파라미터 로깅 여부 판별 로직 추가 (기존 파일 수정) | `/home/lsjtop10/projects/cornermon/backend/cmd/server/main.go` |
+| B-2 | DB 초기화 방식을 `pgxpool.NewWithConfig`로 변경 및 Tracer 주입 (기존 파일 수정) | `/home/lsjtop10/projects/cornermon/backend/cmd/server/main.go` |
+| B-3 | `.env.example` 파일에 `APP_ENV`, `LOGLEVEL` 예시값 주석 추가 (기존 파일 수정) | `/home/lsjtop10/projects/cornermon/backend/.env.example` |
+
+## 8. 검증 체크리스트
+### 8.2 유즈케이스 검증
+- [x] UC-1: `APP_ENV`가 `development`일 때 파라미터 값들이 `slog.Debug`로 출력되는가?
+- [x] UC-1: `APP_ENV`가 `production`일 때 파라미터 값이 마스킹(`[N parameters hidden]`) 처리되어 출력되는가?
+- [x] UC-2: 500ms 이상 지연되는 쿼리가 `Warn` 레벨로 출력되는가?
+- [x] UC-3: 쿼리 실패(에러) 시 에러 내용과 함께 쿼리가 `Error` 레벨로 출력되는가?

--- a/backend/fix_ast.go
+++ b/backend/fix_ast.go
@@ -45,7 +45,7 @@ func main() {
 
 		astutil.Apply(file, func(c *astutil.Cursor) bool {
 			n := c.Node()
-			
+
 			// Replace UnaryExpr `&domain.X{...}`
 			if un, ok := n.(*ast.UnaryExpr); ok && un.Op == token.AND {
 				if comp, ok := un.X.(*ast.CompositeLit); ok {
@@ -54,10 +54,10 @@ func main() {
 							structName := selExpr.Sel.Name
 							if !strings.HasSuffix(structName, "Props") {
 								selExpr.Sel.Name = structName + "Props"
-								
+
 								callExpr := &ast.CallExpr{
 									Fun: &ast.SelectorExpr{
-										X: &ast.Ident{Name: "domain"},
+										X:   &ast.Ident{Name: "domain"},
 										Sel: &ast.Ident{Name: "New" + structName + "FromProps"},
 									},
 									Args: []ast.Expr{comp},
@@ -70,7 +70,7 @@ func main() {
 					}
 				}
 			}
-			
+
 			// Replace CompositeLit `domain.X{...}`
 			if comp, ok := n.(*ast.CompositeLit); ok {
 				if selExpr, ok := comp.Type.(*ast.SelectorExpr); ok {
@@ -78,10 +78,10 @@ func main() {
 						structName := selExpr.Sel.Name
 						if !strings.HasSuffix(structName, "Props") {
 							selExpr.Sel.Name = structName + "Props"
-							
+
 							callExpr := &ast.CallExpr{
 								Fun: &ast.SelectorExpr{
-									X: &ast.Ident{Name: "domain"},
+									X:   &ast.Ident{Name: "domain"},
 									Sel: &ast.Ident{Name: "New" + structName + "ValFromProps"},
 								},
 								Args: []ast.Expr{comp},

--- a/backend/internal/domain/Announcement.go
+++ b/backend/internal/domain/Announcement.go
@@ -64,31 +64,32 @@ func (a *Announcement) SentAt() time.Time {
 }
 
 type AnnouncementProps struct {
-	ID AnnouncementID
+	ID          AnnouncementID
 	ChannelType MessageChannelType
-	CampID CampID
-	SenderRole SenderRole
-	Content string
-	SentAt time.Time
+	CampID      CampID
+	SenderRole  SenderRole
+	Content     string
+	SentAt      time.Time
 }
+
 func NewAnnouncementFromProps(p AnnouncementProps) *Announcement {
 	return &Announcement{
-		id: p.ID,
+		id:          p.ID,
 		channelType: p.ChannelType,
-		campID: p.CampID,
-		senderRole: p.SenderRole,
-		content: p.Content,
-		sentAt: p.SentAt,
+		campID:      p.CampID,
+		senderRole:  p.SenderRole,
+		content:     p.Content,
+		sentAt:      p.SentAt,
 	}
 }
 func NewAnnouncementValFromProps(p AnnouncementProps) Announcement {
 	return Announcement{
-		id: p.ID,
+		id:          p.ID,
 		channelType: p.ChannelType,
-		campID: p.CampID,
-		senderRole: p.SenderRole,
-		content: p.Content,
-		sentAt: p.SentAt,
+		campID:      p.CampID,
+		senderRole:  p.SenderRole,
+		content:     p.Content,
+		sentAt:      p.SentAt,
 	}
 }
 
@@ -110,24 +111,26 @@ func (r *NoteceReceipt) SetReadAt(t Optional[time.Time]) {
 
 type NoteceReceiptProps struct {
 	NoticeID AnnouncementID
-	TrackID TrackID
-	ReadAt Optional[time.Time]
+	TrackID  TrackID
+	ReadAt   Optional[time.Time]
 }
+
 func NewNoteceReceiptFromProps(p NoteceReceiptProps) *NoteceReceipt {
 	return &NoteceReceipt{
 		noticeID: p.NoticeID,
-		trackID: p.TrackID,
-		readAt: p.ReadAt,
+		trackID:  p.TrackID,
+		readAt:   p.ReadAt,
 	}
 }
 func NewNoteceReceiptValFromProps(p NoteceReceiptProps) NoteceReceipt {
 	return NoteceReceipt{
 		noticeID: p.NoticeID,
-		trackID: p.TrackID,
-		readAt: p.ReadAt,
+		trackID:  p.TrackID,
+		readAt:   p.ReadAt,
 	}
 }
 
 type AnnouncementReceiptProps = NoteceReceiptProps
+
 var NewAnnouncementReceiptFromProps = NewNoteceReceiptFromProps
 var NewAnnouncementReceiptValFromProps = NewNoteceReceiptValFromProps

--- a/backend/internal/domain/admin.go
+++ b/backend/internal/domain/admin.go
@@ -69,25 +69,26 @@ func (a *Admin) Role() AdminRole {
 }
 
 type AdminProps struct {
-	ID AdminID
-	Username string
+	ID           AdminID
+	Username     string
 	PasswordHash string
-	Role AdminRole
+	Role         AdminRole
 }
+
 func NewAdminFromProps(p AdminProps) *Admin {
 	return &Admin{
-		id: p.ID,
-		username: p.Username,
+		id:           p.ID,
+		username:     p.Username,
 		passwordHash: p.PasswordHash,
-		role: p.Role,
+		role:         p.Role,
 	}
 }
 func NewAdminValFromProps(p AdminProps) Admin {
 	return Admin{
-		id: p.ID,
-		username: p.Username,
+		id:           p.ID,
+		username:     p.Username,
 		passwordHash: p.PasswordHash,
-		role: p.Role,
+		role:         p.Role,
 	}
 }
 
@@ -120,34 +121,35 @@ func (a *AdminSession) RevokedAt() Optional[time.Time] {
 }
 
 type AdminSessionProps struct {
-	ID AdminSessionID
-	AdminID AdminID
+	ID              AdminSessionID
+	AdminID         AdminID
 	AccessTokenHash string
-	DeviceInfo string
-	CreatedAt time.Time
-	LastUsedAt time.Time
-	RevokedAt Optional[time.Time]
+	DeviceInfo      string
+	CreatedAt       time.Time
+	LastUsedAt      time.Time
+	RevokedAt       Optional[time.Time]
 }
+
 func NewAdminSessionFromProps(p AdminSessionProps) *AdminSession {
 	return &AdminSession{
-		id: p.ID,
-		adminID: p.AdminID,
+		id:              p.ID,
+		adminID:         p.AdminID,
 		accessTokenHash: p.AccessTokenHash,
-		deviceInfo: p.DeviceInfo,
-		createdAt: p.CreatedAt,
-		lastUsedAt: p.LastUsedAt,
-		revokedAt: p.RevokedAt,
+		deviceInfo:      p.DeviceInfo,
+		createdAt:       p.CreatedAt,
+		lastUsedAt:      p.LastUsedAt,
+		revokedAt:       p.RevokedAt,
 	}
 }
 func NewAdminSessionValFromProps(p AdminSessionProps) AdminSession {
 	return AdminSession{
-		id: p.ID,
-		adminID: p.AdminID,
+		id:              p.ID,
+		adminID:         p.AdminID,
 		accessTokenHash: p.AccessTokenHash,
-		deviceInfo: p.DeviceInfo,
-		createdAt: p.CreatedAt,
-		lastUsedAt: p.LastUsedAt,
-		revokedAt: p.RevokedAt,
+		deviceInfo:      p.DeviceInfo,
+		createdAt:       p.CreatedAt,
+		lastUsedAt:      p.LastUsedAt,
+		revokedAt:       p.RevokedAt,
 	}
 }
 

--- a/backend/internal/domain/admin_test.go
+++ b/backend/internal/domain/admin_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (
@@ -14,7 +13,7 @@ func TestAdminSession_Lifecycle(t *testing.T) {
 	idleTTL := 30 * time.Minute
 
 	t.Run("Session touch sliding expiration and expiry verification", func(t *testing.T) {
-		session := domain.NewAdminSessionFromProps(domain.AdminSessionProps{ID:              domain.AdminSessionID("session-1"),
+		session := domain.NewAdminSessionFromProps(domain.AdminSessionProps{ID: domain.AdminSessionID("session-1"),
 			AdminID:         domain.AdminID("admin-1"),
 			AccessTokenHash: "access-hash",
 			CreatedAt:       now,
@@ -45,7 +44,7 @@ func TestAdminSession_Lifecycle(t *testing.T) {
 	})
 
 	t.Run("Revoke and revoked session check", func(t *testing.T) {
-		session := domain.NewAdminSessionFromProps(domain.AdminSessionProps{ID:         domain.AdminSessionID("session-2"),
+		session := domain.NewAdminSessionFromProps(domain.AdminSessionProps{ID: domain.AdminSessionID("session-2"),
 			LastUsedAt: now,
 			RevokedAt:  domain.None[time.Time](),
 		})

--- a/backend/internal/domain/audit_log.go
+++ b/backend/internal/domain/audit_log.go
@@ -56,33 +56,34 @@ func (a *AuditLog) Metadata() map[string]any {
 }
 
 type AuditLogProps struct {
-	ID AuditLogID
-	Actor string
-	Action string
-	Target string
-	Success bool
+	ID         AuditLogID
+	Actor      string
+	Action     string
+	Target     string
+	Success    bool
 	OccurredAt time.Time
-	Metadata map[string]any
+	Metadata   map[string]any
 }
+
 func NewAuditLogFromProps(p AuditLogProps) *AuditLog {
 	return &AuditLog{
-		id: p.ID,
-		actor: p.Actor,
-		action: p.Action,
-		target: p.Target,
-		success: p.Success,
+		id:         p.ID,
+		actor:      p.Actor,
+		action:     p.Action,
+		target:     p.Target,
+		success:    p.Success,
 		occurredAt: p.OccurredAt,
-		metadata: p.Metadata,
+		metadata:   p.Metadata,
 	}
 }
 func NewAuditLogValFromProps(p AuditLogProps) AuditLog {
 	return AuditLog{
-		id: p.ID,
-		actor: p.Actor,
-		action: p.Action,
-		target: p.Target,
-		success: p.Success,
+		id:         p.ID,
+		actor:      p.Actor,
+		action:     p.Action,
+		target:     p.Target,
+		success:    p.Success,
 		occurredAt: p.OccurredAt,
-		metadata: p.Metadata,
+		metadata:   p.Metadata,
 	}
 }

--- a/backend/internal/domain/audit_log_test.go
+++ b/backend/internal/domain/audit_log_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (

--- a/backend/internal/domain/badge.go
+++ b/backend/internal/domain/badge.go
@@ -60,27 +60,28 @@ func (b *Badge) SetAssignedGroupID(g Optional[GroupID]) {
 }
 
 type BadgeProps struct {
-	ID BadgeID
-	ShortID string
-	QRPayload string
-	Status BadgeStatus
+	ID              BadgeID
+	ShortID         string
+	QRPayload       string
+	Status          BadgeStatus
 	AssignedGroupID Optional[GroupID]
 }
+
 func NewBadgeFromProps(p BadgeProps) *Badge {
 	return &Badge{
-		id: p.ID,
-		shortID: p.ShortID,
-		qrPayload: p.QRPayload,
-		status: p.Status,
+		id:              p.ID,
+		shortID:         p.ShortID,
+		qrPayload:       p.QRPayload,
+		status:          p.Status,
 		assignedGroupID: p.AssignedGroupID,
 	}
 }
 func NewBadgeValFromProps(p BadgeProps) Badge {
 	return Badge{
-		id: p.ID,
-		shortID: p.ShortID,
-		qrPayload: p.QRPayload,
-		status: p.Status,
+		id:              p.ID,
+		shortID:         p.ShortID,
+		qrPayload:       p.QRPayload,
+		status:          p.Status,
 		assignedGroupID: p.AssignedGroupID,
 	}
 }

--- a/backend/internal/domain/badge_test.go
+++ b/backend/internal/domain/badge_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (
@@ -10,7 +9,7 @@ import (
 
 func TestBadge_AssignTo(t *testing.T) {
 	t.Run("AssignTo on UNASSIGNED badge succeeds", func(t *testing.T) {
-		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID:     domain.BadgeID("badge-1"),
+		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID: domain.BadgeID("badge-1"),
 			Status: domain.BadgeUnassigned,
 		})
 
@@ -33,7 +32,7 @@ func TestBadge_AssignTo(t *testing.T) {
 	})
 
 	t.Run("AssignTo on ASSIGNED badge fails with ErrBadgeAlreadyAssigned", func(t *testing.T) {
-		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID:              domain.BadgeID("badge-1"),
+		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID: domain.BadgeID("badge-1"),
 			Status:          domain.BadgeAssigned,
 			AssignedGroupID: domain.Some(domain.GroupID("group-1")),
 		})
@@ -53,7 +52,7 @@ func TestBadge_AssignTo(t *testing.T) {
 
 func TestBadge_Release(t *testing.T) {
 	t.Run("Release on ASSIGNED badge succeeds", func(t *testing.T) {
-		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID:              domain.BadgeID("badge-1"),
+		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID: domain.BadgeID("badge-1"),
 			Status:          domain.BadgeAssigned,
 			AssignedGroupID: domain.Some(domain.GroupID("group-1")),
 		})
@@ -73,7 +72,7 @@ func TestBadge_Release(t *testing.T) {
 	})
 
 	t.Run("Release on UNASSIGNED badge fails with ErrBadgeNotAssigned", func(t *testing.T) {
-		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID:     domain.BadgeID("badge-1"),
+		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID: domain.BadgeID("badge-1"),
 			Status: domain.BadgeUnassigned,
 		})
 

--- a/backend/internal/domain/camp.go
+++ b/backend/internal/domain/camp.go
@@ -172,43 +172,44 @@ func (c *Camp) BottleneckRatioPct() int {
 }
 
 type CampProps struct {
-	ID CampID
-	RegistrationCode string
-	Name string
-	StartAt time.Time
-	EndAt time.Time
-	ActivatedAt Optional[time.Time]
-	EndedAt Optional[time.Time]
-	Status CampStatus
+	ID                   CampID
+	RegistrationCode     string
+	Name                 string
+	StartAt              time.Time
+	EndAt                time.Time
+	ActivatedAt          Optional[time.Time]
+	EndedAt              Optional[time.Time]
+	Status               CampStatus
 	BottleneckMinSamples int
-	BottleneckRatioPct int
+	BottleneckRatioPct   int
 }
+
 func NewCampFromProps(p CampProps) *Camp {
 	return &Camp{
-		id: p.ID,
-		registrationCode: p.RegistrationCode,
-		name: p.Name,
-		startAt: p.StartAt,
-		endAt: p.EndAt,
-		activatedAt: p.ActivatedAt,
-		endedAt: p.EndedAt,
-		status: p.Status,
+		id:                   p.ID,
+		registrationCode:     p.RegistrationCode,
+		name:                 p.Name,
+		startAt:              p.StartAt,
+		endAt:                p.EndAt,
+		activatedAt:          p.ActivatedAt,
+		endedAt:              p.EndedAt,
+		status:               p.Status,
 		bottleneckMinSamples: p.BottleneckMinSamples,
-		bottleneckRatioPct: p.BottleneckRatioPct,
+		bottleneckRatioPct:   p.BottleneckRatioPct,
 	}
 }
 func NewCampValFromProps(p CampProps) Camp {
 	return Camp{
-		id: p.ID,
-		registrationCode: p.RegistrationCode,
-		name: p.Name,
-		startAt: p.StartAt,
-		endAt: p.EndAt,
-		activatedAt: p.ActivatedAt,
-		endedAt: p.EndedAt,
-		status: p.Status,
+		id:                   p.ID,
+		registrationCode:     p.RegistrationCode,
+		name:                 p.Name,
+		startAt:              p.StartAt,
+		endAt:                p.EndAt,
+		activatedAt:          p.ActivatedAt,
+		endedAt:              p.EndedAt,
+		status:               p.Status,
 		bottleneckMinSamples: p.BottleneckMinSamples,
-		bottleneckRatioPct: p.BottleneckRatioPct,
+		bottleneckRatioPct:   p.BottleneckRatioPct,
 	}
 }
 
@@ -248,27 +249,28 @@ func (c *CampSettingsPatch) SetBottleneckRatioPct(n Optional[int]) {
 }
 
 type CampSettingsPatchProps struct {
-	Name Optional[string]
-	StartAt Optional[time.Time]
-	EndAt Optional[time.Time]
+	Name                 Optional[string]
+	StartAt              Optional[time.Time]
+	EndAt                Optional[time.Time]
 	BottleneckMinSamples Optional[int]
-	BottleneckRatioPct Optional[int]
+	BottleneckRatioPct   Optional[int]
 }
+
 func NewCampSettingsPatchFromProps(p CampSettingsPatchProps) *CampSettingsPatch {
 	return &CampSettingsPatch{
-		name: p.Name,
-		startAt: p.StartAt,
-		endAt: p.EndAt,
+		name:                 p.Name,
+		startAt:              p.StartAt,
+		endAt:                p.EndAt,
 		bottleneckMinSamples: p.BottleneckMinSamples,
-		bottleneckRatioPct: p.BottleneckRatioPct,
+		bottleneckRatioPct:   p.BottleneckRatioPct,
 	}
 }
 func NewCampSettingsPatchValFromProps(p CampSettingsPatchProps) CampSettingsPatch {
 	return CampSettingsPatch{
-		name: p.Name,
-		startAt: p.StartAt,
-		endAt: p.EndAt,
+		name:                 p.Name,
+		startAt:              p.StartAt,
+		endAt:                p.EndAt,
 		bottleneckMinSamples: p.BottleneckMinSamples,
-		bottleneckRatioPct: p.BottleneckRatioPct,
+		bottleneckRatioPct:   p.BottleneckRatioPct,
 	}
 }

--- a/backend/internal/domain/camp_test.go
+++ b/backend/internal/domain/camp_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (
@@ -40,7 +39,7 @@ func TestCamp_Activate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			camp := domain.NewCampFromProps(domain.CampProps{ID:     domain.CampID("camp-1"),
+			camp := domain.NewCampFromProps(domain.CampProps{ID: domain.CampID("camp-1"),
 				Status: tt.initialStatus,
 			})
 
@@ -98,7 +97,7 @@ func TestCamp_End(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			camp := domain.NewCampFromProps(domain.CampProps{ID:     domain.CampID("camp-1"),
+			camp := domain.NewCampFromProps(domain.CampProps{ID: domain.CampID("camp-1"),
 				Status: tt.initialStatus,
 			})
 

--- a/backend/internal/domain/corner.go
+++ b/backend/internal/domain/corner.go
@@ -72,27 +72,28 @@ func (c *Corner) IsMandatory() bool {
 }
 
 type CornerProps struct {
-	ID CornerID
-	CampID CampID
-	Name string
+	ID            CornerID
+	CampID        CampID
+	Name          string
 	TargetMinutes int
-	IsMandatory bool
+	IsMandatory   bool
 }
+
 func NewCornerFromProps(p CornerProps) *Corner {
 	return &Corner{
-		id: p.ID,
-		campID: p.CampID,
-		name: p.Name,
+		id:            p.ID,
+		campID:        p.CampID,
+		name:          p.Name,
 		targetMinutes: p.TargetMinutes,
-		isMandatory: p.IsMandatory,
+		isMandatory:   p.IsMandatory,
 	}
 }
 func NewCornerValFromProps(p CornerProps) Corner {
 	return Corner{
-		id: p.ID,
-		campID: p.CampID,
-		name: p.Name,
+		id:            p.ID,
+		campID:        p.CampID,
+		name:          p.Name,
 		targetMinutes: p.TargetMinutes,
-		isMandatory: p.IsMandatory,
+		isMandatory:   p.IsMandatory,
 	}
 }

--- a/backend/internal/domain/corner_test.go
+++ b/backend/internal/domain/corner_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (
@@ -8,7 +7,7 @@ import (
 )
 
 func TestCorner_OperationalStatus(t *testing.T) {
-	corner := domain.NewCornerFromProps(domain.CornerProps{ID:            domain.CornerID("corner-1"),
+	corner := domain.NewCornerFromProps(domain.CornerProps{ID: domain.CornerID("corner-1"),
 		TargetMinutes: 10,
 	})
 
@@ -62,7 +61,7 @@ func TestCorner_OperationalStatus(t *testing.T) {
 }
 
 func TestCorner_EffectiveTargetMinutes(t *testing.T) {
-	corner := domain.NewCornerFromProps(domain.CornerProps{ID:            domain.CornerID("corner-1"),
+	corner := domain.NewCornerFromProps(domain.CornerProps{ID: domain.CornerID("corner-1"),
 		TargetMinutes: 12,
 	})
 

--- a/backend/internal/domain/device_registration.go
+++ b/backend/internal/domain/device_registration.go
@@ -149,45 +149,46 @@ func (d *DeviceRegistration) CreatedAt() time.Time {
 }
 
 type DeviceRegistrationProps struct {
-	ID DeviceRegistrationID
-	CampID CampID
-	DeviceName string
-	DeviceModel string
-	DisplayName string
-	Status DeviceRegistrationStatus
-	TokenHash string
+	ID                DeviceRegistrationID
+	CampID            CampID
+	DeviceName        string
+	DeviceModel       string
+	DisplayName       string
+	Status            DeviceRegistrationStatus
+	TokenHash         string
 	FailedPinAttempts int
-	LockedUntil Optional[time.Time]
-	ApprovedAt Optional[time.Time]
-	CreatedAt time.Time
+	LockedUntil       Optional[time.Time]
+	ApprovedAt        Optional[time.Time]
+	CreatedAt         time.Time
 }
+
 func NewDeviceRegistrationFromProps(p DeviceRegistrationProps) *DeviceRegistration {
 	return &DeviceRegistration{
-		id: p.ID,
-		campID: p.CampID,
-		deviceName: p.DeviceName,
-		deviceModel: p.DeviceModel,
-		displayName: p.DisplayName,
-		status: p.Status,
-		tokenHash: p.TokenHash,
+		id:                p.ID,
+		campID:            p.CampID,
+		deviceName:        p.DeviceName,
+		deviceModel:       p.DeviceModel,
+		displayName:       p.DisplayName,
+		status:            p.Status,
+		tokenHash:         p.TokenHash,
 		failedPinAttempts: p.FailedPinAttempts,
-		lockedUntil: p.LockedUntil,
-		approvedAt: p.ApprovedAt,
-		createdAt: p.CreatedAt,
+		lockedUntil:       p.LockedUntil,
+		approvedAt:        p.ApprovedAt,
+		createdAt:         p.CreatedAt,
 	}
 }
 func NewDeviceRegistrationValFromProps(p DeviceRegistrationProps) DeviceRegistration {
 	return DeviceRegistration{
-		id: p.ID,
-		campID: p.CampID,
-		deviceName: p.DeviceName,
-		deviceModel: p.DeviceModel,
-		displayName: p.DisplayName,
-		status: p.Status,
-		tokenHash: p.TokenHash,
+		id:                p.ID,
+		campID:            p.CampID,
+		deviceName:        p.DeviceName,
+		deviceModel:       p.DeviceModel,
+		displayName:       p.DisplayName,
+		status:            p.Status,
+		tokenHash:         p.TokenHash,
 		failedPinAttempts: p.FailedPinAttempts,
-		lockedUntil: p.LockedUntil,
-		approvedAt: p.ApprovedAt,
-		createdAt: p.CreatedAt,
+		lockedUntil:       p.LockedUntil,
+		approvedAt:        p.ApprovedAt,
+		createdAt:         p.CreatedAt,
 	}
 }

--- a/backend/internal/domain/device_registration_test.go
+++ b/backend/internal/domain/device_registration_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (
@@ -13,7 +12,7 @@ func TestDeviceRegistration_ApproveRejectRevoke(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC)
 
 	t.Run("Approve on PENDING succeeds", func(t *testing.T) {
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:     domain.DeviceRegistrationID("device-1"),
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: domain.DeviceRegistrationID("device-1"),
 			Status: domain.DevicePending,
 		})
 
@@ -33,7 +32,7 @@ func TestDeviceRegistration_ApproveRejectRevoke(t *testing.T) {
 	})
 
 	t.Run("Approve on APPROVED fails with ErrDeviceInvalidTransition", func(t *testing.T) {
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:     domain.DeviceRegistrationID("device-1"),
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: domain.DeviceRegistrationID("device-1"),
 			Status: domain.DeviceApproved,
 		})
 
@@ -44,7 +43,7 @@ func TestDeviceRegistration_ApproveRejectRevoke(t *testing.T) {
 	})
 
 	t.Run("Reject on PENDING succeeds", func(t *testing.T) {
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:     domain.DeviceRegistrationID("device-1"),
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: domain.DeviceRegistrationID("device-1"),
 			Status: domain.DevicePending,
 		})
 
@@ -59,7 +58,7 @@ func TestDeviceRegistration_ApproveRejectRevoke(t *testing.T) {
 	})
 
 	t.Run("Reject on REJECTED fails with ErrDeviceInvalidTransition", func(t *testing.T) {
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:     domain.DeviceRegistrationID("device-1"),
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: domain.DeviceRegistrationID("device-1"),
 			Status: domain.DeviceRejected,
 		})
 
@@ -70,7 +69,7 @@ func TestDeviceRegistration_ApproveRejectRevoke(t *testing.T) {
 	})
 
 	t.Run("Revoke on APPROVED succeeds", func(t *testing.T) {
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:     domain.DeviceRegistrationID("device-1"),
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: domain.DeviceRegistrationID("device-1"),
 			Status: domain.DeviceApproved,
 		})
 
@@ -85,7 +84,7 @@ func TestDeviceRegistration_ApproveRejectRevoke(t *testing.T) {
 	})
 
 	t.Run("Revoke on PENDING fails with ErrDeviceNotApproved", func(t *testing.T) {
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:     domain.DeviceRegistrationID("device-1"),
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: domain.DeviceRegistrationID("device-1"),
 			Status: domain.DevicePending,
 		})
 
@@ -98,7 +97,7 @@ func TestDeviceRegistration_ApproveRejectRevoke(t *testing.T) {
 
 func TestDeviceRegistration_PinFailuresLockPolicies(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC)
-	device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:     domain.DeviceRegistrationID("device-1"),
+	device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: domain.DeviceRegistrationID("device-1"),
 		Status: domain.DeviceApproved,
 	})
 

--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -72,6 +72,7 @@ func (d *DeviceLockedError) LockedUntil() time.Time {
 type DeviceLockedErrorProps struct {
 	LockedUntil time.Time
 }
+
 func NewDeviceLockedErrorFromProps(p DeviceLockedErrorProps) *DeviceLockedError {
 	return &DeviceLockedError{
 		lockedUntil: p.LockedUntil,
@@ -90,6 +91,7 @@ func (i *InvalidPinError) LockedUntil() Optional[time.Time] {
 type InvalidPinErrorProps struct {
 	LockedUntil Optional[time.Time]
 }
+
 func NewInvalidPinErrorFromProps(p InvalidPinErrorProps) *InvalidPinError {
 	return &InvalidPinError{
 		lockedUntil: p.LockedUntil,

--- a/backend/internal/domain/event.go
+++ b/backend/internal/domain/event.go
@@ -37,18 +37,19 @@ func (t *TrackDeletedEvent) OccurredAt() time.Time {
 }
 
 type TrackDeletedEventProps struct {
-	TrackID TrackID
+	TrackID    TrackID
 	OccurredAt time.Time
 }
+
 func NewTrackDeletedEventFromProps(p TrackDeletedEventProps) *TrackDeletedEvent {
 	return &TrackDeletedEvent{
-		trackID: p.TrackID,
+		trackID:    p.TrackID,
 		occurredAt: p.OccurredAt,
 	}
 }
 func NewTrackDeletedEventValFromProps(p TrackDeletedEventProps) TrackDeletedEvent {
 	return TrackDeletedEvent{
-		trackID: p.TrackID,
+		trackID:    p.TrackID,
 		occurredAt: p.OccurredAt,
 	}
 }
@@ -62,18 +63,19 @@ func (t *TrackPINRegeneratedEvent) OccurredAt() time.Time {
 }
 
 type TrackPINRegeneratedEventProps struct {
-	TrackID TrackID
+	TrackID    TrackID
 	OccurredAt time.Time
 }
+
 func NewTrackPINRegeneratedEventFromProps(p TrackPINRegeneratedEventProps) *TrackPINRegeneratedEvent {
 	return &TrackPINRegeneratedEvent{
-		trackID: p.TrackID,
+		trackID:    p.TrackID,
 		occurredAt: p.OccurredAt,
 	}
 }
 func NewTrackPINRegeneratedEventValFromProps(p TrackPINRegeneratedEventProps) TrackPINRegeneratedEvent {
 	return TrackPINRegeneratedEvent{
-		trackID: p.TrackID,
+		trackID:    p.TrackID,
 		occurredAt: p.OccurredAt,
 	}
 }
@@ -87,18 +89,19 @@ func (c *CampEndedEvent) OccurredAt() time.Time {
 }
 
 type CampEndedEventProps struct {
-	CampID CampID
+	CampID     CampID
 	OccurredAt time.Time
 }
+
 func NewCampEndedEventFromProps(p CampEndedEventProps) *CampEndedEvent {
 	return &CampEndedEvent{
-		campID: p.CampID,
+		campID:     p.CampID,
 		occurredAt: p.OccurredAt,
 	}
 }
 func NewCampEndedEventValFromProps(p CampEndedEventProps) CampEndedEvent {
 	return CampEndedEvent{
-		campID: p.CampID,
+		campID:     p.CampID,
 		occurredAt: p.OccurredAt,
 	}
 }
@@ -112,18 +115,19 @@ func (t *TrackFreedEvent) OccurredAt() time.Time {
 }
 
 type TrackFreedEventProps struct {
-	TrackID TrackID
+	TrackID    TrackID
 	OccurredAt time.Time
 }
+
 func NewTrackFreedEventFromProps(p TrackFreedEventProps) *TrackFreedEvent {
 	return &TrackFreedEvent{
-		trackID: p.TrackID,
+		trackID:    p.TrackID,
 		occurredAt: p.OccurredAt,
 	}
 }
 func NewTrackFreedEventValFromProps(p TrackFreedEventProps) TrackFreedEvent {
 	return TrackFreedEvent{
-		trackID: p.TrackID,
+		trackID:    p.TrackID,
 		occurredAt: p.OccurredAt,
 	}
 }

--- a/backend/internal/domain/facilitator_session.go
+++ b/backend/internal/domain/facilitator_session.go
@@ -60,30 +60,31 @@ func (f *FacilitatorSession) MigrationTargetTrackID() Optional[TrackID] {
 }
 
 type FacilitatorSessionProps struct {
-	ID FacilitatorSessionID
-	TrackID TrackID
-	TokenHash string
-	CreatedAt time.Time
-	RevokedAt Optional[time.Time]
+	ID                     FacilitatorSessionID
+	TrackID                TrackID
+	TokenHash              string
+	CreatedAt              time.Time
+	RevokedAt              Optional[time.Time]
 	MigrationTargetTrackID Optional[TrackID]
 }
+
 func NewFacilitatorSessionFromProps(p FacilitatorSessionProps) *FacilitatorSession {
 	return &FacilitatorSession{
-		id: p.ID,
-		trackID: p.TrackID,
-		tokenHash: p.TokenHash,
-		createdAt: p.CreatedAt,
-		revokedAt: p.RevokedAt,
+		id:                     p.ID,
+		trackID:                p.TrackID,
+		tokenHash:              p.TokenHash,
+		createdAt:              p.CreatedAt,
+		revokedAt:              p.RevokedAt,
 		migrationTargetTrackID: p.MigrationTargetTrackID,
 	}
 }
 func NewFacilitatorSessionValFromProps(p FacilitatorSessionProps) FacilitatorSession {
 	return FacilitatorSession{
-		id: p.ID,
-		trackID: p.TrackID,
-		tokenHash: p.TokenHash,
-		createdAt: p.CreatedAt,
-		revokedAt: p.RevokedAt,
+		id:                     p.ID,
+		trackID:                p.TrackID,
+		tokenHash:              p.TokenHash,
+		createdAt:              p.CreatedAt,
+		revokedAt:              p.RevokedAt,
 		migrationTargetTrackID: p.MigrationTargetTrackID,
 	}
 }

--- a/backend/internal/domain/facilitator_session_test.go
+++ b/backend/internal/domain/facilitator_session_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (
@@ -13,7 +12,7 @@ func TestFacilitatorSession_Lifecycle(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC)
 
 	t.Run("New session is active and can be revoked", func(t *testing.T) {
-		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID:        domain.FacilitatorSessionID("session-1"),
+		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID: domain.FacilitatorSessionID("session-1"),
 			TrackID:   domain.TrackID("track-1"),
 			TokenHash: "token-hash",
 			CreatedAt: now,

--- a/backend/internal/domain/group.go
+++ b/backend/internal/domain/group.go
@@ -20,8 +20,8 @@ const (
 
 func (cp *CornerProgress) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		CornerID CornerID               `json:"CornerID"`
-		Status   VisitStatusPerCorner   `json:"Status"`
+		CornerID CornerID             `json:"CornerID"`
+		Status   VisitStatusPerCorner `json:"Status"`
 	}{
 		CornerID: cp.cornerID,
 		Status:   cp.status,
@@ -30,8 +30,8 @@ func (cp *CornerProgress) MarshalJSON() ([]byte, error) {
 
 func (cp *CornerProgress) UnmarshalJSON(data []byte) error {
 	var aux struct {
-		CornerID CornerID               `json:"CornerID"`
-		Status   VisitStatusPerCorner   `json:"Status"`
+		CornerID CornerID             `json:"CornerID"`
+		Status   VisitStatusPerCorner `json:"Status"`
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
@@ -136,18 +136,19 @@ func (c *CornerProgress) Status() VisitStatusPerCorner {
 
 type CornerProgressProps struct {
 	CornerID CornerID
-	Status VisitStatusPerCorner
+	Status   VisitStatusPerCorner
 }
+
 func NewCornerProgressFromProps(p CornerProgressProps) *CornerProgress {
 	return &CornerProgress{
 		cornerID: p.CornerID,
-		status: p.Status,
+		status:   p.Status,
 	}
 }
 func NewCornerProgressValFromProps(p CornerProgressProps) CornerProgress {
 	return CornerProgress{
 		cornerID: p.CornerID,
-		status: p.Status,
+		status:   p.Status,
 	}
 }
 
@@ -176,27 +177,28 @@ func (g *Group) SetItinerary(itinerary []CornerProgress) {
 }
 
 type GroupProps struct {
-	ID GroupID
-	CampID CampID
-	Name string
-	BadgeID BadgeID
+	ID        GroupID
+	CampID    CampID
+	Name      string
+	BadgeID   BadgeID
 	Itinerary []CornerProgress
 }
+
 func NewGroupFromProps(p GroupProps) *Group {
 	return &Group{
-		id: p.ID,
-		campID: p.CampID,
-		name: p.Name,
-		badgeID: p.BadgeID,
+		id:        p.ID,
+		campID:    p.CampID,
+		name:      p.Name,
+		badgeID:   p.BadgeID,
 		itinerary: p.Itinerary,
 	}
 }
 func NewGroupValFromProps(p GroupProps) Group {
 	return Group{
-		id: p.ID,
-		campID: p.CampID,
-		name: p.Name,
-		badgeID: p.BadgeID,
+		id:        p.ID,
+		campID:    p.CampID,
+		name:      p.Name,
+		badgeID:   p.BadgeID,
 		itinerary: p.Itinerary,
 	}
 }

--- a/backend/internal/domain/group_test.go
+++ b/backend/internal/domain/group_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (
@@ -10,7 +9,7 @@ import (
 
 func TestGroup_IsFinishedAndStatus(t *testing.T) {
 	t.Run("Empty itinerary is not finished and status is IDLE_MOVING", func(t *testing.T) {
-		g := domain.NewGroupFromProps(domain.GroupProps{ID:        domain.GroupID("group-1"),
+		g := domain.NewGroupFromProps(domain.GroupProps{ID: domain.GroupID("group-1"),
 			Itinerary: []domain.CornerProgress{},
 		})
 

--- a/backend/internal/domain/message.go
+++ b/backend/internal/domain/message.go
@@ -76,36 +76,37 @@ func (m *Message) SetReadAt(t Optional[time.Time]) {
 }
 
 type MessageProps struct {
-	ID MessageID
+	ID          MessageID
 	ChannelType MessageChannelType
-	CampID Optional[CampID]
-	TrackID TrackID
-	SenderRole SenderRole
-	Content string
-	SentAt time.Time
-	ReadAt Optional[time.Time]
+	CampID      Optional[CampID]
+	TrackID     TrackID
+	SenderRole  SenderRole
+	Content     string
+	SentAt      time.Time
+	ReadAt      Optional[time.Time]
 }
+
 func NewMessageFromProps(p MessageProps) *Message {
 	return &Message{
-		id: p.ID,
+		id:          p.ID,
 		channelType: p.ChannelType,
-		campID: p.CampID,
-		trackID: p.TrackID,
-		senderRole: p.SenderRole,
-		content: p.Content,
-		sentAt: p.SentAt,
-		readAt: p.ReadAt,
+		campID:      p.CampID,
+		trackID:     p.TrackID,
+		senderRole:  p.SenderRole,
+		content:     p.Content,
+		sentAt:      p.SentAt,
+		readAt:      p.ReadAt,
 	}
 }
 func NewMessageValFromProps(p MessageProps) Message {
 	return Message{
-		id: p.ID,
+		id:          p.ID,
 		channelType: p.ChannelType,
-		campID: p.CampID,
-		trackID: p.TrackID,
-		senderRole: p.SenderRole,
-		content: p.Content,
-		sentAt: p.SentAt,
-		readAt: p.ReadAt,
+		campID:      p.CampID,
+		trackID:     p.TrackID,
+		senderRole:  p.SenderRole,
+		content:     p.Content,
+		sentAt:      p.SentAt,
+		readAt:      p.ReadAt,
 	}
 }

--- a/backend/internal/domain/message_test.go
+++ b/backend/internal/domain/message_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (
@@ -11,7 +10,7 @@ func TestMessage_MarkRead(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC)
 
 	t.Run("MarkRead sets read time on first call and keeps it on subsequent calls", func(t *testing.T) {
-		msg := domain.NewMessageFromProps(domain.MessageProps{ID:         domain.MessageID("msg-1"),
+		msg := domain.NewMessageFromProps(domain.MessageProps{ID: domain.MessageID("msg-1"),
 			SenderRole: domain.RoleAdmin,
 			Content:    "hello world",
 			TrackID:    domain.TrackID("track-1"),

--- a/backend/internal/domain/notice_test.go
+++ b/backend/internal/domain/notice_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (

--- a/backend/internal/domain/optional_test.go
+++ b/backend/internal/domain/optional_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (

--- a/backend/internal/domain/registration_code_test.go
+++ b/backend/internal/domain/registration_code_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (

--- a/backend/internal/domain/track.go
+++ b/backend/internal/domain/track.go
@@ -147,41 +147,42 @@ func (tr *Track) UnreadByTrackCount() int {
 }
 
 type TrackProps struct {
-	ID TrackID
-	CornerID CornerID
-	TrackNo int
-	Status TrackStatus
-	PINHash string
-	PINCiphertext string
-	CurrentVisitID Optional[VisitID]
-	DeletedAt Optional[time.Time]
+	ID                 TrackID
+	CornerID           CornerID
+	TrackNo            int
+	Status             TrackStatus
+	PINHash            string
+	PINCiphertext      string
+	CurrentVisitID     Optional[VisitID]
+	DeletedAt          Optional[time.Time]
 	UnreadByAdminCount int
 	UnreadByTrackCount int
 }
+
 func NewTrackFromProps(p TrackProps) *Track {
 	return &Track{
-		id: p.ID,
-		cornerID: p.CornerID,
-		trackNo: p.TrackNo,
-		status: p.Status,
-		pINHash: p.PINHash,
-		pINCiphertext: p.PINCiphertext,
-		currentVisitID: p.CurrentVisitID,
-		deletedAt: p.DeletedAt,
+		id:                 p.ID,
+		cornerID:           p.CornerID,
+		trackNo:            p.TrackNo,
+		status:             p.Status,
+		pINHash:            p.PINHash,
+		pINCiphertext:      p.PINCiphertext,
+		currentVisitID:     p.CurrentVisitID,
+		deletedAt:          p.DeletedAt,
 		unreadByAdminCount: p.UnreadByAdminCount,
 		unreadByTrackCount: p.UnreadByTrackCount,
 	}
 }
 func NewTrackValFromProps(p TrackProps) Track {
 	return Track{
-		id: p.ID,
-		cornerID: p.CornerID,
-		trackNo: p.TrackNo,
-		status: p.Status,
-		pINHash: p.PINHash,
-		pINCiphertext: p.PINCiphertext,
-		currentVisitID: p.CurrentVisitID,
-		deletedAt: p.DeletedAt,
+		id:                 p.ID,
+		cornerID:           p.CornerID,
+		trackNo:            p.TrackNo,
+		status:             p.Status,
+		pINHash:            p.PINHash,
+		pINCiphertext:      p.PINCiphertext,
+		currentVisitID:     p.CurrentVisitID,
+		deletedAt:          p.DeletedAt,
 		unreadByAdminCount: p.UnreadByAdminCount,
 		unreadByTrackCount: p.UnreadByTrackCount,
 	}

--- a/backend/internal/domain/track_test.go
+++ b/backend/internal/domain/track_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (
@@ -11,7 +10,7 @@ import (
 
 func TestTrack_StartVisit(t *testing.T) {
 	t.Run("StartVisit on active idle track succeeds", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.None[domain.VisitID](),
 		})
@@ -31,7 +30,7 @@ func TestTrack_StartVisit(t *testing.T) {
 	})
 
 	t.Run("StartVisit on DELETED track fails with ErrTrackNotActive", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status:         domain.TrackDeleted,
 			CurrentVisitID: domain.None[domain.VisitID](),
 		})
@@ -43,7 +42,7 @@ func TestTrack_StartVisit(t *testing.T) {
 	})
 
 	t.Run("StartVisit on busy track fails with ErrTrackBusy", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.Some(domain.VisitID("visit-1")),
 		})
@@ -59,7 +58,7 @@ func TestTrack_CompleteVisit(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC)
 
 	t.Run("CompleteVisit on busy active track succeeds", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.Some(domain.VisitID("visit-1")),
 		})
@@ -82,7 +81,7 @@ func TestTrack_CompleteVisit(t *testing.T) {
 	})
 
 	t.Run("CompleteVisit on DELETED track fails with ErrTrackNotActive", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status:         domain.TrackDeleted,
 			CurrentVisitID: domain.Some(domain.VisitID("visit-1")),
 		})
@@ -94,7 +93,7 @@ func TestTrack_CompleteVisit(t *testing.T) {
 	})
 
 	t.Run("CompleteVisit on idle track fails with ErrTrackNotBusy", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.None[domain.VisitID](),
 		})
@@ -126,7 +125,7 @@ func TestTrack_Delete(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 30, 0, 0, time.UTC)
 
 	t.Run("Delete on idle active track succeeds", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.None[domain.VisitID](),
 		})
@@ -157,7 +156,7 @@ func TestTrack_Delete(t *testing.T) {
 	})
 
 	t.Run("Delete on busy track fails with ErrTrackDeleteBlocked", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.Some(domain.VisitID("visit-1")),
 		})
@@ -169,7 +168,7 @@ func TestTrack_Delete(t *testing.T) {
 	})
 
 	t.Run("Delete on already DELETED track fails with ErrTrackAlreadyDeleted", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:     domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status: domain.TrackDeleted,
 		})
 
@@ -184,7 +183,7 @@ func TestTrack_RegeneratePIN(t *testing.T) {
 	now := time.Date(2026, 7, 9, 15, 45, 0, 0, time.UTC)
 
 	t.Run("RegeneratePIN on active track succeeds", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:      domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status:  domain.TrackActive,
 			PINHash: "old-hash",
 		})
@@ -207,7 +206,7 @@ func TestTrack_RegeneratePIN(t *testing.T) {
 	})
 
 	t.Run("RegeneratePIN on DELETED track fails with ErrTrackNotActive", func(t *testing.T) {
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:     domain.TrackID("track-1"),
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: domain.TrackID("track-1"),
 			Status: domain.TrackDeleted,
 		})
 

--- a/backend/internal/domain/visit.go
+++ b/backend/internal/domain/visit.go
@@ -116,36 +116,37 @@ func (v *Visit) SetEndedAt(t Optional[time.Time]) {
 }
 
 type VisitProps struct {
-	ID VisitID
-	GroupID GroupID
-	CornerID CornerID
-	TrackID TrackID
-	Status VisitStatus
+	ID          VisitID
+	GroupID     GroupID
+	CornerID    CornerID
+	TrackID     TrackID
+	Status      VisitStatus
 	InputMethod VisitInputMethod
-	StartedAt time.Time
-	EndedAt Optional[time.Time]
+	StartedAt   time.Time
+	EndedAt     Optional[time.Time]
 }
+
 func NewVisitFromProps(p VisitProps) *Visit {
 	return &Visit{
-		id: p.ID,
-		groupID: p.GroupID,
-		cornerID: p.CornerID,
-		trackID: p.TrackID,
-		status: p.Status,
+		id:          p.ID,
+		groupID:     p.GroupID,
+		cornerID:    p.CornerID,
+		trackID:     p.TrackID,
+		status:      p.Status,
 		inputMethod: p.InputMethod,
-		startedAt: p.StartedAt,
-		endedAt: p.EndedAt,
+		startedAt:   p.StartedAt,
+		endedAt:     p.EndedAt,
 	}
 }
 func NewVisitValFromProps(p VisitProps) Visit {
 	return Visit{
-		id: p.ID,
-		groupID: p.GroupID,
-		cornerID: p.CornerID,
-		trackID: p.TrackID,
-		status: p.Status,
+		id:          p.ID,
+		groupID:     p.GroupID,
+		cornerID:    p.CornerID,
+		trackID:     p.TrackID,
+		status:      p.Status,
 		inputMethod: p.InputMethod,
-		startedAt: p.StartedAt,
-		endedAt: p.EndedAt,
+		startedAt:   p.StartedAt,
+		endedAt:     p.EndedAt,
 	}
 }

--- a/backend/internal/domain/visit_test.go
+++ b/backend/internal/domain/visit_test.go
@@ -1,4 +1,3 @@
-
 package domain_test
 
 import (

--- a/backend/internal/errs/error_test.go
+++ b/backend/internal/errs/error_test.go
@@ -1,4 +1,3 @@
-
 package errs_test
 
 import (

--- a/backend/internal/infrastructure/crypto/track_pin_protector_test.go
+++ b/backend/internal/infrastructure/crypto/track_pin_protector_test.go
@@ -1,4 +1,3 @@
-
 package crypto
 
 import (

--- a/backend/internal/infrastructure/postgres/corner_view_querier_test.go
+++ b/backend/internal/infrastructure/postgres/corner_view_querier_test.go
@@ -1,4 +1,3 @@
-
 package postgres
 
 import "testing"

--- a/backend/internal/infrastructure/postgres/device_registration_repo_test.go
+++ b/backend/internal/infrastructure/postgres/device_registration_repo_test.go
@@ -1,4 +1,3 @@
-
 package postgres
 
 import (

--- a/backend/internal/infrastructure/postgres/tracer.go
+++ b/backend/internal/infrastructure/postgres/tracer.go
@@ -1,0 +1,79 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// SlogQueryTracer intercepts pgx queries to log their execution time, errors, and parameters.
+type SlogQueryTracer struct {
+	SlowQueryThreshold time.Duration
+	LogParameterValues bool // If true, logs actual parameter values. If false, hides them.
+}
+
+type ctxKey string
+
+const queryDataKey ctxKey = "query_data_key"
+
+type queryData struct {
+	startTime time.Time
+	sql       string
+	args      []any
+}
+
+// TraceQueryStart is called at the beginning of a query execution.
+func (t *SlogQueryTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryStartData) context.Context {
+	return context.WithValue(ctx, queryDataKey, queryData{
+		startTime: time.Now(),
+		sql:       data.SQL,
+		args:      data.Args,
+	})
+}
+
+// TraceQueryEnd is called at the end of a query execution.
+func (t *SlogQueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data pgx.TraceQueryEndData) {
+	qd, ok := ctx.Value(queryDataKey).(queryData)
+	if !ok {
+		return
+	}
+
+	duration := time.Since(qd.startTime)
+
+	var argsToLog any
+	if t.LogParameterValues {
+		argsToLog = qd.args
+	} else if len(qd.args) > 0 {
+		argsToLog = fmt.Sprintf("[%d parameters hidden]", len(qd.args))
+	} else {
+		argsToLog = "[]"
+	}
+
+	if data.Err != nil {
+		slog.Error("Database query error",
+			"sql", qd.sql,
+			"args", argsToLog,
+			"duration", duration,
+			"error", data.Err,
+		)
+		return
+	}
+
+	if t.SlowQueryThreshold > 0 && duration > t.SlowQueryThreshold {
+		slog.Warn("Slow query detected",
+			"sql", qd.sql,
+			"args", argsToLog,
+			"duration", duration,
+		)
+		return
+	}
+
+	slog.Debug("Database query",
+		"sql", qd.sql,
+		"args", argsToLog,
+		"duration", duration,
+	)
+}

--- a/backend/internal/infrastructure/postgres/tracer_test.go
+++ b/backend/internal/infrastructure/postgres/tracer_test.go
@@ -1,0 +1,33 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func TestSlogQueryTracer_ShouldStoreDataInContext_WhenTraceQueryStartCalled(t *testing.T) {
+	// Arrange
+	tracer := &SlogQueryTracer{}
+	ctx := context.Background()
+	startData := pgx.TraceQueryStartData{
+		SQL:  "SELECT 1",
+		Args: []any{1, "test"},
+	}
+
+	// Act
+	newCtx := tracer.TraceQueryStart(ctx, nil, startData)
+
+	// Assert
+	qd, ok := newCtx.Value(queryDataKey).(queryData)
+	if !ok {
+		t.Errorf("Expected queryData to be stored in context")
+	}
+	if qd.sql != "SELECT 1" {
+		t.Errorf("Expected SQL 'SELECT 1', got %s", qd.sql)
+	}
+	if len(qd.args) != 2 {
+		t.Errorf("Expected 2 args, got %d", len(qd.args))
+	}
+}

--- a/backend/internal/infrastructure/sse/broadcaster_test.go
+++ b/backend/internal/infrastructure/sse/broadcaster_test.go
@@ -1,4 +1,3 @@
-
 package sse
 
 import (

--- a/backend/internal/infrastructure/web/admin_management_handler_test.go
+++ b/backend/internal/infrastructure/web/admin_management_handler_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (

--- a/backend/internal/infrastructure/web/camp_handler_test.go
+++ b/backend/internal/infrastructure/web/camp_handler_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (

--- a/backend/internal/infrastructure/web/corner_handler_test.go
+++ b/backend/internal/infrastructure/web/corner_handler_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (

--- a/backend/internal/infrastructure/web/error_handler_middleware_test.go
+++ b/backend/internal/infrastructure/web/error_handler_middleware_test.go
@@ -1,4 +1,3 @@
-
 package web_test
 
 import (
@@ -14,7 +13,6 @@ import (
 	"cornermon/backend/internal/infrastructure/web"
 	"github.com/labstack/echo/v4"
 )
-
 
 func TestErrorHandler_AppError(t *testing.T) {
 	// arrange
@@ -83,4 +81,3 @@ func TestErrorHandlerShouldLogErrorMsgUserAgentAndDurationMsWhenSystemErrorOccur
 		t.Error("expected stack_trace to be present for a Wrap()-ed 5xx error")
 	}
 }
-

--- a/backend/internal/infrastructure/web/event_handler_test.go
+++ b/backend/internal/infrastructure/web/event_handler_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (

--- a/backend/internal/infrastructure/web/group_handler_test.go
+++ b/backend/internal/infrastructure/web/group_handler_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (

--- a/backend/internal/infrastructure/web/health_handler_test.go
+++ b/backend/internal/infrastructure/web/health_handler_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (

--- a/backend/internal/infrastructure/web/logger_middleware_test.go
+++ b/backend/internal/infrastructure/web/logger_middleware_test.go
@@ -1,4 +1,3 @@
-
 package web_test
 
 import (

--- a/backend/internal/infrastructure/web/message_handler_test.go
+++ b/backend/internal/infrastructure/web/message_handler_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (

--- a/backend/internal/infrastructure/web/track_handler_test.go
+++ b/backend/internal/infrastructure/web/track_handler_test.go
@@ -1,4 +1,3 @@
-
 package web
 
 import (

--- a/backend/internal/usecase/admin_management_test.go
+++ b/backend/internal/usecase/admin_management_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (

--- a/backend/internal/usecase/announcement_test.go
+++ b/backend/internal/usecase/announcement_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (

--- a/backend/internal/usecase/auth_admin_test.go
+++ b/backend/internal/usecase/auth_admin_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (
@@ -78,7 +77,7 @@ func TestAdminAuthService_ValidateAccessToken(t *testing.T) {
 		// Arrange
 		now := time.Now()
 		sessions := NewMockAdminSessionRepository()
-		session := domain.NewAdminSessionFromProps(domain.AdminSessionProps{ID:              "session-1",
+		session := domain.NewAdminSessionFromProps(domain.AdminSessionProps{ID: "session-1",
 			AdminID:         "admin-1",
 			AccessTokenHash: hashSHA256("access-token-1"),
 			CreatedAt:       now.Add(-1 * time.Hour),
@@ -105,7 +104,7 @@ func TestAdminAuthService_ValidateAccessToken(t *testing.T) {
 		// Arrange
 		now := time.Now()
 		sessions := NewMockAdminSessionRepository()
-		session := domain.NewAdminSessionFromProps(domain.AdminSessionProps{ID:              "session-1",
+		session := domain.NewAdminSessionFromProps(domain.AdminSessionProps{ID: "session-1",
 			AdminID:         "admin-1",
 			AccessTokenHash: hashSHA256("access-token-1"),
 			CreatedAt:       now.Add(-13 * time.Hour),

--- a/backend/internal/usecase/auth_facilitator_test.go
+++ b/backend/internal/usecase/auth_facilitator_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (
@@ -24,7 +23,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 
 		tracks := NewMockTrackRepository()
 		pinHash, _ := hashPassword("123456")
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:       "track-1",
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1",
 			CornerID: "corner-1",
 			Status:   domain.TrackActive,
 			PINHash:  pinHash,
@@ -34,7 +33,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 		devices := NewMockDeviceRegistrationRepository()
 		deviceToken := "device-token-1"
 		deviceTokenHash := hashSHA256(deviceToken)
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:        "device-1",
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1",
 			CampID:    "camp-1",
 			Status:    domain.DeviceApproved,
 			TokenHash: deviceTokenHash,
@@ -88,7 +87,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 
 		tracks := NewMockTrackRepository()
 		pinHash, _ := hashPassword("123456")
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:       "track-1",
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1",
 			CornerID: "corner-1",
 			Status:   domain.TrackActive,
 			PINHash:  pinHash,
@@ -98,7 +97,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 		devices := NewMockDeviceRegistrationRepository()
 		deviceToken := "device-token-1"
 		deviceTokenHash := hashSHA256(deviceToken)
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:        "device-1",
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1",
 			CampID:    "camp-1",
 			Status:    domain.DevicePending,
 			TokenHash: deviceTokenHash,
@@ -133,7 +132,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 
 		tracks := NewMockTrackRepository()
 		pinHash, _ := hashPassword("123456")
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:       "track-1",
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1",
 			CornerID: "corner-1",
 			Status:   domain.TrackActive,
 			PINHash:  pinHash,
@@ -143,7 +142,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 		devices := NewMockDeviceRegistrationRepository()
 		deviceToken := "device-token-1"
 		deviceTokenHash := hashSHA256(deviceToken)
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:          "device-1",
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1",
 			CampID:      "camp-1",
 			Status:      domain.DeviceApproved,
 			TokenHash:   deviceTokenHash,
@@ -179,7 +178,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 
 		tracks := NewMockTrackRepository()
 		pinHash, _ := hashPassword("123456")
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:       "track-1",
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1",
 			CornerID: "corner-1",
 			Status:   domain.TrackActive,
 			PINHash:  pinHash,
@@ -189,7 +188,7 @@ func TestFacilitatorAuthService_Login(t *testing.T) {
 		devices := NewMockDeviceRegistrationRepository()
 		deviceToken := "device-token-1"
 		deviceTokenHash := hashSHA256(deviceToken)
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:                "device-1",
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1",
 			CampID:            "camp-1",
 			Status:            domain.DeviceApproved,
 			TokenHash:         deviceTokenHash,

--- a/backend/internal/usecase/camp_test.go
+++ b/backend/internal/usecase/camp_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (
@@ -110,7 +109,7 @@ func TestCampService_EndCamp(t *testing.T) {
 		camps.Save(context.Background(), camp)
 
 		sessions := NewMockFacilitatorSessionRepository()
-		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID:        "session-1",
+		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID: "session-1",
 			TrackID:   "track-1",
 			TokenHash: "token-hash-1",
 			CreatedAt: now,

--- a/backend/internal/usecase/corner_test.go
+++ b/backend/internal/usecase/corner_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (

--- a/backend/internal/usecase/device_trust_test.go
+++ b/backend/internal/usecase/device_trust_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (
@@ -110,7 +109,7 @@ func TestDeviceTrustService_ApproveDevice(t *testing.T) {
 		now := time.Now()
 		camps := NewMockCampRepository()
 		devices := NewMockDeviceRegistrationRepository()
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID:     "device-1",
+		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1",
 			CampID: "camp-1",
 			Status: domain.DevicePending,
 		})

--- a/backend/internal/usecase/group_test.go
+++ b/backend/internal/usecase/group_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (
@@ -24,7 +23,7 @@ func TestGroupService_RegisterBadge(t *testing.T) {
 		corners.Save(context.Background(), corner2)
 
 		badges := NewMockBadgeRepository()
-		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID:              "badge-1",
+		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID: "badge-1",
 			ShortID:         "B1",
 			QRPayload:       "qr-1",
 			Status:          domain.BadgeUnassigned,
@@ -71,7 +70,7 @@ func TestGroupService_RegisterBadge(t *testing.T) {
 		camps.Save(context.Background(), camp)
 
 		badges := NewMockBadgeRepository()
-		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID:        "badge-1",
+		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID: "badge-1",
 			QRPayload: "qr-1",
 			Status:    domain.BadgeUnassigned,
 		})

--- a/backend/internal/usecase/list_views_test.go
+++ b/backend/internal/usecase/list_views_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (

--- a/backend/internal/usecase/message_test.go
+++ b/backend/internal/usecase/message_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (

--- a/backend/internal/usecase/mock_test.go
+++ b/backend/internal/usecase/mock_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (

--- a/backend/internal/usecase/report_test.go
+++ b/backend/internal/usecase/report_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (

--- a/backend/internal/usecase/snapshot_test.go
+++ b/backend/internal/usecase/snapshot_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (

--- a/backend/internal/usecase/track_test.go
+++ b/backend/internal/usecase/track_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (
@@ -96,7 +95,7 @@ func TestTrackService_DeleteTrack(t *testing.T) {
 		corners.Save(context.Background(), corner)
 
 		tracks := NewMockTrackRepository()
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             "track-1",
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1",
 			CornerID:       "corner-1",
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.None[domain.VisitID](),
@@ -104,7 +103,7 @@ func TestTrackService_DeleteTrack(t *testing.T) {
 		tracks.Save(context.Background(), track)
 
 		sessions := NewMockFacilitatorSessionRepository()
-		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID:        "session-1",
+		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID: "session-1",
 			TrackID:   "track-1",
 			TokenHash: "hash-1",
 			CreatedAt: now,
@@ -153,7 +152,7 @@ func TestTrackService_DeleteTrack(t *testing.T) {
 		camps := NewMockCampRepository()
 		corners := NewMockCornerRepository()
 		tracks := NewMockTrackRepository()
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             "track-1",
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1",
 			CornerID:       "corner-1",
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.Some[domain.VisitID]("visit-1"),

--- a/backend/internal/usecase/visit_test.go
+++ b/backend/internal/usecase/visit_test.go
@@ -1,4 +1,3 @@
-
 package usecase
 
 import (
@@ -22,7 +21,7 @@ func TestVisitService_StartVisitByQR(t *testing.T) {
 		corners.Save(context.Background(), corner)
 
 		tracks := NewMockTrackRepository()
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             "track-1",
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1",
 			CornerID:       "corner-1",
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.None[domain.VisitID](),
@@ -30,7 +29,7 @@ func TestVisitService_StartVisitByQR(t *testing.T) {
 		tracks.Save(context.Background(), track)
 
 		badges := NewMockBadgeRepository()
-		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID:              "badge-1",
+		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID: "badge-1",
 			QRPayload:       "qr-payload-1",
 			Status:          domain.BadgeAssigned,
 			AssignedGroupID: domain.Some[domain.GroupID]("group-1"),
@@ -38,7 +37,7 @@ func TestVisitService_StartVisitByQR(t *testing.T) {
 		badges.Save(context.Background(), badge)
 
 		groups := NewMockGroupRepository()
-		group := domain.NewGroupFromProps(domain.GroupProps{ID:      "group-1",
+		group := domain.NewGroupFromProps(domain.GroupProps{ID: "group-1",
 			CampID:  "camp-1",
 			BadgeID: "badge-1",
 			Itinerary: []domain.CornerProgress{
@@ -50,7 +49,7 @@ func TestVisitService_StartVisitByQR(t *testing.T) {
 		sessions := NewMockFacilitatorSessionRepository()
 		sessionToken := "session-token-1"
 		tokenHash := hashSHA256(sessionToken)
-		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID:        "session-1",
+		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID: "session-1",
 			TrackID:   "track-1",
 			TokenHash: tokenHash,
 			CreatedAt: now,
@@ -121,7 +120,7 @@ func TestVisitService_StartVisitByQR(t *testing.T) {
 		sessions := NewMockFacilitatorSessionRepository()
 		sessionToken := "session-token-2"
 		tokenHash := hashSHA256(sessionToken)
-		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID:        "session-2",
+		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID: "session-2",
 			TrackID:   "track-1",
 			TokenHash: tokenHash,
 			CreatedAt: now,
@@ -154,7 +153,7 @@ func TestVisitService_StartVisitByQR(t *testing.T) {
 
 		corners := NewMockCornerRepository()
 		tracks := NewMockTrackRepository()
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             "track-1",
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1",
 			CornerID:       "corner-1",
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.Some[domain.VisitID]("visit-0"),
@@ -162,7 +161,7 @@ func TestVisitService_StartVisitByQR(t *testing.T) {
 		tracks.Save(context.Background(), track)
 
 		badges := NewMockBadgeRepository()
-		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID:              "badge-1",
+		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID: "badge-1",
 			QRPayload:       "qr-payload-1",
 			Status:          domain.BadgeAssigned,
 			AssignedGroupID: domain.Some[domain.GroupID]("group-1"),
@@ -170,7 +169,7 @@ func TestVisitService_StartVisitByQR(t *testing.T) {
 		badges.Save(context.Background(), badge)
 
 		groups := NewMockGroupRepository()
-		group := domain.NewGroupFromProps(domain.GroupProps{ID:      "group-1",
+		group := domain.NewGroupFromProps(domain.GroupProps{ID: "group-1",
 			CampID:  "camp-1",
 			BadgeID: "badge-1",
 			Itinerary: []domain.CornerProgress{
@@ -182,7 +181,7 @@ func TestVisitService_StartVisitByQR(t *testing.T) {
 		sessions := NewMockFacilitatorSessionRepository()
 		sessionToken := "session-token-3"
 		tokenHash := hashSHA256(sessionToken)
-		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID:        "session-3",
+		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID: "session-3",
 			TrackID:   "track-1",
 			TokenHash: tokenHash,
 			CreatedAt: now,
@@ -213,7 +212,7 @@ func TestVisitService_CompleteVisit(t *testing.T) {
 		camps := NewMockCampRepository()
 		corners := NewMockCornerRepository()
 		tracks := NewMockTrackRepository()
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             "track-1",
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1",
 			CornerID:       "corner-1",
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.Some[domain.VisitID]("visit-1"),
@@ -221,7 +220,7 @@ func TestVisitService_CompleteVisit(t *testing.T) {
 		tracks.Save(context.Background(), track)
 
 		groups := NewMockGroupRepository()
-		group := domain.NewGroupFromProps(domain.GroupProps{ID:     "group-1",
+		group := domain.NewGroupFromProps(domain.GroupProps{ID: "group-1",
 			CampID: "camp-1",
 			Itinerary: []domain.CornerProgress{
 				domain.NewCornerProgressValFromProps(domain.CornerProgressProps{CornerID: "corner-1", Status: domain.VisitInProgress}),
@@ -236,7 +235,7 @@ func TestVisitService_CompleteVisit(t *testing.T) {
 		sessions := NewMockFacilitatorSessionRepository()
 		sessionToken := "session-token-1"
 		tokenHash := hashSHA256(sessionToken)
-		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID:        "session-1",
+		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID: "session-1",
 			TrackID:   "track-1",
 			TokenHash: tokenHash,
 			CreatedAt: now,
@@ -292,7 +291,7 @@ func TestVisitService_CompleteVisit(t *testing.T) {
 		camps := NewMockCampRepository()
 		corners := NewMockCornerRepository()
 		tracks := NewMockTrackRepository()
-		track := domain.NewTrackFromProps(domain.TrackProps{ID:             "track-1",
+		track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1",
 			CornerID:       "corner-1",
 			Status:         domain.TrackActive,
 			CurrentVisitID: domain.None[domain.VisitID](),
@@ -302,7 +301,7 @@ func TestVisitService_CompleteVisit(t *testing.T) {
 		sessions := NewMockFacilitatorSessionRepository()
 		sessionToken := "session-token-1"
 		tokenHash := hashSHA256(sessionToken)
-		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID:        "session-1",
+		session := domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{ID: "session-1",
 			TrackID:   "track-1",
 			TokenHash: tokenHash,
 			CreatedAt: now,


### PR DESCRIPTION
## 변경 사항 및 이유
인프라스트럭처 레벨(PostgreSQL)에서 실행되는 쿼리의 소요 시간, 실패, 파라미터 등을 로깅하기 위해 pgx/v5의 QueryTracer를 도입했습니다.

## 구현 상세
-  구현 및 500ms 이상 소요 시 슬로우 쿼리(Warn) 로깅 추가
- 환경변수(`APP_ENV`)에 따라 운영 환경에서는 쿼리 파라미터가 마스킹 되도록 처리하여 보안 강화
- 에서 를 통해 커스텀 Tracer 의존성 주입

## 종료 조건 증명
- 쿼리 트레이서 구현 및 테스트 통과
- 파라미터 숨김 처리 로직 구현 확인
- 모든 검증 체크리스트 자체 검토 완료