### PR TITLE
feat: 진행자(TrackAuth) 코너 조회 엔드포인트 신설

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -2350,6 +2350,40 @@ paths:
       summary: 트랙 교체 (비상용)
       tags:
       - B. Resource Management (Admin)
+  /tracks/{trackId}/corner:
+    get:
+      description: 인증된 진행자(TrackAuth)의 트랙이 속한 코너의 핵심 정보를 조회한다. 세션의 트랙과 path trackId가
+        일치해야 한다. 다른 트랙의 활성 목록·병목 지표 등 관리자 전용 정보는 포함하지 않는다.
+      parameters:
+      - description: 트랙 ID
+        in: path
+        name: trackId
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/CornerResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "403":
+          description: 세션 트랙과 요청 트랙 불일치
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: 트랙 또는 코너 없음
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - TrackAuth: []
+      summary: 진행자 코너 조회
+      tags:
+      - C. Visit (Scan Flow)
   /tracks/{trackId}/groups:
     get:
       description: 인증된 진행자의 트랙이 속한 캠프의 조 목록을 반환한다. 세션의 트랙과 path trackId가 일치해야 한다.

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -137,7 +137,7 @@ func main() {
 	authAdminService := usecase.NewAdminAuthService(adminRepo, adminSessionRepo, facilitatorSessionRepo, trackRepo, cornerRepo, broadcaster, auditLogRepo, txManager)
 
 	deviceTrustService := usecase.NewDeviceTrustService(campRepo, deviceRepo, auditLogRepo, broadcaster, txManager)
-	cornerService := usecase.NewCornerService(campRepo, cornerRepo, auditLogRepo, broadcaster, txManager)
+	cornerService := usecase.NewCornerService(campRepo, cornerRepo, trackRepo, auditLogRepo, broadcaster, txManager)
 	cornerViewQuerier := postgres.NewCornerViewQuerier(pool)
 	groupService := usecase.NewGroupService(campRepo, cornerRepo, trackRepo, groupRepo, badgeRepo, visitRepo, auditLogRepo, txManager)
 	badgeService := usecase.NewBadgeService(badgeRepo, groupRepo, auditLogRepo, txManager)

--- a/backend/internal/infrastructure/web/corner_handler.go
+++ b/backend/internal/infrastructure/web/corner_handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"net/http"
 
 	"cornermon/backend/internal/domain"
@@ -141,6 +142,38 @@ func (h *CornerHandler) GetCorner(c echo.Context) error {
 		return domain.ErrCornerNotFound
 	}
 	return c.JSON(http.StatusOK, mapCornerViewToDTO(*view))
+}
+
+// @Summary      진행자 코너 조회
+// @Description  인증된 진행자(TrackAuth)의 트랙이 속한 코너의 핵심 정보를 조회한다. 세션의 트랙과 path trackId가 일치해야 한다. 다른 트랙의 활성 목록·병목 지표 등 관리자 전용 정보는 포함하지 않는다.
+// @Tags         C. Visit (Scan Flow)
+// @Security     TrackAuth
+// @Produce      json
+// @Param        trackId path string true "트랙 ID"
+// @Success      200 {object} CornerResponse
+// @Failure      401 {object} ErrorResponse
+// @Failure      403 {object} ErrorResponse "세션 트랙과 요청 트랙 불일치"
+// @Failure      404 {object} ErrorResponse "트랙 또는 코너 없음"
+// @Router       /tracks/{trackId}/corner [get]
+func (h *CornerHandler) GetCornerByTrack(c echo.Context) error {
+	session, ok := c.Get("facilitatorSession").(*domain.FacilitatorSession)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: "unauthorized"})
+	}
+
+	trackID := domain.TrackID(c.Param("trackId"))
+	if session.TrackID() != trackID {
+		return echo.NewHTTPError(http.StatusForbidden, ErrorResponse{Code: "FORBIDDEN", Message: domain.ErrTrackScopeForbidden.Error()}).SetInternal(domain.ErrTrackScopeForbidden)
+	}
+
+	corner, err := h.svc.GetCornerByTrack(c.Request().Context(), trackID)
+	if err != nil {
+		if errors.Is(err, domain.ErrTrackNotFound) || errors.Is(err, domain.ErrCornerNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "NOT_FOUND", Message: err.Error()}).SetInternal(err)
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
+	}
+	return c.JSON(http.StatusOK, mapDomainCornerToDTO(corner))
 }
 
 // @Summary      코너 삭제

--- a/backend/internal/infrastructure/web/corner_handler_test.go
+++ b/backend/internal/infrastructure/web/corner_handler_test.go
@@ -94,6 +94,95 @@ func TestGetCornerShouldReturnViewAndNotFound(t *testing.T) {
 	})
 }
 
+func TestGetCornerByTrackShouldReturnCornerWhenSessionTrackMatchesPath(t *testing.T) {
+	// Arrange
+	corner := domain.NewCornerFromProps(domain.CornerProps{ID: "corner-1", CampID: "camp-1", Name: "코너 1", TargetMinutes: 10})
+	track := domain.NewTrackFromProps(domain.TrackProps{ID: "track-1", CornerID: "corner-1"})
+	service := usecase.NewCornerService(
+		nil,
+		cornerRepoForGroupHandler{corner: corner},
+		trackRepoForGroupHandler{track: track},
+		nil, nil, nil,
+	)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/tracks/track-1/corner", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/tracks/:trackId/corner")
+	c.SetParamNames("trackId")
+	c.SetParamValues("track-1")
+	c.Set("facilitatorSession", domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{TrackID: "track-1"}))
+
+	// Act
+	err := NewCornerHandler(service, nil).GetCornerByTrack(c)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body := rec.Body.String()
+	if rec.Code != http.StatusOK || !containsAll(body, `"id":"corner-1"`, `"targetMinutes":10`) || strings.Contains(body, `"activeTracks":[{`) {
+		t.Fatalf("expected minimal corner response, status=%d body=%s", rec.Code, body)
+	}
+}
+
+func TestGetCornerByTrackShouldRejectRequestWhenSessionTrackDiffers(t *testing.T) {
+	// Arrange
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/tracks/track-2/corner", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/tracks/:trackId/corner")
+	c.SetParamNames("trackId")
+	c.SetParamValues("track-2")
+	c.Set("facilitatorSession", domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{TrackID: "track-1"}))
+
+	// Act
+	err := NewCornerHandler(nil, nil).GetCornerByTrack(c)
+
+	// Assert
+	var httpErr *echo.HTTPError
+	if !errorsAsHTTPError(err, &httpErr) || httpErr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 Forbidden HTTPError, got %v", err)
+	}
+}
+
+func TestGetCornerByTrackShouldReturnNotFoundWhenTrackMissing(t *testing.T) {
+	// Arrange
+	service := usecase.NewCornerService(
+		nil,
+		cornerRepoForGroupHandler{},
+		trackRepoForGroupHandler{},
+		nil, nil, nil,
+	)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/tracks/track-1/corner", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetPath("/tracks/:trackId/corner")
+	c.SetParamNames("trackId")
+	c.SetParamValues("track-1")
+	c.Set("facilitatorSession", domain.NewFacilitatorSessionFromProps(domain.FacilitatorSessionProps{TrackID: "track-1"}))
+
+	// Act
+	err := NewCornerHandler(service, nil).GetCornerByTrack(c)
+
+	// Assert
+	var httpErr *echo.HTTPError
+	if !errorsAsHTTPError(err, &httpErr) || httpErr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 NotFound HTTPError, got %v", err)
+	}
+}
+
+func errorsAsHTTPError(err error, target **echo.HTTPError) bool {
+	he, ok := err.(*echo.HTTPError)
+	if !ok {
+		return false
+	}
+	*target = he
+	return true
+}
+
 func containsAll(value string, parts ...string) bool {
 	for _, part := range parts {
 		if !strings.Contains(value, part) {

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -147,6 +147,9 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 	if h.Group != nil {
 		track.GET("/tracks/:trackId/groups", h.Group.ListGroupsByTrack)
 	}
+	if h.Corner != nil {
+		track.GET("/tracks/:trackId/corner", h.Corner.GetCornerByTrack)
+	}
 
 	// ── C. Visit ──
 	if h.Visit != nil {

--- a/backend/internal/usecase/corner.go
+++ b/backend/internal/usecase/corner.go
@@ -12,6 +12,7 @@ import (
 type CornerService struct {
 	camps       CampRepository
 	corners     CornerRepository
+	tracks      TrackRepository
 	auditLogs   AuditLogRepository
 	broadcaster Broadcaster
 	tx          TxManager
@@ -23,6 +24,7 @@ type CornerService struct {
 func NewCornerService(
 	camps CampRepository,
 	corners CornerRepository,
+	tracks TrackRepository,
 	auditLogs AuditLogRepository,
 	broadcaster Broadcaster,
 	tx TxManager,
@@ -30,6 +32,7 @@ func NewCornerService(
 	return &CornerService{
 		camps:       camps,
 		corners:     corners,
+		tracks:      tracks,
 		auditLogs:   auditLogs,
 		broadcaster: broadcaster,
 		tx:          tx,
@@ -77,6 +80,28 @@ func (s *CornerService) ListCorners(ctx context.Context, campID domain.CampID) (
 // GetCorner
 func (s *CornerService) GetCorner(ctx context.Context, id domain.CornerID) (*domain.Corner, error) {
 	corner, err := s.corners.Get(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if corner == nil {
+		return nil, domain.ErrCornerNotFound
+	}
+	return corner, nil
+}
+
+// GetCornerByTrack derives the corner from the track's immutable corner
+// assignment — for TrackAuth (진행자) callers, who may only see their own
+// track's corner, never another track's admin-facing detail.
+func (s *CornerService) GetCornerByTrack(ctx context.Context, trackID domain.TrackID) (*domain.Corner, error) {
+	track, err := s.tracks.Get(ctx, trackID)
+	if err != nil {
+		return nil, err
+	}
+	if track == nil {
+		return nil, domain.ErrTrackNotFound
+	}
+
+	corner, err := s.corners.Get(ctx, track.CornerID())
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/usecase/corner_test.go
+++ b/backend/internal/usecase/corner_test.go
@@ -13,7 +13,7 @@ func TestCornerServiceCommandRegression(t *testing.T) {
 	camps := NewMockCampRepository()
 	_ = camps.Save(ctx, domain.NewCampFromProps(domain.CampProps{ID: "camp-1", Status: domain.CampPending}))
 	corners := NewMockCornerRepository()
-	service := NewCornerService(camps, corners, &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+	service := NewCornerService(camps, corners, NewMockTrackRepository(), &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
 	service.uuidFn = func() string { return "corner-1" }
 
 	created, err := service.AddLearningCorner(ctx, "camp-1", "처음 이름")
@@ -32,5 +32,53 @@ func TestCornerServiceCommandRegression(t *testing.T) {
 	deleted, err := corners.Get(ctx, created.ID())
 	if err != nil || deleted != nil {
 		t.Fatalf("corner should be deleted: corner=%+v err=%v", deleted, err)
+	}
+}
+
+func TestGetCornerByTrackShouldReturnCornerWhenTrackAndCornerExist(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	corners := NewMockCornerRepository()
+	_ = corners.Save(ctx, domain.NewCornerFromProps(domain.CornerProps{ID: "corner-1", CampID: "camp-1", Name: "코너 1"}))
+	tracks := NewMockTrackRepository()
+	_ = tracks.Save(ctx, domain.NewTrackFromProps(domain.TrackProps{ID: "track-1", CornerID: "corner-1"}))
+	service := NewCornerService(NewMockCampRepository(), corners, tracks, &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+
+	// Act
+	corner, err := service.GetCornerByTrack(ctx, "track-1")
+
+	// Assert
+	if err != nil || corner == nil || corner.ID() != "corner-1" {
+		t.Fatalf("expected corner-1, got corner=%+v err=%v", corner, err)
+	}
+}
+
+func TestGetCornerByTrackShouldReturnTrackNotFoundWhenTrackMissing(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	service := NewCornerService(NewMockCampRepository(), NewMockCornerRepository(), NewMockTrackRepository(), &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+
+	// Act
+	corner, err := service.GetCornerByTrack(ctx, "missing-track")
+
+	// Assert
+	if err != domain.ErrTrackNotFound || corner != nil {
+		t.Fatalf("expected ErrTrackNotFound, got corner=%+v err=%v", corner, err)
+	}
+}
+
+func TestGetCornerByTrackShouldReturnCornerNotFoundWhenCornerMissing(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	tracks := NewMockTrackRepository()
+	_ = tracks.Save(ctx, domain.NewTrackFromProps(domain.TrackProps{ID: "track-1", CornerID: "missing-corner"}))
+	service := NewCornerService(NewMockCampRepository(), NewMockCornerRepository(), tracks, &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+
+	// Act
+	corner, err := service.GetCornerByTrack(ctx, "track-1")
+
+	// Assert
+	if err != domain.ErrCornerNotFound || corner != nil {
+		t.Fatalf("expected ErrCornerNotFound, got corner=%+v err=%v", corner, err)
 	}
 }

--- a/docs/artifacts/plan/20260720_진행자_코너조회_엔드포인트_plan_.md
+++ b/docs/artifacts/plan/20260720_진행자_코너조회_엔드포인트_plan_.md
@@ -1,0 +1,188 @@
+# 진행자(TrackAuth) 코너 조회 엔드포인트 신설 계획
+
+## 0. 배경
+
+이슈 #109 워크트리 QA 중 발견: 진행자 앱 `main_track_screen.dart`가 코너 목표시간(`targetMinutes`)을
+`GET /corners/{id}` (AdminAuth 전용)로 조회하고 있어, 트랙 세션(토큰)으로 호출 시 `401 session not found`가
+발생한다. 로그인은 정상, 다른 TrackAuth 엔드포인트도 모두 정상 — 세션 버그가 아니라 **API 계약 공백**이다.
+
+- `/auth/track/login` 응답(`TrackLoginResponse.corner`)은 이미 `CornerResponse` 전체(= `targetMinutes` 포함)를
+  내려주므로, 로그인 시점 값은 별도 호출 없이 `session.corner.targetMinutes`로 바로 쓸 수 있다.
+- 다만 트랙 세션은 무만료(§2.4)이고, 관리자가 캠프 진행 중 코너의 `targetMinutes`를 바꿀 수 있으므로
+  로그인 시점 스냅샷만으로는 부족하다.
+- 백엔드는 코너 변경 시 `EventCornersUpdated`(`scope: camp`)를 브로드캐스트하는데,
+  `BroadcasterImpl.Broadcast`가 캠프 스코프 이벤트를 **해당 캠프의 모든 트랙 구독자에게도** 전달한다
+  (`backend/internal/infrastructure/sse/broadcaster.go:49-52`). 즉 진행자의 `/events/track/{trackId}` 스트림에도
+  이미 `corners_updated`가 도달하고 있다 — 프론트가 `track_event_coordinator.dart:63`에서
+  "관리자 전용 알림"이라는 주석과 함께 명시적으로 무시하고 있을 뿐이다.
+- 그래서 실시간 갱신을 하려던 원작성자가 `GET /corners/{id}`를 끌어다 썼지만 TrackAuth로는 호출할 수 없는
+  엔드포인트였다 — 이 계획은 **TrackAuth로 자기 트랙의 코너를 조회할 수 있는 전용 엔드포인트**를 신설해
+  이 공백을 메운다.
+
+## 1. 유즈케이스 우선 정의
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-TC-1: 진행자 코너 초기 조회 | 진행자가 화면 진입 시(또는 `corners_updated` 수신 후) 자기 트랙이 속한 코너 정보를 TrackAuth로 조회한다 | **프로덕션 핵심 로직** |
+| **P0** | UC-TC-2: 트랙 스코프 강제 | 세션의 `trackId`와 URL의 `trackId`가 다르면 403으로 거부한다 | **보안 경계** |
+| **P0** | UC-TC-3: 실시간 목표시간 갱신 | 관리자가 코너의 `targetMinutes`를 바꾸면 `corners_updated` 이벤트로 진행자 화면이 재조회한다 | **프로덕션 핵심 로직** |
+| P1 | UC-TC-4: 관리자 코너 API 회귀 방지 | 기존 `/corners/{id}` (AdminAuth), `/camps/{campId}/corners` 계약과 동작은 변경하지 않는다 | 회귀 방지 |
+| P1 | UC-TC-5: 크로스 트랙 정보 비노출 | 새 응답에는 다른 트랙의 활성 목록(`activeTracks`)이나 병목 지표(`isBottleneck`, `cornerMetric`) 등 관리자 전용 분석 정보를 담지 않는다 | **보안/정보 최소화** |
+
+## 2. 현재 코드 분석과 결정
+
+- 기준 계약은 `api/swagger.yaml`. `CornerResponse` 스키마(1951행 부근)는 이미 존재하며
+  `mapDomainCornerToDTO`(`backend/internal/infrastructure/web/corner_handler.go`)가 `id/campId/name/targetMinutes/status`만
+  채우고 `activeTracks`·`cornerMetric`은 비워둔다 — 이게 그대로 UC-TC-5가 요구하는 "안전한 최소 응답"이다.
+  새 DTO를 만들지 않고 **기존 `CornerResponse` + `mapDomainCornerToDTO`를 재사용**한다.
+- `GET /tracks/{trackId}/groups` (`backend/internal/usecase/group.go:126-148`,
+  `backend/internal/infrastructure/web/group_handler.go:86-99`)가 정확히 같은 모양의 선례다:
+  `TrackRepository.Get` → `track.CornerID()` → `CornerRepository.Get` 순으로 기존 포트만 재사용하고,
+  핸들러에서 `facilitatorSession.TrackID()`와 path `trackId`를 비교해 불일치 시 `domain.ErrTrackScopeForbidden`(403)을
+  반환한다. 이 계획도 동일한 패턴을 그대로 따른다.
+- `CornerService`(`backend/internal/usecase/corner.go`)에는 아직 `TrackRepository` 의존성이 없다.
+  `GroupService`처럼 필드를 추가하고 `NewCornerService` 생성자 시그니처를 확장해야 한다
+  (`cmd/server/main.go`의 호출부 갱신 필요).
+- 읽기 전용 조회이므로 감사 로그 대상이 아니다(`ListGroupsByTrack`과 동일 판단).
+- 프론트는 `session.corner`(로그인 응답)로 초기값을 즉시 렌더링하고, 새 엔드포인트는 **`corners_updated` 수신 시
+  재조회하는 용도로만** 쓴다. 화면 진입 시마다 매번 호출할 필요는 없다(로그인 스냅샷이 이미 최신이므로).
+
+## 3. 객체·메서드 설계
+
+### Backend
+
+```go
+// backend/internal/usecase/corner.go — CornerService에 필드 추가
+type CornerService struct {
+    camps       CampRepository
+    corners     CornerRepository
+    tracks      TrackRepository // 신규
+    auditLogs   AuditLogRepository
+    broadcaster Broadcaster
+    tx          TxManager
+    // ...
+}
+
+// 책임: 트랙의 불변 corner 귀속을 통해 해당 코너를 반환한다(ListGroupsByTrack과 동일 패턴).
+func (s *CornerService) GetCornerByTrack(
+    ctx context.Context,
+    trackID domain.TrackID,
+) (*domain.Corner, error)
+```
+
+```go
+// backend/internal/infrastructure/web/corner_handler.go
+// 책임: TrackAuth 세션과 path trackId 일치를 검증하고 기존 CornerResponse(mapDomainCornerToDTO)로 변환한다.
+// @Security TrackAuth
+// @Router   /tracks/{trackId}/corner [get]
+func (h *CornerHandler) GetCornerByTrack(c echo.Context) error
+```
+
+- 없는 트랙/코너: 기존 `domain.ErrTrackNotFound` / `domain.ErrCornerNotFound` (404) 재사용.
+- 세션/path 불일치: 기존 `domain.ErrTrackScopeForbidden` (403) 재사용.
+- 응답 매핑은 `mapDomainCornerToDTO(corner)` 그대로 사용 — `activeTracks`/`cornerMetric` 없이 나간다.
+
+### Frontend
+
+```dart
+// frontend/lib/shared/api/providers/corner_track_providers.dart (기존 파일 확장)
+// 책임: TrackAuth로 자기 트랙의 코너를 조회한다. cornerDetailProvider(AdminAuth 전용)와 별개 provider.
+@riverpod
+Future<Corner> trackCorner(Ref ref, TrackId trackId) async {
+  final apiInstance = ref.watch(trackApiProvider); // 신규 또는 기존 track-scoped api provider
+  final response = await apiInstance.tracksTrackIdCornerGet(trackId: trackId.value);
+  ...
+}
+```
+
+```dart
+// frontend/lib/facilitator/features/main_track/track_event_coordinator.dart
+// SseEventEventEnum.cornersUpdated 분기 추가 — scope.kind == camp일 때 trackCornerProvider(trackId) invalidate
+```
+
+```dart
+// frontend/lib/facilitator/features/main_track/main_track_screen.dart
+// cornerDetailProvider(admin) 호출 제거.
+// 1) 초기값: session.corner.targetMinutes (로그인 스냅샷, 즉시 사용 가능)
+// 2) trackCornerProvider(trackId) watch 결과가 있으면 그 값으로 덮어쓴다(실시간 갱신 반영)
+```
+
+## 4. 구현 단계
+
+### Phase A: 백엔드 서비스 (예상 1시간)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| A-1 | `CornerService`에 `TrackRepository` 의존성 추가, `GetCornerByTrack` 구현 | `backend/internal/usecase/corner.go` (기존 파일 확장) |
+| A-2 | `NewCornerService` 호출부에 `tracks` 인자 추가 | `backend/cmd/server/main.go` (기존 파일 확장) |
+
+### Phase B: 백엔드 HTTP·계약 (예상 1시간)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| B-1 | `GET /tracks/:trackId/corner`를 TrackAuth 그룹(`track := v1.Group("")`)에 등록 | `backend/internal/infrastructure/web/router.go` (기존 파일 확장) |
+| B-2 | 세션/path 일치 검증 + `mapDomainCornerToDTO` 응답 핸들러 구현 (`ListGroupsByTrack` 패턴 그대로) | `backend/internal/infrastructure/web/corner_handler.go` (기존 파일 확장) |
+| B-3 | Swag annotation 추가, `api/swagger.yaml`/`swagger.json`/`docs.go` 재생성 (`workflow/Collaborate.md`) | `api/swagger.yaml` 등 (생성 갱신) |
+
+### Phase C: 백엔드 검증 (예상 30분~1시간)
+
+- `GetCornerByTrack`: 정상 조회, 트랙/코너 없음(404) 테스트
+- 핸들러: 세션-path 일치 200, 불일치 403 테스트 (`group_handler_test.go` 스타일)
+- 기존 `/corners/{id}`, `/camps/{campId}/corners` 회귀 테스트
+- `go test ./...`, `go test -race ./internal/usecase ./internal/infrastructure/web`
+
+### Phase D: 프론트 API 클라이언트 갱신 (예상 30분)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| D-1 | 백엔드 반영된 `api/swagger.yaml` 기준으로 `openapi-generator` 재실행 | `frontend/lib/shared/api/gen/**` (생성) |
+| D-2 | `dart run build_runner build` 직후 `gen` 패키지 `.g.dart` 삭제 여부 확인·복구 (`frontend/docs/DEVELOPER_GUIDE.md` 알려진 이슈) | `frontend/lib/shared/api/gen/**` |
+
+### Phase E: 프론트 화면 연동 (예상 1~1.5시간)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| E-1 | `trackCornerProvider(trackId)` 추가 (TrackAuth 클라이언트로 신규 엔드포인트 호출) | `frontend/lib/shared/api/providers/corner_track_providers.dart` (기존 파일 확장) |
+| E-2 | `track_event_coordinator.dart`에 `cornersUpdated` 분기 추가(camp scope → `ref.invalidate(trackCornerProvider(trackId))`) | `frontend/lib/facilitator/features/main_track/track_event_coordinator.dart` (기존 파일 확장) |
+| E-3 | `main_track_screen.dart`에서 `cornerDetailProvider` 제거, `session.corner.targetMinutes` 초기값 + `trackCornerProvider` watch로 대체 | `frontend/lib/facilitator/features/main_track/main_track_screen.dart` (기존 파일 확장) |
+
+### Phase F: 프론트 검증 (예상 30분~1시간)
+
+- 위젯 테스트: 로그인 스냅샷 값이 즉시 표시되는지, `corners_updated` 수신 후 갱신되는지
+- 실기기/시뮬레이터: 관리자 앱에서 코너 `targetMinutes` 변경 → 진행자 화면에 반영되는지 수동 확인
+- 기존 `cornerDetailProvider`(관리자 코너 상세 화면) 사용처는 그대로 유지되는지 회귀 확인
+
+## 5. 검증 체크리스트
+
+- [x] TrackAuth 세션은 자기 `trackId` 경로만 호출할 수 있다 (403 검증) — `corner_handler_test.go` `ShouldRejectRequestWhenSessionTrackDiffers`
+- [x] 없는 트랙/코너는 404 — `corner_handler_test.go` `ShouldReturnNotFoundWhenTrackMissing`, `corner_test.go` 3종
+- [x] 새 응답에 `activeTracks`/`cornerMetric`/`isBottleneck` 등 관리자 전용 정보가 없다 — `mapDomainCornerToDTO` 재사용, 위젯 테스트에서 `activeTracks` 미포함 단언
+- [x] 기존 `/corners/{id}` (AdminAuth), `/camps/{campId}/corners` 동작 불변 — 해당 핸들러/라우팅 미수정
+- [x] `CornerService`의 모든 메서드 첫 인자가 `context.Context`
+- [x] `router.go`와 Swag annotation이 일치 — `api/swagger.yaml`에 `/tracks/{trackId}/corner` 수기 반영(아래 한계 참고)
+- [x] 진행자 화면이 화면 진입 시 TrackAuth로 최신 `targetMinutes`를 조회하고, 응답 전에는 로그인 스냅샷을 임시로 보여준다(§2 UC-TC-1 기준으로 "로그인 직후 별도 호출 없이"에서 조정 — 아래 3번 참고)
+- [x] 관리자가 코너 목표시간을 바꾸면 진행자 화면이 SSE로 갱신됨 — `track_event_coordinator_test.dart`로 단위 검증(실기기 수동 확인은 미실시, 아래 한계 참고)
+- [x] `build_runner` 실행 후 `lib/shared/api/gen` 삭제 여부 확인·복구 — 삭제되지 않았음, 새 엔드포인트 관련 3개 파일만 변경됨을 확인
+- [x] `flutter test` 전체 152개 통과, `dart analyze` 이슈 없음
+- [ ] `go test ./...` — 이 환경에 Go 툴체인이 없어 실행하지 못함(아래 한계 참고)
+
+## 6. 구현 결과 및 자체 리뷰
+
+**백엔드** (별도 워크트리 `issue-109-track-corner-lookup-backend`, 브랜치 `worktree-issue-109-track-corner-lookup-backend`, `origin/main` 기준):
+- Plan대로 `CornerService.GetCornerByTrack`, `GET /tracks/{trackId}/corner` 핸들러, 라우팅을 추가했다.
+- **한 가지 계획에서 벗어난 판단**: Plan은 `ListGroupsByTrack`처럼 바깥에서 `domain.ErrTrackScopeForbidden`/`ErrTrackNotFound`를 그대로 반환하는 패턴을 선례로 들었지만, 실제로 그 패턴은 `error_handler_middleware.go`가 domain sentinel을 매핑하지 않아 403/404가 아니라 500으로 응답되는 것으로 보인다(`group_handler_test.go`도 핸들러의 반환값 동일성만 확인하고 실제 HTTP status는 검증하지 않음). 대신 이 파일의 다른 메서드들(`ListCorners`, `CreateCorner` 등)이 이미 쓰고 있는 "핸들러에서 `echo.NewHTTPError`로 명시 매핑" 관례를 따라 403/404가 실제로 응답되도록 구현했다. `ListGroupsByTrack` 자체는 이번 스코프 밖이라 손대지 않았다.
+- **`backend/docs/DEVELOPER_GUIDE.md` §4.2와의 불일치 발견**: 가이드는 "핸들러는 usecase 에러를 그대로 리턴하고 `ErrorHandler()`가 중앙에서 domain sentinel과 `echo.HTTPError`를 구분해 매핑한다"고 명시하지만, 실제 `error_handler_middleware.go`는 `*echo.HTTPError`만 처리하고 domain sentinel 매핑 로직이 없다(위 항목과 동일 원인). 즉 이 가이드 문서가 아직 구현되지 않은 의도된 설계를 서술하고 있거나, 관련 리팩터를 하다 만 상태로 보인다 — 기존 코드(`corner_handler.go`의 다른 메서드, `admin_management_handler.go`, `device_handler.go`)는 전부 핸들러-로컬 매핑을 쓰고 있어 이번 구현도 그 실제 관례를 따랐다. 이 스코프에서 `ErrorHandler()` 중앙화를 새로 구현하지는 않았다 — 관련 파일이 많고 별도 작업 단위이므로, 팀에 별도 이슈로 공유할 것을 제안한다.
+- Go 툴체인이 이 환경에 설치돼 있지 않아 `go build`/`go test`를 실행하지 못했다. 기존에 통과하던 동일 패턴(`group_handler_test.go`)을 그대로 모사했고, 코드를 여러 번 재검토했지만 **머지 전 `go test ./...`와 `go vet` 실행을 별도로 확인해야 한다.**
+- `api/swagger.yaml`은 `swag init`(Go 툴체인 필요) 대신 손으로 동일한 스타일의 경로 블록을 추가했다. `api/swagger.json`, `api/docs.go`는 건드리지 않았다 — 대량의 생성 파일을 손으로 잘못 고치는 위험이 더 크다고 판단했다. **머지 전 `make -C backend` 또는 `swag init` 재실행으로 `swagger.json`/`docs.go`를 동기화해야 한다.**
+
+**프론트엔드** (워크트리 `issue-109-device-registration-frontend`):
+- `api/swagger.yaml`에 동일한 경로를 반영한 뒤 `openapi-generator`로 클라이언트를 재생성했다. 초기 재생성 시 전체 70여 개 파일에서 `// @dart=2.18` pragma가 사라지는 노이즈가 발생해(환경/버전 차이로 추정) 새 엔드포인트 관련 3개 파일 외에는 복원해 diff를 최소화했다.
+- `trackCornerProvider` 추가, `track_event_coordinator.dart`에 `corners_updated`(camp scope) 분기 추가, `main_track_screen.dart`에서 `cornerDetailProvider`(AdminAuth) 제거.
+- **Plan 대비 조정**: Plan 1절 UC-TC-1은 "화면 진입 시(또는 corners_updated 수신 후)" 조회를 P0로 명시했으나, 3절 코드 스니펫과 5절 체크리스트 초안은 "로그인 스냅샷을 초기값으로, SSE 수신 시에만 재조회"로 더 좁게 적어 서로 어긋나 있었다. 트랙 세션이 무만료라는 점(로그인이 며칠 전이었을 수 있음)을 고려해 UC-TC-1 원안대로 화면 진입 시에도 `trackCornerProvider`를 watch하도록 구현했다 — 응답 전 첫 프레임만 로그인 스냅샷을 임시로 보여준다.
+- `dart analyze lib/` 이슈 없음, `flutter test` 152개 전체 통과(회귀 없음).
+- 실기기로 "관리자가 목표시간 변경 → 진행자 화면 반영"을 직접 확인하지는 못했다 — `track_event_coordinator_test.dart`의 단위 테스트로 이벤트 분기 로직만 검증했다.
+
+**남은 일 (머지 전 필수)**:
+1. Go 툴체인이 있는 환경에서 백엔드 `go build ./... && go test ./...`, `go vet ./...` 실행.
+2. `swag init` (또는 `make` 타겟)으로 `api/swagger.json`/`api/docs.go` 재생성해 손으로 편집한 `api/swagger.yaml`과 동기화.
+3. 백엔드 PR 머지 후, 프론트 PR에서 실제 서버로 로그인→코너 조회→관리자 목표시간 변경 시나리오 수동 확인.

--- a/docs/artifacts/plan/20260720_진행자_코너조회_엔드포인트_plan_.md
+++ b/docs/artifacts/plan/20260720_진행자_코너조회_엔드포인트_plan_.md
@@ -182,7 +182,14 @@ Future<Corner> trackCorner(Ref ref, TrackId trackId) async {
 - `dart analyze lib/` 이슈 없음, `flutter test` 152개 전체 통과(회귀 없음).
 - 실기기로 "관리자가 목표시간 변경 → 진행자 화면 반영"을 직접 확인하지는 못했다 — `track_event_coordinator_test.dart`의 단위 테스트로 이벤트 분기 로직만 검증했다.
 
-**남은 일 (머지 전 필수)**:
-1. Go 툴체인이 있는 환경에서 백엔드 `go build ./... && go test ./...`, `go vet ./...` 실행.
-2. `swag init` (또는 `make` 타겟)으로 `api/swagger.json`/`api/docs.go` 재생성해 손으로 편집한 `api/swagger.yaml`과 동기화.
+**남은 일 (머지 전 필수) — 사용자 결정: 이 세션/환경에서는 실행하지 않고 PR 리뷰로 위임**:
+
+이 작업 환경에는 Go 툴체인이 없고, 사용자가 OrbStack/Docker를 통한 컨테이너 실행도 보류하기로
+결정했다("여기서 백엔드를 정 테스트하고 싶다면 orbstack + docker를 이용해서 테스트해" → 이후 "백엔드는
+별도 PR로 올려줘. 검토해볼게"). 따라서 아래 항목은 이 세션에서 완료된 작업이 아니라, 백엔드
+PR(https://github.com/lsjtop10/cornermon/pull/138)의 리뷰/CI 단계에서 확인되어야 할 항목으로
+명시적으로 넘긴다:
+
+1. Go 툴체인이 있는 환경에서 백엔드 `go build ./... && go test ./...`, `go vet ./...` 실행. — PR #138 본문에 미완료 체크박스로 기재됨.
+2. `swag init` (또는 `make` 타겟)으로 `api/swagger.json`/`api/docs.go` 재생성해 손으로 편집한 `api/swagger.yaml`과 동기화. — PR #138 본문에 미완료 체크박스로 기재됨.
 3. 백엔드 PR 머지 후, 프론트 PR에서 실제 서버로 로그인→코너 조회→관리자 목표시간 변경 시나리오 수동 확인.


### PR DESCRIPTION
## Summary
- 이슈 #109 프론트 워크트리 QA 중 발견: 진행자 앱이 코너 목표시간(targetMinutes)을 조회하려면 `GET /corners/{id}` (AdminAuth 전용)를 호출해야 했음 — TrackAuth 세션으로는 401 "session not found"가 나는 API 계약 공백.
- `GET /tracks/{trackId}/corner` (TrackAuth)를 신설. `GET /tracks/:trackId/groups`(`ListGroupsByTrack`)와 동일한 track→corner 스코프 도출 패턴을 그대로 따름.
- 응답은 기존 `mapDomainCornerToDTO`를 재사용 — `activeTracks`/`cornerMetric`/`isBottleneck` 등 관리자 전용/크로스 트랙 정보는 나가지 않음.
- 세션-path 트랙 불일치는 403, 트랙/코너 없음은 404로 핸들러에서 명시 매핑(`corner_handler.go`의 다른 메서드들과 동일 관례).
- `api/swagger.yaml`에 계약 반영 (`workflow/Collaborate.md` 프로토콜).

## Test plan
- [x] `usecase` 유닛 테스트 3종: 정상 조회 / 트랙 없음(404) / 코너 없음(404)
- [x] `web` 핸들러 테스트 3종: 세션-path 일치 200(관리자 전용 필드 미포함 확인) / 불일치 403 / 트랙 없음 404
- [ ] `go build ./...`, `go test ./...`, `go vet ./...` — 이 환경에 Go 툴체인이 없어 작성자가 직접 실행하지 못함. 리뷰어가 확인 필요.
- [ ] `swag init` 재실행으로 `api/swagger.json`/`api/docs.go`를 `api/swagger.yaml`과 동기화 필요 (이번 PR은 `swagger.yaml`만 수기 반영).
- 상세 계획/자체 리뷰: `docs/artifacts/plan/20260720_진행자_코너조회_엔드포인트_plan_.md`

관련 프론트엔드 변경은 별도 워크트리(`issue-109-device-registration-frontend`)에서 이 API 계약을 소비하도록 진행 중.