### PR TITLE
feat: read SSE heartbeat interval from environment variable

### DIFF
--- a/backend/internal/infrastructure/web/event_handler.go
+++ b/backend/internal/infrastructure/web/event_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"cornermon/backend/internal/domain"
@@ -119,7 +120,13 @@ func (h *EventHandler) streamEvents(c echo.Context, ch <-chan usecase.SSEMessage
 	}
 	c.Response().Flush()
 
-	ticker := time.NewTicker(15 * time.Second)
+	heartbeatDuration := 15 * time.Second
+	if envInterval := os.Getenv("SSE_HEARTBEAT_INTERVAL"); envInterval != "" {
+		if d, err := time.ParseDuration(envInterval); err == nil && d > 0 {
+			heartbeatDuration = d
+		}
+	}
+	ticker := time.NewTicker(heartbeatDuration)
 	defer ticker.Stop()
 	for {
 		select {


### PR DESCRIPTION
## 변경 사항과 이유
백엔드의 SSE 하트비트 주기를 코드에 하드코딩된 15초 대신 `SSE_HEARTBEAT_INTERVAL` 환경변수에서 읽어오도록 수정하였습니다. 다양한 환경(로컬, 프로덕션 등)에서 유연하게 하트비트 주기를 설정하기 위함입니다.

## 종료 조건 증명
`backend/internal/infrastructure/web/event_handler.go` 파일에서 `os.Getenv("SSE_HEARTBEAT_INTERVAL")`을 통해 환경변수를 파싱하고, `time.NewTicker`의 주기로 설정하는 로직이 추가되었습니다.