### PR TITLE
fix: 관리자 조 추가 시 QR 스캔 콜백으로 인한 앱 강제종료 수정

### DIFF
--- a/frontend/docs/artifacts/plan/20260720_issue139_group_add_scan_crash_plan_.md
+++ b/frontend/docs/artifacts/plan/20260720_issue139_group_add_scan_crash_plan_.md
@@ -24,9 +24,34 @@ QR 스캔 탭 `MobileScanner.onDetect` 콜백이 `mounted` 가드 없이 `setSta
    이름을 허용해 `_submit()`의 `trim().isEmpty` 체크와 불일치하던 부분을
    `trim()`으로 통일.
 
+## 추가 조치: 카메라 QR 스캔에 의존하지 않는 직접 입력 경로
+
+`mounted` 가드를 추가한 뒤에도 실기기에서 크래시가 재현되었다. 관리자 앱과 진행자
+앱은 같은 iOS `Runner` 프로젝트를 공유하는데, `Info.plist`에 `NSCameraUsageDescription`이
+없어(#140에서 확인된 것과 동일한 원인) 카메라 권한 API를 건드리는 즉시 iOS TCC가
+프로세스를 중단시키는 것으로 추정된다. 이 plist 수정은 `fix/140-facilitator-scan-freeze`
+브랜치에만 있고 아직 main에 병합되지 않았다. 근본 수정(#140 병합)과 별개로, 관리자가
+카메라 없이도 조를 등록할 수 있는 경로를 추가한다.
+
+1. `_RegisterGroupDialog`의 탭을 3개로 확장: `카메라 QR` / `목록에서 선택` /
+   `직접 입력`. `직접 입력` 탭은 `_payload` 컨트롤러에 바로 연결된 `TextField`로,
+   배지 스티커에 인쇄된 ID를 타이핑해 입력할 수 있다.
+2. `badge_sticker_pdf.dart`의 스티커에 기존 `shortId` 아래 `qrPayload`(실제
+   `scan-register` API가 요구하는 값)를 작은 글씨로 추가 인쇄. `직접 입력` 탭에서
+   타이핑할 수 있는 값은 `shortId`가 아니라 `qrPayload`이므로(백엔드 `ScanAssignBadgeRequest`
+   스키마에 `qrPayload` 필드만 존재, `shortId`는 없음) 반드시 이 값을 스티커에 노출해야
+   실제로 대체 입력 수단이 된다.
+
 ## 검증
 
-- `flutter analyze lib/admin/features/group_list/group_list_screen.dart`
-- 수동 시나리오(에뮬레이터/실기기): QR 스캔 탭에서 코드 인식 직후 곧바로 다이얼로그를
-  닫거나 탭을 전환해도 강제종료가 발생하지 않는지 확인.
-- API 계약 변경 없음 (프론트엔드 전용 수정).
+- `flutter analyze lib/admin/features/group_list/group_list_screen.dart
+  lib/admin/features/badge_precreate/badge_sticker_pdf.dart` — No issues found
+- `flutter test test/admin/features/badge_precreate/badge_sticker_pdf_test.dart` — 통과
+  (기존 테스트는 PDF magic bytes만 검증하므로 텍스트 추가로 깨지지 않음)
+- 수동 시나리오(에뮬레이터/실기기):
+  - QR 스캔 탭에서 코드 인식 직후 곧바로 다이얼로그를 닫거나 탭을 전환해도
+    강제종료가 발생하지 않는지 확인
+  - '직접 입력' 탭에서 스티커에 인쇄된 ID를 타이핑해 조 등록이 정상 동작하는지 확인
+  - 배지 스티커 PDF에 shortId와 qrPayload가 모두 출력되는지 확인
+- API 계약 변경 없음 (프론트엔드 전용 수정, 기존 `POST /badges/scan-register`
+  스키마 그대로 사용).

--- a/frontend/docs/artifacts/plan/20260720_issue139_group_add_scan_crash_plan_.md
+++ b/frontend/docs/artifacts/plan/20260720_issue139_group_add_scan_crash_plan_.md
@@ -1,0 +1,32 @@
+# Issue #139: 관리자 조 관리 - 조 추가 시 앱 강제종료
+
+## 원인
+
+`_RegisterGroupDialog`(`lib/admin/features/group_list/group_list_screen.dart`)의
+QR 스캔 탭 `MobileScanner.onDetect` 콜백이 `mounted` 가드 없이 `setState`를 호출한다.
+
+`mobile_scanner`는 `dispose()`에서 `super.dispose()`를 먼저 호출한 뒤 스트림 구독을
+비동기로(unawaited) 취소하므로, 다이얼로그가 닫히는 순간(등록 확정 성공 후 `Navigator.pop`,
+또는 탭 전환)과 카메라가 이미 큐에 쌓아둔 프레임 감지 콜백이 겹치면 위젯이 unmount된
+이후에 `setState`가 호출된다. `main_admin.dart`에는 `runZonedGuarded`/`FlutterError.onError`
+등 전역 에러 핸들러가 없어 이 예외가 그대로 앱을 강제종료시킨다.
+
+같은 파일의 `_submit()`은 await 이후 모든 상태 변경을 `mounted` 체크로 감싸는데
+(212, 216, 222행), `onDetect` 콜백만 누락되어 있었다.
+
+## 해결 방안
+
+1. `onDetect` 콜백 시작부에 `if (!mounted || _scanned) return;` 가드 추가.
+   - `!mounted`: unmount 이후 들어오는 감지 콜백을 무시해 크래시를 차단.
+   - `_scanned`: 이미 코드를 인식한 이후 초당 여러 번 들어오는 중복 감지에 대해
+     불필요한 `setState` 재실행을 막음.
+2. (부수 수정) '등록 확정' 버튼 활성화 조건이 `_name.text.isEmpty`로 공백만 있는
+   이름을 허용해 `_submit()`의 `trim().isEmpty` 체크와 불일치하던 부분을
+   `trim()`으로 통일.
+
+## 검증
+
+- `flutter analyze lib/admin/features/group_list/group_list_screen.dart`
+- 수동 시나리오(에뮬레이터/실기기): QR 스캔 탭에서 코드 인식 직후 곧바로 다이얼로그를
+  닫거나 탭을 전환해도 강제종료가 발생하지 않는지 확인.
+- API 계약 변경 없음 (프론트엔드 전용 수정).

--- a/frontend/lib/admin/features/badge_precreate/badge_sticker_pdf.dart
+++ b/frontend/lib/admin/features/badge_precreate/badge_sticker_pdf.dart
@@ -12,7 +12,7 @@ Future<Uint8List> buildBadgeStickerPdf(List<api.Badge> badges) async {
       build: (_) => [
         pw.GridView(
           crossAxisCount: 3,
-          childAspectRatio: .9,
+          childAspectRatio: 1.1,
           children: [
             for (final badge in badges)
               pw.Container(

--- a/frontend/lib/admin/features/badge_precreate/badge_sticker_pdf.dart
+++ b/frontend/lib/admin/features/badge_precreate/badge_sticker_pdf.dart
@@ -33,6 +33,11 @@ Future<Uint8List> buildBadgeStickerPdf(List<api.Badge> badges) async {
                       badge.shortId ?? badge.id ?? '',
                       style: pw.TextStyle(fontSize: 12),
                     ),
+                    pw.SizedBox(height: 2),
+                    pw.Text(
+                      badge.qrPayload ?? badge.id ?? '',
+                      style: pw.TextStyle(fontSize: 7),
+                    ),
                   ],
                 ),
               ),

--- a/frontend/lib/admin/features/group_list/group_list_screen.dart
+++ b/frontend/lib/admin/features/group_list/group_list_screen.dart
@@ -250,6 +250,7 @@ class _RegisterGroupDialogState extends ConsumerState<_RegisterGroupDialog> {
                     ? Center(child: Text('QR 인식 완료: ${_payload.text}'))
                     : MobileScanner(
                         onDetect: (capture) {
+                          if (!mounted || _scanned) return;
                           final token = capture.barcodes.firstOrNull?.rawValue;
                           if (token != null) {
                             setState(() {
@@ -301,7 +302,10 @@ class _RegisterGroupDialogState extends ConsumerState<_RegisterGroupDialog> {
           variant: AppButtonVariant.primary,
           size: AppButtonSize.compact,
           label: '등록 확정',
-          onPressed: _busy || _payload.text.isEmpty || _name.text.isEmpty
+          onPressed:
+              _busy ||
+                  _payload.text.trim().isEmpty ||
+                  _name.text.trim().isEmpty
               ? null
               : _submit,
         ),

--- a/frontend/lib/admin/features/group_list/group_list_screen.dart
+++ b/frontend/lib/admin/features/group_list/group_list_screen.dart
@@ -237,6 +237,7 @@ class _RegisterGroupDialogState extends ConsumerState<_RegisterGroupDialog> {
               segments: const [
                 ButtonSegment(value: 0, label: Text('카메라 QR')),
                 ButtonSegment(value: 1, label: Text('목록에서 선택')),
+                ButtonSegment(value: 2, label: Text('직접 입력')),
               ],
               selected: {_tab},
               onSelectionChanged: (value) =>
@@ -261,7 +262,7 @@ class _RegisterGroupDialogState extends ConsumerState<_RegisterGroupDialog> {
                         },
                       ),
               )
-            else
+            else if (_tab == 1)
               SizedBox(
                 height: 180,
                 child: badges.when(
@@ -282,6 +283,15 @@ class _RegisterGroupDialogState extends ConsumerState<_RegisterGroupDialog> {
                         ),
                     ],
                   ),
+                ),
+              )
+            else
+              TextField(
+                controller: _payload,
+                onChanged: (_) => setState(() {}),
+                decoration: const InputDecoration(
+                  labelText: '배지 ID',
+                  hintText: 'QR 코드 아래 인쇄된 ID를 입력하세요',
                 ),
               ),
             if (_payload.text.isNotEmpty)


### PR DESCRIPTION
## 원인

`_RegisterGroupDialog`(`frontend/lib/admin/features/group_list/group_list_screen.dart`)의
QR 스캔 탭에서 `MobileScanner.onDetect` 콜백이 `mounted` 가드 없이 `setState`를 호출했습니다.

`mobile_scanner`는 `dispose()`에서 `super.dispose()`를 먼저 실행한 뒤 스트림 구독을
비동기로(unawaited) 취소합니다. 따라서 다이얼로그가 닫히는 순간(등록 확정 성공 후
`Navigator.pop`, 또는 카메라 QR ↔ 목록에서 선택 탭 전환)과 카메라가 이미 큐에 쌓아둔
프레임 감지 콜백이 겹치면, 위젯이 unmount된 이후 `setState`가 호출되어 예외가 발생합니다.
`main_admin.dart`에는 `runZonedGuarded`/`FlutterError.onError` 같은 전역 에러 핸들러가
없어 이 예외가 그대로 앱을 강제종료시켰습니다.

이 가드를 추가한 뒤에도 실기기에서 크래시가 계속 재현되었습니다. 관리자 앱은
진행자 앱과 같은 iOS `Runner` 프로젝트를 공유하는데, `Info.plist`에
`NSCameraUsageDescription`이 없어(#140에서 확인된 원인과 동일) 카메라 권한 API를
건드리는 즉시 iOS TCC가 프로세스를 중단시키는 것으로 추정됩니다. 이 plist 수정은
`fix/140-facilitator-scan-freeze` 브랜치에만 있고 아직 main에 병합되지 않았습니다.

## 해결 방안

1. `onDetect` 콜백에 `if (!mounted || _scanned) return;` 가드 추가
   - `!mounted`: unmount 이후 들어오는 감지 콜백을 무시해 크래시 차단
   - `_scanned`: 코드 인식 이후 초당 여러 번 들어오는 중복 감지에 대한 불필요한
     `setState` 재실행 방지
2. (부수 수정) '등록 확정' 버튼 활성화 조건을 `_submit()`과 동일하게 `trim()` 기준으로
   통일 (공백만 있는 이름으로 버튼이 활성화되던 불일치 제거)
3. **카메라에 의존하지 않는 대체 입력 경로 추가** — 근본 원인(#140의 Info.plist 수정)이
   main에 병합되기 전에도 관리자가 조를 등록할 수 있도록:
   - 조 등록 다이얼로그에 `직접 입력` 탭 추가 — 배지 스티커에 인쇄된 ID를 타이핑해
     입력 가능
   - 배지 스티커 PDF(`badge_sticker_pdf.dart`)에 기존 `shortId` 아래 `qrPayload`
     (실제 `scan-register` API가 요구하는 값)를 텍스트로 추가 인쇄. `shortId`는
     백엔드 `ScanAssignBadgeRequest` 스키마에 없는 필드라 직접 입력에 쓸 수 없으므로
     `qrPayload`를 노출해야 실질적인 대체 수단이 됩니다.
4. **배지 스티커 PDF에서 텍스트가 전혀 렌더링되지 않던 사전 존재 버그 수정** —
   `qrPayload` 텍스트를 추가하려다 발견했습니다. `GridView(childAspectRatio: .9)`로
   계산된 셀 높이(약 159pt)가 `Container` margin(12) + padding(16) + QR 바코드(110) +
   텍스트 줄 높이의 합을 근소하게 초과하고 있었고, `pdf` 패키지의 `GridView`는 셀에
   tight 제약을 주기 때문에 `Column`이 그 높이 안에 자식을 다 배치하지 못하면 넘치는
   `Text`를 조용히 그리지 않습니다(에러/경고 없음). 실제로는 `qrPayload` 추가 이전,
   `shortId` 한 줄짜리 원래 코드에서도 동일하게 텍스트가 전혀 렌더링되고 있지 않았습니다.
   PDF 콘텐츠 스트림을 직접 압축 해제해 텍스트 표시 연산자(`TJ`)가 없다는 것을 확인한
   뒤 `childAspectRatio`를 `1.1`로 늘려 해결했고, 다시 압축 해제해 `TJ`가 정상적으로
   나타나는 것을 확인했습니다.

API 계약 변경 없음 — 순수 프론트엔드 버그이며, 기존 `POST /badges/scan-register`
요청/응답 스펙(`qrPayload`, `groupName` in; `Group` out)을 그대로 사용합니다.

## 검증

- [x] `dart analyze lib/admin/features/group_list/group_list_screen.dart
      lib/admin/features/badge_precreate/badge_sticker_pdf.dart` — No issues found
- [x] `flutter test test/admin/features/badge_precreate/badge_sticker_pdf_test.dart` — 통과
- [x] 생성된 PDF의 압축 해제된 콘텐츠 스트림에서 `TJ` 연산자(텍스트 표시)가 정상적으로
      나타나는지 직접 확인 (shortId 한 줄만 있던 원래 코드와, qrPayload 두 번째 줄을
      추가한 새 코드 양쪽 모두 재현/검증)
- [ ] 실기기/에뮬레이터에서 QR 스캔 직후 곧바로 다이얼로그를 닫거나 탭을 전환해도
      강제종료가 발생하지 않는지 수동 확인 필요
- [ ] '직접 입력' 탭에서 스티커에 인쇄된 ID로 조 등록이 정상 동작하는지 수동 확인 필요
- [ ] 실제 프린터로 배지 스티커를 출력해 QR 코드/shortId/qrPayload 텍스트가 모두
      보이는지 수동 확인 필요

## 참고

근본 원인 중 하나(iOS 카메라 권한 설명 누락)는 #140 PR에서 이미 수정되었습니다.
이 PR이 먼저 병합되면 관리자 앱은 여전히 카메라 QR 탭에서 크래시가 날 수 있으나,
새로 추가된 '직접 입력' 탭으로 우회할 수 있습니다. #140이 main에 병합되면 카메라
경로도 정상화됩니다.

Fixes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)