### PR TITLE
fix: SSE 재연결 배너가 계속 재연결 시도중에 고정되는 문제 수정 (#141)

### DIFF
--- a/frontend/build.yaml
+++ b/frontend/build.yaml
@@ -9,6 +9,7 @@ targets:
             - lib/shared/api/providers/*.dart
             - lib/shared/api/sse/*.dart
             - lib/shared/auth/*.dart
+            - lib/shared/network/*.dart
             - lib/facilitator/session/*.dart
             - lib/facilitator/features/**/*.dart
             - lib/facilitator/router/*.dart

--- a/frontend/docs/artifacts/plan/재연결배너_상태버그_수정_plan_20260720.md
+++ b/frontend/docs/artifacts/plan/재연결배너_상태버그_수정_plan_20260720.md
@@ -1,0 +1,444 @@
+# Issue #141 — 진행자 메인 페이지 "재연결 시도 중…" 배너 고착 버그 수정 Plan
+
+- 이슈: [#141](https://github.com/) 진행자 메인 페이지에서 계속 재연결 시도중 메시지 표시됨
+- 범위: **프론트엔드만** (`frontend/lib/shared/api/sse/**`, `frontend/lib/shared/network/**`(신설),
+  `frontend/pubspec.yaml`) — 백엔드 코드는 읽기만 하고 수정하지 않음
+- 작성일: 2026-07-20
+- 코드 리뷰 반영: 지수 백오프+지터, Reachability(OS 네트워크 상태 변경 감지) 병행 — 다른
+  개발자 리뷰 코멘트 반영(2.4/3.3/Phase D 참고)
+
+---
+
+## 1. 원인 조사 결과
+
+### 1.1 증상 재현 경로
+
+`MainTrackHeader`(`frontend/lib/facilitator/features/main_track/_main_track_header.dart:37-43`)는
+`trackConnectionProvider`의 `TrackConnectionState`를 그대로 `ConnectionBannerState`에 매핑한다.
+`TrackConnectionState`는 `track_event_stream.dart`의 `TrackConnection.build()`에서
+`trackEventsProvider`의 `AsyncValue<SSENotification>`을 관찰해 아래처럼 정해진다
+(`frontend/lib/shared/api/sse/track_event_stream.dart:40-52`):
+
+```dart
+state = next.when(
+  data: (_) => TrackConnectionState.connected,
+  error: (_, _) => TrackConnectionState.reconnecting,
+  loading: () => TrackConnectionState.reconnecting,
+);
+```
+
+즉 **실제 도메인 알림(SSENotification) 데이터가 최소 1건 도착해야만** `connected`로 바뀐다.
+문제는 두 가지가 겹쳐서 이 조건이 사실상 충족되지 않는다는 점이다.
+
+### 1.2 근본 원인 (2가지가 겹친 버그)
+
+**(A) 백엔드의 최초 핸드셰이크 프레임이 프론트에서 파싱 실패 후 조용히 버려짐**
+
+`backend/internal/infrastructure/web/event_handler.go:120-122`에서 SSE 연결이 열리자마자
+바로 `data: connected\n\n` 한 줄을 흘려보낸다(`event:` 라인 없이, JSON도 아닌 순수 문자열
+`connected`). 이건 "연결이 살아있다"를 알리기 위한 의도적 핸드셰이크 프레임이다.
+
+그런데 `SseClient.dispatchFrame()`(`frontend/lib/shared/api/sse/sse_client.dart:54-72`)은
+모든 `data:` 라인을 무조건 `SSENotification` JSON으로 간주하고 `jsonDecode`한다.
+`"connected"`는 유효한 JSON이 아니므로 예외가 발생하고, 바로 아래 `catch (_) {}` (깨진
+프레임 하나가 스트림 전체를 죽이지 않기 위한 방어 코드, 주석 참고)에 조용히 삼켜진다.
+→ **연결 직후의 유일한 즉시 신호가 파싱 실패로 사라진다.**
+
+**(B) 트랙 SSE는 best-effort 알림이라 실제 도메인 이벤트가 한동안 안 올 수 있음**
+
+`event_handler.go`의 스웨거 설명에도 명시되어 있듯("이벤트는 best-effort 알림이므로...")
+트랙에 아무 변화도 없으면(참가자 방문 상태 변경, 공지 등) 15초 하트비트(`:heartbeat`)만
+흐르고 실제 `SSENotification` 데이터는 한참 동안 없을 수 있다. `:heartbeat` 주석은
+`SseClient.processLine`에서 liveness 용도로만 쓰이고 `controller.add()`를 호출하지 않으므로
+(`sse_client.dart:82-85`), 이 역시 `trackEventsProvider`의 `AsyncValue`를 `data`로 바꾸지 못한다.
+
+**결론**: (A)+(B) 때문에 HTTP 연결 자체는 정상적으로 열려 있고 하트비트도 잘 도착하는데도,
+실제 도메인 알림이 우연히 도착하기 전까지는 `TrackConnectionState`가 초기값 `reconnecting`에서
+한 발짝도 못 벗어난다. 트랙에 변화가 뜸하면 배너가 "재연결 시도 중…"으로 계속 고정되어
+보이는 게 이번 이슈의 증상이다.
+
+### 1.3 부수적으로 확인된 문제 (같은 근본 원인의 연장선)
+
+- `trackEvents`/`adminEvents` 제너레이터(`track_event_stream.dart:24-33`,
+  `admin_event_stream.dart:23-31`)는 `client.connect(path)`에서 발생한 에러를 `catch (_) {}`로
+  **삼키고 재시도만 할 뿐 다시 던지지 않는다.** 즉 `ref.listen`이 관찰하는
+  `trackEventsProvider`의 `AsyncValue`는 사실상 `error` 상태가 되는 일이 거의 없다
+  (스트림 자체가 에러로 끝나지 않고 내부에서 조용히 재연결되므로). 그 결과
+  `next.when`의 `error` 분기는 죽은 코드에 가깝고, 상태는 `loading`(최초 1회)과
+  `data`(도메인 이벤트 도착 시)만으로 왔다갔다한다 — 연결이 끊겼다가 재연결되는 도중에도
+  상태가 그대로 `connected`로 고정돼 있을 수 있다는 뜻이며, 이는 정반대 방향(끊겼는데도
+  "정상"으로 보임)의 잠재 버그이기도 하다.
+- `admin_event_stream.dart`도 동일한 패턴(`AdminConnectionState`)으로 구현되어 있어 **동일한
+  버그를 그대로 갖고 있다.** 관리자 앱에서는 아직 이슈로 보고되지 않았지만 구조가 완전히
+  같으므로 같이 고친다.
+- `ConnectionBannerState`/`TrackConnectionState`/`AdminConnectionState` 모두 `disconnected`
+  값을 갖고 있지만, 실제로 이 값을 만들어내는 로직이 어디에도 없다(`reconnecting`과
+  `connected`만 실제로 발생). 사용자 피드백: 죽은 연결(하트비트 타임아웃이 반복되며 실제로는
+  서버/네트워크가 응답하지 않는 상태)도 존재할 수 있으므로, 이번 Plan에서 `disconnected`
+  판정 로직도 함께 구현한다(2.1 UC-4 참고, 아래에서 P2→P0로 범위 조정).
+
+### 1.4 코드 리뷰에서 추가로 지적된 문제
+
+- **재연결 간격이 고정 1초**: `trackEvents`/`adminEvents`의 재연결 루프는
+  `await Future<void>.delayed(const Duration(seconds: 1))`로 실패 원인·연속 실패 횟수와
+  무관하게 항상 1초 뒤 즉시 재시도한다(`track_event_stream.dart:32`,
+  `admin_event_stream.dart:30`). 파일 상단 주석은 "짧은 backoff"라고 표현하지만 실제로는
+  백오프가 아니라 고정 지연이다. 서버/네트워크가 완전히 죽은 상태에서 진행자·관리자 클라이언트
+  다수가 동시에 1초마다 재연결을 시도하면 서버에 불필요한 부하를 준다.
+- **OS 네트워크 상태 변경을 감지하지 않음**: 현재 재연결은 오직 "하트비트 타임아웃(40초)"에만
+  의존한다. 기기가 Wi-Fi에서 LTE로 전환되는 등 물리적으로 네트워크 인터페이스가 바뀌면 OS는
+  이 사실을 즉시 알 수 있는데도, 프론트는 그걸 활용하지 않고 최대 40초(하트비트 타임아웃)를
+  그냥 흘려보낸 뒤에야 끊긴 걸 알아챈다. `pubspec.yaml`에 `connectivity_plus` 같은 네트워크
+  상태 감지 패키지도 없다.
+
+---
+
+## 2. 해결 방향
+
+핵심 아이디어: **"연결됨" 상태를 도메인 알림(SSENotification) 도착 여부가 아니라, HTTP 스트림이
+실제로 열려 있는지 여부로 판단하도록 신호 체계를 분리한다.** 백엔드의 `data: connected`
+문자열 파싱을 억지로 통과시키는 방식(fragile)이 아니라, `SseClient`가 스스로 "연결 성립/해제"
+시점을 알고 있으므로 그 시점을 콜백으로 노출한다.
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| **P0** | UC-1: 트랙에 변화가 없어도 연결 성립 즉시 배너가 사라진다 | 도메인 이벤트 도착과 무관하게 HTTP 스트림이 열리면 `connected` | 프로덕션 핵심 로직 |
+| **P0** | UC-2: 연결이 끊기면(하트비트 타임아웃/HTTP 에러) 즉시 `reconnecting`으로 전환된다 | 현재는 내부에서 에러를 삼켜 상태가 안 바뀔 수 있음 | 프로덕션 핵심 로직 |
+| **P0** | UC-4: 재연결이 일정 시간 이상 계속 실패하면(=죽은 연결) `disconnected`로 전환된다 | 하트비트 타임아웃이 반복되는 것은 "곧 복구될 일시적 끊김"이 아니라 서버/네트워크 자체가 죽었을 가능성을 뜻하므로, 무기한 `reconnecting`으로만 두지 않고 사용자에게 명확히 알린다 | 프로덕션 핵심 로직 |
+| **P1** | UC-3: 관리자 앱(`AdminConnection`)도 동일하게 수정 | 완전히 동일한 버그 구조 | 프로덕션 핵심 로직 |
+| **P1** | UC-5: 재연결 실패가 반복될수록 재시도 간격이 지수적으로 늘어나고(지터 포함), 성공하면 다시 초기 간격으로 리셋된다 | 서버/네트워크가 완전히 죽었을 때 다수 클라이언트가 동시에 1초마다 재시도해 부하를 더하지 않도록 함(코드 리뷰 지적) | 프로덕션 핵심 로직 |
+| **P1** | UC-6: Wi-Fi↔LTE 전환 등 OS 네트워크 상태 변경 이벤트가 오면 백오프 대기를 기다리지 않고 즉시 재연결을 시도한다 | 하트비트 타임아웃(최대 40초)까지 기다리지 않고 물리적 단선/복구를 즉시 반영(코드 리뷰 지적) | 프로덕션 핵심 로직 |
+
+---
+
+## 3. 객체/메서드 설계
+
+### 3.1 `SseClient` — 연결 성립/해제 콜백 추가 (`sse_client.dart`, 기존 파일 확장)
+
+```dart
+class SseClient {
+  /// [onConnected]: HTTP 응답이 성공적으로 도착해 바이트 스트림 구독을 시작하는 시점(=연결 성립)에
+  /// 정확히 1회 호출된다. 도메인 알림 파싱 성공 여부와 무관하다.
+  /// [onDisconnected]: 워치독 타임아웃, HTTP 스트림 에러, 스트림 종료(onDone), 최초 연결 실패
+  /// 중 하나가 발생할 때마다 정확히 1회 호출되며, 항상 controller.addError/close()보다 먼저
+  /// 호출된다 — 호출측(track_event_stream.dart)이 실패 1건을 정확히 1번만 세도록 하기 위함.
+  Stream<SSENotification> connect(
+    String path, {
+    void Function()? onConnected,
+    void Function()? onDisconnected,
+  })
+}
+```
+
+- 책임: 프레임 파싱과 무관하게 "HTTP 스트림 연결/해제"라는 전송 계층 사실만 알린다.
+- `data: connected` 프레임 자체를 특수 처리하지 않는다 — 파싱 실패는 여전히 무시하되(방어
+  코드 유지), 실제 판단 기준은 `_dio.get()` 성공 여부로 옮긴다. 백엔드 프로토콜 변경 불필요.
+
+### 3.2 `track_event_stream.dart` / `admin_event_stream.dart` (기존 파일 확장)
+
+`TrackConnection`/`AdminConnection`은 더 이상 `trackEventsProvider`/`adminEventsProvider`의
+`AsyncValue`를 상태 판단에 쓰지 않는다(1.3에서 확인했듯 그 신호 자체가 신뢰할 수 없음).
+대신 `trackEvents`/`adminEvents` 제너레이터가 `connect()` 콜백을 통해 직접 상태를 갱신한다.
+
+**"죽은 연결" 판정 (연속 실패 횟수 기준)**: 시간이 아니라 **연속 실패 횟수**로 센다 —
+`onDisconnected`(하트비트 타임아웃/HTTP 에러/최초 연결 실패 등, 원인 불문)가 호출될 때마다
+연속 실패 카운터를 1 증가시키고 즉시 `reconnecting`으로 전환한다. 카운터가
+`AppEnv.sseMaxConsecutiveMisses`(=3)에 도달하는 순간 `disconnected`로 전환한다. `onConnected`가 한 번이라도
+호출되면(=재연결 성공) 카운터를 0으로 리셋하고 `connected`로 되돌린다 — 즉 "하트비트 1번
+놓치면 재연결 시도 중, 3번 연속으로 놓치면(그 사이 단 한 번도 재연결 성공 없이) 연결 끊김"이
+그대로 코드가 된다.
+
+기존 `AppEnv.sseHeartbeatTimeoutSeconds`와 같은 패턴으로, 이 임계값도 `--dart-define`으로
+주입 가능한 환경변수로 둔다(환경마다 네트워크 품질이 달라 튜닝이 필요할 수 있으므로).
+
+```dart
+// frontend/lib/shared/config/app_env.dart (기존 파일 확장)
+class AppEnv {
+  // ...기존 필드 유지...
+
+  /// 재연결 시도가 이 횟수만큼 연속으로 실패하면(=하트비트 타임아웃이 반복되는 등, 그 사이
+  /// 단 한 번도 재연결에 성공하지 못하면) "죽은 연결"로 보고 disconnected로 전환한다.
+  /// 1~2번 정도의 일시적 끊김은 reconnecting으로 흡수한다.
+  static const int sseMaxConsecutiveMisses = int.fromEnvironment(
+    'SSE_MAX_CONSECUTIVE_MISSES',
+    defaultValue: 3,
+  );
+}
+```
+
+**구현 중 발견한 문제(수정 반영)**: `TrackConnection`을 기본(autoDispose)으로 두면, `trackEvents`가
+`ref.watch`가 아니라 `ref.read(...notifier)`로 이 notifier를 붙잡기 때문에 — 위젯
+(`MainTrackHeader`)이 아직 `trackConnectionProvider`를 watch하기 전이면 리스너가 0개인 순간
+곧바로 dispose→재생성되어, `trackEvents`가 들고 있던 참조가 아무도 안 보는 고아 인스턴스가 되고
+상태 갱신이 반영되지 않는다(단위 테스트로 재현·확인함). 상태값 자체는 enum+int뿐이라 계속 들고
+있어도 비용이 없으므로 `keepAlive: true`로 이 경쟁을 근본적으로 없앤다.
+
+```dart
+@Riverpod(keepAlive: true)
+class TrackConnection extends _$TrackConnection {
+  int _consecutiveMisses = 0;
+
+  @override
+  TrackConnectionState build(TrackId trackId) => TrackConnectionState.reconnecting;
+
+  // 같은 파일 내부(track_event_stream.dart)의 trackEvents()에서만 호출하는 private 갱신 메서드.
+  void _markConnected() {
+    _consecutiveMisses = 0;
+    state = TrackConnectionState.connected;
+  }
+
+  void _markDisconnected() {
+    _consecutiveMisses++;
+    state = _consecutiveMisses >= AppEnv.sseMaxConsecutiveMisses
+        ? TrackConnectionState.disconnected
+        : TrackConnectionState.reconnecting;
+  }
+}
+
+@riverpod
+Stream<SSENotification> trackEvents(Ref ref, TrackId trackId) async* {
+  var disposed = false;
+  ref.onDispose(() => disposed = true);
+
+  final client = ref.watch(sseClientProvider);
+  final connection = ref.read(trackConnectionProvider(trackId).notifier);
+  final reachability = ref.watch(networkReachabilityProvider).stream; // 3.4 — NetworkReachability 래퍼의 .stream 필드
+  final backoff = ReconnectBackoff(); // 3.3
+  final path = '/events/track/${trackId.value}';
+
+  while (!disposed) {
+    try {
+      yield* client.connect(
+        path,
+        onConnected: () {
+          backoff.reset();
+          connection._markConnected();
+        },
+        onDisconnected: connection._markDisconnected,
+      );
+    } catch (_) {
+      // 실패 원인과 무관하게 SseClient가 실패 시점에 이미 onDisconnected를 호출한 뒤
+      // 에러를 던진다(Phase A) — 여기서 다시 _markDisconnected()를 부르면 같은 실패를
+      // 두 번 세게 되어 카운터가 실제보다 빨리 올라간다. 그래서 여기서는 그냥 삼키기만 한다.
+    }
+    if (disposed) break;
+    await backoff.waitOrFastRetryOn(reachability); // 3.3 + 3.4
+  }
+}
+```
+
+**중복 카운트 주의**: `SseClient.connect()`는 모든 실패 경로(워치독 타임아웃/HTTP 에러/
+스트림 종료/최초 연결 실패)에서 `onDisconnected`를 호출한 **다음에** 에러를 던지거나 스트림을
+닫는다. 즉 `onDisconnected` 콜백이 이미 실패 1건을 정확히 1회 센 상태이므로, `trackEvents`의
+바깥쪽 `catch`는 `_markDisconnected()`를 다시 호출하지 않고 삼키기만 해야 한다(위 코드 반영됨).
+Phase A 구현 시 "콜백 호출 → 에러 전파" 순서를 반드시 지켜야 이 가정이 성립한다.
+
+`AdminConnection`/`adminEvents`도 동일한 패턴으로 수정한다.
+
+### 3.3 `ReconnectBackoff` — 지수 백오프 + 지터 (신규, `frontend/lib/shared/api/sse/reconnect_backoff.dart`)
+
+재연결 루프가 도메인 로직(리트라이 간격 계산)까지 떠맡지 않도록 별도 객체로 분리한다.
+`trackEvents`/`adminEvents` 양쪽에서 재사용한다.
+
+```dart
+/// 재연결 간격을 지수적으로 늘리며(최대 상한 있음) 소폭의 지터를 더한다.
+/// reset()이 호출되기 전까지는 실패할 때마다 간격이 계속 늘어난다.
+class ReconnectBackoff {
+  ReconnectBackoff({
+    this.initialDelay = const Duration(milliseconds: 300),
+    this.maxDelay = const Duration(seconds: 5),
+    Random? random,
+  }) : _random = random ?? Random();
+
+  final Duration initialDelay;
+  final Duration maxDelay;
+  final Random _random;
+  int _attempt = 0;
+
+  /// 연결 성공 시(onConnected) 호출 — 다음 실패는 다시 initialDelay부터 시작한다.
+  void reset() => _attempt = 0;
+
+  /// 다음 재시도까지 기다릴 시간. attempt=0(첫 실패)이면 initialDelay 근처,
+  /// 실패가 반복될수록 2배씩 늘어나 maxDelay에서 상한이 걸린다. ±20% full-jitter 적용.
+  Duration nextDelay() {
+    final exponential = initialDelay * (1 << _attempt.clamp(0, 10));
+    final capped = exponential > maxDelay ? maxDelay : exponential;
+    _attempt++;
+    final jitterRatio = 0.8 + _random.nextDouble() * 0.4; // 0.8x~1.2x
+    return capped * jitterRatio;
+  }
+
+  /// [reachability]가 먼저 이벤트를 내보내면(=OS가 네트워크 회복/전환을 감지) 남은 백오프
+  /// 대기를 포기하고 즉시 반환한다. 그렇지 않으면 nextDelay()만큼 그냥 기다린다(3.4).
+  ///
+  /// **구현 중 발견한 버그(수정 반영)**: `reachability.first`를 그대로 `Future.any`에 넣으면,
+  /// reachability 스트림이 이벤트 없이 끝나거나 에러를 내는 순간(`StateError` 등) 그 에러가
+  /// `waitOrFastRetryOn`을 통해 재연결 루프 밖으로 새어나가 루프 전체가 죽어버린다(원래
+  /// 버그보다 더 심각한 회귀). `.then(_, onError: (_) => never)`로 감싸 이 경로의 에러를
+  /// 흡수하고, 그 경우엔 `nextDelay()` 타이머만으로 동작하도록 방어한다.
+  Future<void> waitOrFastRetryOn(Stream<void> reachability) {
+    final never = Completer<void>().future;
+    final onReachable = reachability.first.then<void>((_) {}, onError: (_) => never);
+    return Future.any<void>([
+      Future<void>.delayed(nextDelay()),
+      onReachable,
+    ]);
+  }
+}
+```
+
+- `nextDelay()`가 호출 시점에 `_attempt`를 증가시키므로 `waitOrFastRetryOn` 한 번 호출 = 백오프
+  한 스텝 전진. Reachability가 먼저 반응해 조기 반환되더라도 다음 실패 시엔 그 다음 스텝의
+  간격으로 넘어간다(무한정 attempt=0에 머무르지 않음) — 다만 Reachability로 인한 조기 재시도가
+  성공하면 `onConnected`가 `reset()`을 호출해 attempt가 0으로 돌아온다.
+- 상한 5초: `disconnected`로 전환되기 전(연속 3회 실패, `AppEnv.sseMaxConsecutiveMisses`)까지
+  배너가 "재연결 시도 중…" 스피너로 너무 오래 도는 느낌을 주지 않도록 사용자 피드백을 반영해
+  낮게 잡았다(초기값 300ms → 600ms → 1.2s → 2.4s → 4.8s → 이후 5초 고정). 현재는
+  `--dart-define`으로 노출하지 않는다(범위 외, 6절 참고). 필요해지면 `AppEnv`에 추가.
+
+### 3.4 `NetworkReachability` — OS 네트워크 상태 변경 감지 (신규, `frontend/lib/shared/network/network_reachability.dart`)
+
+`connectivity_plus` 패키지(신규 의존성, `frontend/pubspec.yaml`에 추가)를 얇게 감싸, "네트워크가
+쓸 수 있는 상태로 바뀌었다"는 신호만 브로드캐스트하는 keepAlive provider를 둔다. Dio/Client류와
+같은 "앱 전체에서 하나만 있어야 하는 장수 객체"이므로 `frontend/docs/DEVELOPER_GUIDE.md` §2.1
+관례대로 `keepAlive: true`로 고정한다.
+
+**구현 중 발견한 문제(수정 반영)**: 처음엔 `@riverpod Stream<void> networkReachability(...)`로
+선언했으나, 이 저장소가 쓰는 riverpod 3.x(`riverpod_generator` 4.x)에서 생성된 provider는
+`.stream` modifier를 제공하지 않는다(구버전 riverpod의 `provider.stream` 패턴이 사라짐) —
+`ref.watch(networkReachabilityProvider.stream)`가 `undefined_getter`로 컴파일 에러가 난다.
+그래서 원시 `Stream<void>`를 provider의 반환 타입으로 직접 쓰지 않고, `NetworkReachability`라는
+평범한 값 타입으로 한 번 감싸서 그 안에 `Stream<void> stream` 필드를 둔다. 이러면 provider
+자체는 (AsyncValue로 래핑되는 StreamProvider가 아니라) 일반 값 provider가 되어
+`ref.watch(networkReachabilityProvider).stream`으로 원시 Stream을 꺼낼 수 있다.
+
+```dart
+class NetworkReachability {
+  NetworkReachability(this.stream);
+  final Stream<void> stream;
+}
+
+/// connectivity_plus의 원시 이벤트(예: none→wifi, wifi→mobile)를 그대로 넘기지 않고,
+/// "연결 가능한 상태로 바뀜"만 걸러서 내보낸다 — SSE 재연결 루프는 구체적인 인터페이스
+/// 종류(wifi/mobile)에는 관심 없고 "지금 재시도해볼 만하다"는 신호만 필요하기 때문이다.
+@Riverpod(keepAlive: true)
+NetworkReachability networkReachability(Ref ref) {
+  final connectivity = Connectivity();
+  final stream = connectivity.onConnectivityChanged
+      .where((results) => !results.contains(ConnectivityResult.none))
+      .map((_) {});
+  return NetworkReachability(stream);
+}
+```
+
+- `trackEvents`/`adminEvents`는 `ref.watch(networkReachabilityProvider).stream`을
+  `ReconnectBackoff.waitOrFastRetryOn()`에 그대로 넘겨서, 백오프 대기 중에 네트워크가 회복/전환되면
+  대기를 건너뛰고 바로 다음 `connect()`를
+  시도하게 한다(3.3 참고). 실제 연결 성공 여부는 여전히 `SseClient`가 판단하므로, "네트워크는
+  붙었는데 서버는 여전히 응답 없음" 같은 경우도 안전하게 다음 실패로 이어질 뿐 오작동하지 않는다.
+- Wi-Fi↔LTE처럼 "연결된 상태끼리의 전환"도 `onConnectivityChanged`에서 이벤트가 오므로, 이미
+  연결된 SSE 스트림이 그 전환 때문에 끊기더라도(=인터페이스가 바뀌어 기존 소켓이 죽음)
+  `SseClient`의 워치독/HTTP 에러가 `onDisconnected`를 호출해 재연결 루프로 들어오고, 그 시점에
+  바로 다음 `waitOrFastRetryOn()` 호출에서 (이미 지난 이벤트라 놓쳤더라도) 대개 하트비트
+  타임아웃보다 훨씬 먼저 다음 `onConnectivityChanged` 이벤트나 자연스러운 백오프로 재시도된다.
+
+**기존 provider 생명주기 유지 주의 (구현 후 확정)**: 기존 `TrackConnection.build()`의
+`ref.listen(trackEventsProvider(...))`은 부수적으로 `trackEventsProvider`를 계속 watch 상태로
+유지하는 역할도 겸하고 있었다. 확인 결과 `trackEventsProvider`는
+`TrackEventCoordinator`(`main_track_screen.dart:43`, `ref.watch(trackEventCoordinatorProvider(trackId))`)가
+독립적으로 계속 구독하고 있으므로, `TrackConnection`이 더 이상 `trackEventsProvider`를 watch/listen
+하지 않아도 생명주기에 영향 없다.
+
+`admin_event_stream.dart`는 사정이 달랐다: `adminEventsProvider`를 track의
+`TrackEventCoordinator`처럼 독립적으로 watch하는 화면이 **아직 하나도 없다**(admin SSE 연동은
+아직 라우팅에 붙지 않은 스캐폴딩 단계, `12_admin_sse_integration.md` 참고). 그래서 keep-alive용
+`ref.listen(adminEventsProvider(...))`을 `AdminConnection.build()`에 그대로 옮기면, `adminEvents()`
+내부에서 다시 `adminConnectionProvider(...).notifier`를 read하는 것과 맞물려 build() 도중
+자기 자신을 참조하는 순환 초기화가 생길 위험이 있어 넣지 않았다(3.2/Phase B 참고). 대신
+`AdminConnection`도 `keepAlive: true`로 바꿔 "위젯이 watch하기 전엔 dispose된다" 경쟁 자체를
+없앴다 — 다만 `adminEventsProvider`를 실제로 구동하는 건 여전히 다른 소비자(admin 배너를 실제로
+붙일 때 추가될 `AdminEventCoordinator` 격의 무언가)의 몫으로 남아 있다.
+
+---
+
+## 4. 구현 단계
+
+### Phase A: `SseClient`에 연결 콜백 추가 — ✅ 완료
+
+| 순서 | 작업 | 파일 |
+|---|---|---|
+| A-1 | `connect()`에 `onConnected`/`onDisconnected` 파라미터 추가, `onListen`의 `_dio.get` 성공 직후 `onConnected` 호출 | `frontend/lib/shared/api/sse/sse_client.dart` (기존 확장) |
+| A-2 | 워치독 타임아웃 분기, `subscription`의 `onError`/`onDone`, `_dio.get` 실패(catch) 분기에 각각 `onDisconnected` 호출 추가. **반드시 `controller.addError`/`close()`보다 먼저 호출**해서, 이 콜백 하나가 실패 1건을 정확히 1회씩 세는 유일한 지점이 되도록 한다(3.2의 중복 카운트 주의 참고) | 〃 |
+| A-3 | `sse_client_test.dart`에 `onConnected`/`onDisconnected` 호출 시점 검증 테스트 추가 (연결 성립 시 1회, 워치독 타임아웃/에러/정상종료 시 1회) | `frontend/test/shared/api/sse/sse_client_test.dart` |
+
+### Phase B: `TrackConnection`/`AdminConnection` 상태 판단 로직 교체 — ✅ 완료
+
+| 순서 | 작업 | 파일 |
+|---|---|---|
+| B-1 | `AdminConnection`이 감시하는 화면에서 `adminEventsProvider`가 독립적으로 watch되고 있는지 확인(생명주기 회귀 방지) — **결론: 없음.** 3.4/Phase D 하단 주석 참고 | 조사만, 코드 변경 없음 |
+| B-2 | `AppEnv.sseMaxConsecutiveMisses` 필드 추가(`--dart-define=SSE_MAX_CONSECUTIVE_MISSES`, 기본값 3) | `frontend/lib/shared/config/app_env.dart` |
+| B-3 | `TrackConnection`/`trackEvents`를 3.2 설계대로 수정 (`_markConnected`/`_markDisconnected` + `AppEnv.sseMaxConsecutiveMisses` 기준 연속 실패 카운터 포함, 바깥쪽 `catch`는 재카운트하지 않고 삼키기만 함, **+구현 중 발견한 autoDispose 경쟁 때문에 `keepAlive: true` 추가**) | `frontend/lib/shared/api/sse/track_event_stream.dart` |
+| B-4 | `AdminConnection`/`adminEvents`를 동일하게 수정(단, keep-alive용 `ref.listen` 없이 `keepAlive: true`만 적용 — 순환 초기화 회피, 3.4 참고) | `frontend/lib/shared/api/sse/admin_event_stream.dart` |
+| B-5 | 기존 `.g.dart` 재생성 (`dart run build_runner build`) 후 `lib/shared/api/gen` 삭제 여부 확인·복구(DEVELOPER_GUIDE.md §1 알려진 함정) | build_runner 실행 |
+
+### Phase D: 지수 백오프+지터 및 Reachability 연동 — ✅ 완료
+
+| 순서 | 작업 | 파일 |
+|---|---|---|
+| D-1 | `connectivity_plus` 의존성 추가 | `frontend/pubspec.yaml` |
+| D-2 | `ReconnectBackoff` 클래스 신설(3.3 설계대로, 생성자로 `Random` 주입 가능하게 해 테스트에서 시드 고정, **+reachability 에러 흡수 방어 로직 추가**) | `frontend/lib/shared/api/sse/reconnect_backoff.dart` (신규) |
+| D-3 | `networkReachabilityProvider` 신설(3.4 설계대로, `keepAlive: true`, **riverpod 3.x 제약으로 `NetworkReachability` 래퍼 타입 도입**) | `frontend/lib/shared/network/network_reachability.dart` (신규) |
+| D-4 | `trackEvents`/`adminEvents`의 고정 1초 딜레이를 `ReconnectBackoff.waitOrFastRetryOn(reachability)`로 교체, `onConnected`에서 `backoff.reset()` 호출 추가 | `track_event_stream.dart`, `admin_event_stream.dart` |
+| D-5 | iOS/Android 두 플랫폼 모두 `connectivity_plus`가 별도 권한/manifest 설정 없이 동작하는지 확인 — **확인 결과 별도 수정 불필요**(패키지 자체 AndroidManifest.xml에 `ACCESS_NETWORK_STATE` 포함, Gradle 매니페스트 병합으로 자동 반영. iOS도 별도 권한 불필요) | 조사만, 코드 변경 없음 |
+| D-6 | 기존 `.g.dart` 재생성 후 `lib/shared/api/gen` 삭제 여부 확인·복구 | build_runner 실행 |
+
+### Phase E: 회귀 테스트 — ✅ 완료 (167개 전체 테스트 통과, `dart analyze` 클린)
+
+| 순서 | 작업 | 파일 |
+|---|---|---|
+| E-1 | `trackEvents`/`TrackConnection` 통합 테스트: 도메인 이벤트가 전혀 없어도 연결 성립만으로 `connected`가 되는지 검증 | `frontend/test/shared/api/sse/track_event_stream_test.dart` (신설) |
+| E-2 | 연결 끊김(워치독 타임아웃) 1~2회 발생 시 `reconnecting`으로 전환되고, 그 사이 재연결에 성공하면 카운터가 리셋되어 `disconnected`로 넘어가지 않는지 검증 | 〃 |
+| E-3 | 연결 끊김이 재연결 성공 없이 연속 3회(`AppEnv.sseMaxConsecutiveMisses`) 발생하면 `disconnected`로 전환되는지 검증 | 〃 |
+| E-4 | `SseClient.connect()`가 실패마다 `onDisconnected`를 정확히 1회씩만 호출하는지(=`trackEvents`의 바깥쪽 catch와 중복 카운트되지 않는지) 검증 | 〃 |
+| E-5 | `ReconnectBackoff.nextDelay()`가 실패를 거듭할수록 지수적으로 늘어나다 `maxDelay`에서 상한이 걸리는지, 매 호출마다 지터로 인해 고정값이 아닌지, `reset()` 후 다시 `initialDelay` 근처로 돌아오는지 단위 테스트로 검증(시드 고정 `Random`으로 결정론적 테스트) | `frontend/test/shared/api/sse/reconnect_backoff_test.dart` (신규) |
+| E-6 | `waitOrFastRetryOn`이 reachability 스트림에 이벤트가 먼저 오면 백오프 타이머보다 먼저 반환되는지 검증(`fakeAsync` 대신 짧은 실제 `Duration`+`StreamController`로 검증, 충분히 빠르고 결정론적) + reachability 스트림이 에러 없이 끝나도 백오프가 안전하게 fallback하는지(구현 중 발견한 버그의 회귀 테스트) 검증 | 〃 |
+| E-7 | 기존 `sse_client_test.dart` 4개 테스트 + 신규 `onConnected`/`onDisconnected` 콜백 테스트가 통과하는지 확인(회귀 없음) | `frontend/test/shared/api/sse/sse_client_test.dart` |
+
+---
+
+## 5. 검증 체크리스트
+
+### 5.1 유즈케이스 검증
+- [x] UC-1: 트랙에 도메인 이벤트가 없어도(:heartbeat만 반복) 연결 성립 즉시 배너가 사라진다 — `track_event_stream_test.dart: ShouldBecomeConnectedAssoonAsSseClientConnectsWithoutAnyDomainEvent`로 검증
+- [x] UC-2: 네트워크 차단/워치독 타임아웃 시 즉시 "재연결 시도 중…" 배너가 뜬다 — 위 테스트 파일의 실패 시나리오들로 검증
+- [x] UC-4: 재연결 시도가 연속 3회(`AppEnv.sseMaxConsecutiveMisses`) 실패하면(그 사이 재연결 성공 없이) 배너가 "연결이 끊겼습니다 · 최근 상태를 보여주고 있어요"로 전환된다 — `ShouldBecomeDisconnectedAfterThreeConsecutiveFailuresWithoutAnySuccess`
+- [x] UC-4: 3회 도달 전에 재연결이 한 번이라도 성공하면 카운터가 리셋되어 `disconnected`로 넘어가지 않고 정상적으로 `connected`로 돌아온다(오탐 방지 확인) — `ShouldStayReconnectingAfterFewerThanThresholdConsecutiveFailures`, `ShouldResetConsecutiveMissCounterOnSuccessfulReconnect`
+- [x] UC-5: 재연결이 반복 실패할수록 재시도 간격이 눈에 띄게 늘어난다, 재연결 성공 후 다시 실패하면 간격이 처음(초기값)부터 다시 시작한다 — `reconnect_backoff_test.dart: ShouldDoubleDelayOnEachConsecutiveFailure`, `ShouldRestartFromInitialDelayAfterReset`
+- [x] UC-6: 백오프 대기 중 기기의 네트워크를 껐다 켜면(또는 Wi-Fi↔모바일 데이터 전환) 남은 대기시간과 무관하게 즉시 재연결을 시도한다 — `reconnect_backoff_test.dart: ShouldSkipRemainingDelayWhenReachabilityEmitsFirst`(단위 테스트 수준. 실제 OS 이벤트로는 미검증, 아래 5.3 참고)
+- [ ] UC-3: 관리자 앱에서도 동일하게 동작한다(수동 확인) — 코드는 track과 동일 패턴으로 구현했으나 admin SSE가 아직 어떤 화면에도 연결되지 않은 스캐폴딩 단계라(1.4/3.4 참고) 실기기 수동 확인 대상 자체가 없음. 추후 admin 배너를 실제로 붙일 때 재검증 필요.
+
+### 5.2 회귀 검증
+- [x] 기존 `sse_client_test.dart` 4개 테스트 통과 — `flutter test test/shared/api/sse/` 전체 19개 테스트 통과 확인
+- [x] `TrackEventCoordinator`의 도메인 이벤트 처리(방문 갱신, 공지 등)가 그대로 동작한다 — `trackEventsProvider` 자체의 `Stream<SSENotification>` 계약은 변경하지 않았고, 전체 테스트 스위트(`flutter test`, 167개) 통과로 확인
+- [x] `dart analyze lib/ test/` 전체 통과(No issues found) — riverpod 3.x `.stream` modifier 부재, `TrackConnection`/`AdminConnection` autoDispose 경쟁 등 구현 중 발견한 컴파일/런타임 문제 모두 수정 반영
+- [x] `lib/shared/api/gen` 디렉터리가 `build_runner` 실행 후에도 손상되지 않았는지 확인 — 매 `build_runner build` 직후 `git status`로 확인하고 `git checkout --`로 복구(DEVELOPER_GUIDE.md §1 알려진 함정 재현·대응)
+- [x] `connectivity_plus` 추가 후 `flutter pub get` 정상 동작 확인. Android manifest 자동 병합(`ACCESS_NETWORK_STATE`, 패키지 자체 매니페스트에 포함되어 있어 앱 쪽 수정 불필요) 확인. 실제 iOS/Android 네이티브 빌드는 이 환경에서 실행 불가 — 5.3 실기기 테스트에서 함께 확인 필요
+
+### 5.3 실기기/에뮬레이터 수동 테스트 (미실행 — 이 환경에는 실기기/에뮬레이터가 없어 코드 구현·자동화 테스트까지만 완료)
+- [ ] `make run-app-facilitator`로 실행 후 트랙 로그인 → 아무 이벤트도 발생시키지 않고 15~30초 대기 → 배너가 사라져 있는지(=connected) 확인
+- [ ] 백엔드 서버를 짧게 한 번 내렸다 올려서(연속 실패 3회 미만) 배너가 "재연결 시도 중…" → 사라짐 순서로 정상 전환되는지 확인
+- [ ] 백엔드 서버를 재연결 3회 이상 실패할 만큼 길게 내려둬서 배너가 "재연결 시도 중…" → "연결이 끊겼습니다 · 최근 상태를 보여주고 있어요"로 전환되는지, 서버를 다시 올리면 정상적으로 `connected`로 복구되는지 확인
+- [ ] 백엔드는 켜둔 채로 기기의 Wi-Fi를 끄고 모바일 데이터로 전환(또는 반대)해서, 하트비트 타임아웃(40초)을 기다리지 않고 훨씬 빠르게 재연결되는지 확인
+- [ ] 관리자 앱(`make run-admin`)에서도 동일 시나리오 확인(단, 현재 admin SSE는 어떤 화면에도 연결돼 있지 않아 이 항목은 admin 배너 연동 이후로 보류)
+
+---
+
+## 6. 범위 외 (Out of Scope)
+
+- 백엔드 `data: connected` 프레임 포맷 변경 — 프론트 판단 기준을 전송 계층 신호로 옮기므로 불필요
+- 런타임 중 네트워크 상태에 따라 `AppEnv.sseMaxConsecutiveMisses`를 자동으로 조정하는 것 — 빌드 타임
+  `--dart-define`으로 환경별 고정값(기본 3)만 지원하고, 필요하면 추후 튜닝
+- `ReconnectBackoff`의 `initialDelay`/`maxDelay`를 `AppEnv` 환경변수로 노출하는 것 — 우선 코드
+  상수(300ms/5초)로 시작하고, 필요해지면 추후 노출
+- Reachability 신호를 SSE 재연결 외의 다른 곳(예: 일반 REST 요청 재시도)에 재사용하는 것 — 이번
+  이슈 범위인 SSE 배너 문제에만 한정

--- a/frontend/lib/shared/api/sse/admin_event_stream.dart
+++ b/frontend/lib/shared/api/sse/admin_event_stream.dart
@@ -3,7 +3,10 @@ import 'dart:async';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:cornermon_api_gen/cornermon_api_gen.dart';
 
+import '../../config/app_env.dart';
+import '../../network/network_reachability.dart';
 import '../ids.dart';
+import 'reconnect_backoff.dart';
 import 'sse_client.dart';
 
 part 'admin_event_stream.g.dart';
@@ -12,40 +15,65 @@ part 'admin_event_stream.g.dart';
 /// `12_admin_sse_integration.md`에서 다룬다(이 Phase는 raw 연결/재연결만 제공).
 enum AdminConnectionState { connected, reconnecting, disconnected }
 
+// keepAlive: true인 이유는 track_event_stream.dart의 TrackConnection과 동일하다 — adminEvents()가
+// ref.read(...notifier)로 이 notifier를 붙잡는데 autoDispose면 리스너 0개 순간 dispose→재생성될
+// 수 있다. 상태값 자체는 enum+int뿐이라 계속 들고 있어도 비용이 없다.
+//
+// 주의: adminEventsProvider를 독립적으로 watch하는 화면이 아직 없다(track의
+// TrackEventCoordinator에 대응하는 admin 쪽 소비자가 아직 없음, 12_admin_sse_integration.md
+// 참고) — 즉 AdminConnection만 watch해선 실제 SSE 연결(adminEvents)이 시작되지 않는다.
+// 여기서 keep-alive용 ref.listen(adminEventsProvider(...))을 걸지 않는 이유: adminEvents()
+// 내부에서 다시 이 notifier를 read하므로, build() 안에서 그 listen을 걸면 build()가 끝나기도
+// 전에 자기 자신을 다시 참조하는 순환 초기화가 된다. admin 배너를 실제로 붙일 때는 track과
+// 동일하게 별도 Coordinator(또는 화면)가 adminEventsProvider를 직접 watch해야 한다.
+@Riverpod(keepAlive: true)
+class AdminConnection extends _$AdminConnection {
+  int _consecutiveMisses = 0;
+
+  @override
+  AdminConnectionState build(CampId campId) => AdminConnectionState.reconnecting;
+
+  // 같은 파일 내부(adminEvents())에서만 호출하는 private 갱신 메서드.
+  void _markConnected() {
+    _consecutiveMisses = 0;
+    state = AdminConnectionState.connected;
+  }
+
+  void _markDisconnected() {
+    _consecutiveMisses++;
+    state = _consecutiveMisses >= AppEnv.sseMaxConsecutiveMisses
+        ? AdminConnectionState.disconnected
+        : AdminConnectionState.reconnecting;
+  }
+}
+
 @riverpod
 Stream<SSENotification> adminEvents(Ref ref, CampId campId) async* {
   var disposed = false;
   ref.onDispose(() => disposed = true);
 
   final client = ref.watch(sseClientProvider);
+  final connection = ref.read(adminConnectionProvider(campId).notifier);
+  final reachability = ref.watch(networkReachabilityProvider).stream;
+  final backoff = ReconnectBackoff();
   final path = '/camps/${campId.value}/events/admin';
 
   while (!disposed) {
     try {
-      yield* client.connect(path);
+      yield* client.connect(
+        path,
+        onConnected: () {
+          backoff.reset();
+          connection._markConnected();
+        },
+        onDisconnected: connection._markDisconnected,
+      );
     } catch (_) {
-      // 연결 에러를 구독자에게 전파하지 않고 여기서 삼킨 뒤 재연결한다.
+      // 실패 원인과 무관하게 SseClient가 실패 시점에 이미 onDisconnected를 호출한 뒤
+      // 에러를 던진다 — 여기서 다시 _markDisconnected()를 부르면 같은 실패를 두 번 세게
+      // 되어 카운터가 실제보다 빨리 올라간다. 그래서 여기서는 그냥 삼키기만 한다.
     }
     if (disposed) break;
-    await Future<void>.delayed(const Duration(seconds: 1));
-  }
-}
-
-@riverpod
-class AdminConnection extends _$AdminConnection {
-  @override
-  AdminConnectionState build(CampId campId) {
-    ref.listen<AsyncValue<SSENotification>>(
-      adminEventsProvider(campId),
-      (previous, next) {
-        state = next.when(
-          data: (_) => AdminConnectionState.connected,
-          error: (_, _) => AdminConnectionState.reconnecting,
-          loading: () => AdminConnectionState.reconnecting,
-        );
-      },
-      fireImmediately: true,
-    );
-    return AdminConnectionState.reconnecting;
+    await backoff.waitOrFastRetryOn(reachability);
   }
 }

--- a/frontend/lib/shared/api/sse/admin_event_stream.g.dart
+++ b/frontend/lib/shared/api/sse/admin_event_stream.g.dart
@@ -9,6 +9,103 @@ part of 'admin_event_stream.dart';
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
 
+@ProviderFor(AdminConnection)
+final adminConnectionProvider = AdminConnectionFamily._();
+
+final class AdminConnectionProvider
+    extends $NotifierProvider<AdminConnection, AdminConnectionState> {
+  AdminConnectionProvider._({
+    required AdminConnectionFamily super.from,
+    required CampId super.argument,
+  }) : super(
+         retry: null,
+         name: r'adminConnectionProvider',
+         isAutoDispose: false,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$adminConnectionHash();
+
+  @override
+  String toString() {
+    return r'adminConnectionProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  AdminConnection create() => AdminConnection();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(AdminConnectionState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<AdminConnectionState>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is AdminConnectionProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$adminConnectionHash() => r'ab9f26a07a852f4fb710de8d5129f60994b2cc4c';
+
+final class AdminConnectionFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          AdminConnection,
+          AdminConnectionState,
+          AdminConnectionState,
+          AdminConnectionState,
+          CampId
+        > {
+  AdminConnectionFamily._()
+    : super(
+        retry: null,
+        name: r'adminConnectionProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: false,
+      );
+
+  AdminConnectionProvider call(CampId campId) =>
+      AdminConnectionProvider._(argument: campId, from: this);
+
+  @override
+  String toString() => r'adminConnectionProvider';
+}
+
+abstract class _$AdminConnection extends $Notifier<AdminConnectionState> {
+  late final _$args = ref.$arg as CampId;
+  CampId get campId => _$args;
+
+  AdminConnectionState build(CampId campId);
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<AdminConnectionState, AdminConnectionState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<AdminConnectionState, AdminConnectionState>,
+              AdminConnectionState,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, () => build(_$args));
+  }
+}
+
 @ProviderFor(adminEvents)
 final adminEventsProvider = AdminEventsFamily._();
 
@@ -64,7 +161,7 @@ final class AdminEventsProvider
   }
 }
 
-String _$adminEventsHash() => r'2344087d3b0b78b338f853d26807f091506fc19e';
+String _$adminEventsHash() => r'bec489d99a5a5a2d3f00c030966632b201e1c4b4';
 
 final class AdminEventsFamily extends $Family
     with $FunctionalFamilyOverride<Stream<SSENotification>, CampId> {
@@ -82,101 +179,4 @@ final class AdminEventsFamily extends $Family
 
   @override
   String toString() => r'adminEventsProvider';
-}
-
-@ProviderFor(AdminConnection)
-final adminConnectionProvider = AdminConnectionFamily._();
-
-final class AdminConnectionProvider
-    extends $NotifierProvider<AdminConnection, AdminConnectionState> {
-  AdminConnectionProvider._({
-    required AdminConnectionFamily super.from,
-    required CampId super.argument,
-  }) : super(
-         retry: null,
-         name: r'adminConnectionProvider',
-         isAutoDispose: true,
-         dependencies: null,
-         $allTransitiveDependencies: null,
-       );
-
-  @override
-  String debugGetCreateSourceHash() => _$adminConnectionHash();
-
-  @override
-  String toString() {
-    return r'adminConnectionProvider'
-        ''
-        '($argument)';
-  }
-
-  @$internal
-  @override
-  AdminConnection create() => AdminConnection();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(AdminConnectionState value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<AdminConnectionState>(value),
-    );
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return other is AdminConnectionProvider && other.argument == argument;
-  }
-
-  @override
-  int get hashCode {
-    return argument.hashCode;
-  }
-}
-
-String _$adminConnectionHash() => r'335719f12d0dbf356ff4c0c59aa2ddb77ef7a513';
-
-final class AdminConnectionFamily extends $Family
-    with
-        $ClassFamilyOverride<
-          AdminConnection,
-          AdminConnectionState,
-          AdminConnectionState,
-          AdminConnectionState,
-          CampId
-        > {
-  AdminConnectionFamily._()
-    : super(
-        retry: null,
-        name: r'adminConnectionProvider',
-        dependencies: null,
-        $allTransitiveDependencies: null,
-        isAutoDispose: true,
-      );
-
-  AdminConnectionProvider call(CampId campId) =>
-      AdminConnectionProvider._(argument: campId, from: this);
-
-  @override
-  String toString() => r'adminConnectionProvider';
-}
-
-abstract class _$AdminConnection extends $Notifier<AdminConnectionState> {
-  late final _$args = ref.$arg as CampId;
-  CampId get campId => _$args;
-
-  AdminConnectionState build(CampId campId);
-  @$mustCallSuper
-  @override
-  WhenComplete runBuild() {
-    final ref = this.ref as $Ref<AdminConnectionState, AdminConnectionState>;
-    final element =
-        ref.element
-            as $ClassProviderElement<
-              AnyNotifier<AdminConnectionState, AdminConnectionState>,
-              AdminConnectionState,
-              Object?,
-              Object?
-            >;
-    return element.handleCreate(ref, () => build(_$args));
-  }
 }

--- a/frontend/lib/shared/api/sse/reconnect_backoff.dart
+++ b/frontend/lib/shared/api/sse/reconnect_backoff.dart
@@ -1,0 +1,46 @@
+import 'dart:async';
+import 'dart:math';
+
+/// 재연결 간격을 지수적으로 늘리며(최대 상한 있음) 소폭의 지터를 더한다.
+/// reset()이 호출되기 전까지는 실패할 때마다 간격이 계속 늘어난다.
+class ReconnectBackoff {
+  ReconnectBackoff({
+    this.initialDelay = const Duration(milliseconds: 300),
+    this.maxDelay = const Duration(seconds: 5),
+    Random? random,
+  }) : _random = random ?? Random();
+
+  final Duration initialDelay;
+  final Duration maxDelay;
+  final Random _random;
+  int _attempt = 0;
+
+  /// 연결 성공 시(onConnected) 호출 — 다음 실패는 다시 initialDelay부터 시작한다.
+  void reset() => _attempt = 0;
+
+  /// 다음 재시도까지 기다릴 시간. attempt=0(첫 실패)이면 initialDelay 근처,
+  /// 실패가 반복될수록 2배씩 늘어나 maxDelay에서 상한이 걸린다. ±20% full-jitter 적용.
+  Duration nextDelay() {
+    final exponential = initialDelay * (1 << _attempt.clamp(0, 10));
+    final capped = exponential > maxDelay ? maxDelay : exponential;
+    _attempt++;
+    final jitterRatio = 0.8 + _random.nextDouble() * 0.4; // 0.8x~1.2x
+    return capped * jitterRatio;
+  }
+
+  /// [reachability]가 먼저 이벤트를 내보내면(=OS가 네트워크 회복/전환을 감지) 남은 백오프
+  /// 대기를 포기하고 즉시 반환한다. 그렇지 않으면 nextDelay()만큼 그냥 기다린다.
+  ///
+  /// [reachability]가 이벤트 없이 에러나 종료로 끝나도(예: connectivity_plus 플랫폼 채널
+  /// 예외) 그 실패를 밖으로 던지지 않는다 — 이 메서드가 재연결 루프의 유일한 대기 지점인데
+  /// 여기서 에러가 새어나가면 루프 전체가 죽어서 다시는 재연결을 시도하지 않게 된다. 그런
+  /// 경우엔 그냥 nextDelay() 타이머만으로 계속 동작한다.
+  Future<void> waitOrFastRetryOn(Stream<void> reachability) {
+    final never = Completer<void>().future;
+    final onReachable = reachability.first.then<void>((_) {}, onError: (_) => never);
+    return Future.any<void>([
+      Future<void>.delayed(nextDelay()),
+      onReachable,
+    ]);
+  }
+}

--- a/frontend/lib/shared/api/sse/sse_client.dart
+++ b/frontend/lib/shared/api/sse/sse_client.dart
@@ -24,7 +24,17 @@ class SseClient {
   final Duration heartbeatTimeout;
 
   /// [path] 예: '/events/track/{trackId}', '/camps/{campId}/events/admin'.
-  Stream<SSENotification> connect(String path) {
+  ///
+  /// [onConnected]: HTTP 응답이 성공적으로 도착해 바이트 스트림 구독을 시작하는 시점(=연결 성립)에
+  /// 정확히 1회 호출된다. 도메인 알림 파싱 성공 여부와 무관하다.
+  /// [onDisconnected]: 워치독 타임아웃, HTTP 스트림 에러, 스트림 종료(onDone), 최초 연결 실패
+  /// 중 하나가 발생할 때마다 정확히 1회 호출되며, 항상 controller.addError/close()보다 먼저
+  /// 호출된다 — 호출측(track_event_stream.dart)이 실패 1건을 정확히 1번만 세도록 하기 위함.
+  Stream<SSENotification> connect(
+    String path, {
+    void Function()? onConnected,
+    void Function()? onDisconnected,
+  }) {
     late final StreamController<SSENotification> controller;
     final cancelToken = CancelToken();
     StreamSubscription<Uint8List>? subscription;
@@ -40,6 +50,7 @@ class SseClient {
     void resetWatchdog() {
       watchdogTimer?.cancel();
       watchdogTimer = Timer(heartbeatTimeout, () {
+        onDisconnected?.call();
         if (!controller.isClosed) {
           controller.addError(
             TimeoutException('SSE heartbeat timeout after $heartbeatTimeout'),
@@ -117,10 +128,12 @@ class SseClient {
               headers: {'Accept': 'text/event-stream'},
             ),
           );
+          onConnected?.call();
           subscription = response.data!.stream.listen(
             onChunk,
             onError: (Object error, StackTrace stackTrace) {
               watchdogTimer?.cancel();
+              onDisconnected?.call();
               if (!controller.isClosed) {
                 controller.addError(error, stackTrace);
                 controller.close();
@@ -128,12 +141,14 @@ class SseClient {
             },
             onDone: () {
               watchdogTimer?.cancel();
+              onDisconnected?.call();
               if (!controller.isClosed) controller.close();
             },
             cancelOnError: true,
           );
         } catch (error, stackTrace) {
           watchdogTimer?.cancel();
+          onDisconnected?.call();
           if (!controller.isClosed) {
             controller.addError(error, stackTrace);
             controller.close();

--- a/frontend/lib/shared/api/sse/track_event_stream.dart
+++ b/frontend/lib/shared/api/sse/track_event_stream.dart
@@ -3,7 +3,10 @@ import 'dart:async';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:cornermon_api_gen/cornermon_api_gen.dart';
 
+import '../../config/app_env.dart';
+import '../../network/network_reachability.dart';
 import '../ids.dart';
+import 'reconnect_backoff.dart';
 import 'sse_client.dart';
 
 part 'track_event_stream.g.dart';
@@ -11,43 +14,63 @@ part 'track_event_stream.g.dart';
 /// B2 헤더 ConnectionBanner에 매핑되는 연결 상태(§01 2-2 책임 분리).
 enum TrackConnectionState { connected, reconnecting, disconnected }
 
-/// 원시 이벤트 스트림 — 에러/종료 시 짧은 backoff 후 재연결을 반복해
-/// 구독자에게는 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임).
+// keepAlive: true인 이유 — trackEvents()가 ref.watch가 아니라 ref.read(...notifier)로 이
+// notifier를 붙잡는데, autoDispose 상태에서는 위젯(MainTrackHeader)이 아직 watch를 시작하기
+// 전이면 리스너가 0개가 되는 순간 곧바로 dispose→재생성되어 trackEvents가 들고 있던 참조가
+// 고아가 될 수 있다(상태 갱신이 아무도 안 보는 인스턴스에만 반영됨). 상태값 자체는 enum
+// 하나뿐이라 계속 들고 있어도 비용이 없으므로 keepAlive로 이 경쟁을 근본적으로 없앤다.
+@Riverpod(keepAlive: true)
+class TrackConnection extends _$TrackConnection {
+  int _consecutiveMisses = 0;
+
+  @override
+  TrackConnectionState build(TrackId trackId) => TrackConnectionState.reconnecting;
+
+  // 같은 파일 내부(trackEvents())에서만 호출하는 private 갱신 메서드.
+  void _markConnected() {
+    _consecutiveMisses = 0;
+    state = TrackConnectionState.connected;
+  }
+
+  void _markDisconnected() {
+    _consecutiveMisses++;
+    state = _consecutiveMisses >= AppEnv.sseMaxConsecutiveMisses
+        ? TrackConnectionState.disconnected
+        : TrackConnectionState.reconnecting;
+  }
+}
+
+/// 원시 이벤트 스트림 — 에러/종료 시 지수 백오프(+지터) 후 재연결을 반복해 구독자에게는
+/// 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임). 연결 상태(배너 표시)는
+/// 도메인 알림 도착 여부가 아니라 SseClient의 연결/해제 콜백으로 직접 판단한다(TrackConnection).
 @riverpod
 Stream<SSENotification> trackEvents(Ref ref, TrackId trackId) async* {
   var disposed = false;
   ref.onDispose(() => disposed = true);
 
   final client = ref.watch(sseClientProvider);
+  final connection = ref.read(trackConnectionProvider(trackId).notifier);
+  final reachability = ref.watch(networkReachabilityProvider).stream;
+  final backoff = ReconnectBackoff();
   final path = '/events/track/${trackId.value}';
 
   while (!disposed) {
     try {
-      yield* client.connect(path);
+      yield* client.connect(
+        path,
+        onConnected: () {
+          backoff.reset();
+          connection._markConnected();
+        },
+        onDisconnected: connection._markDisconnected,
+      );
       // 서버가 정상적으로 스트림을 끝내도(done) 계속 살아있어야 하므로 재연결 루프로 진입.
     } catch (_) {
-      // 연결 에러를 구독자에게 전파하지 않고 여기서 삼킨 뒤 재연결한다.
+      // 실패 원인과 무관하게 SseClient가 실패 시점에 이미 onDisconnected를 호출한 뒤
+      // 에러를 던진다 — 여기서 다시 _markDisconnected()를 부르면 같은 실패를 두 번 세게
+      // 되어 카운터가 실제보다 빨리 올라간다. 그래서 여기서는 그냥 삼키기만 한다.
     }
     if (disposed) break;
-    await Future<void>.delayed(const Duration(seconds: 1));
-  }
-}
-
-@riverpod
-class TrackConnection extends _$TrackConnection {
-  @override
-  TrackConnectionState build(TrackId trackId) {
-    ref.listen<AsyncValue<SSENotification>>(
-      trackEventsProvider(trackId),
-      (previous, next) {
-        state = next.when(
-          data: (_) => TrackConnectionState.connected,
-          error: (_, _) => TrackConnectionState.reconnecting,
-          loading: () => TrackConnectionState.reconnecting,
-        );
-      },
-      fireImmediately: true,
-    );
-    return TrackConnectionState.reconnecting;
+    await backoff.waitOrFastRetryOn(reachability);
   }
 }

--- a/frontend/lib/shared/api/sse/track_event_stream.g.dart
+++ b/frontend/lib/shared/api/sse/track_event_stream.g.dart
@@ -8,14 +8,114 @@ part of 'track_event_stream.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// 원시 이벤트 스트림 — 에러/종료 시 짧은 backoff 후 재연결을 반복해
-/// 구독자에게는 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임).
+
+@ProviderFor(TrackConnection)
+final trackConnectionProvider = TrackConnectionFamily._();
+
+final class TrackConnectionProvider
+    extends $NotifierProvider<TrackConnection, TrackConnectionState> {
+  TrackConnectionProvider._({
+    required TrackConnectionFamily super.from,
+    required TrackId super.argument,
+  }) : super(
+         retry: null,
+         name: r'trackConnectionProvider',
+         isAutoDispose: false,
+         dependencies: null,
+         $allTransitiveDependencies: null,
+       );
+
+  @override
+  String debugGetCreateSourceHash() => _$trackConnectionHash();
+
+  @override
+  String toString() {
+    return r'trackConnectionProvider'
+        ''
+        '($argument)';
+  }
+
+  @$internal
+  @override
+  TrackConnection create() => TrackConnection();
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(TrackConnectionState value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<TrackConnectionState>(value),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is TrackConnectionProvider && other.argument == argument;
+  }
+
+  @override
+  int get hashCode {
+    return argument.hashCode;
+  }
+}
+
+String _$trackConnectionHash() => r'3da84620855636876bac0561b355314d776a6f18';
+
+final class TrackConnectionFamily extends $Family
+    with
+        $ClassFamilyOverride<
+          TrackConnection,
+          TrackConnectionState,
+          TrackConnectionState,
+          TrackConnectionState,
+          TrackId
+        > {
+  TrackConnectionFamily._()
+    : super(
+        retry: null,
+        name: r'trackConnectionProvider',
+        dependencies: null,
+        $allTransitiveDependencies: null,
+        isAutoDispose: false,
+      );
+
+  TrackConnectionProvider call(TrackId trackId) =>
+      TrackConnectionProvider._(argument: trackId, from: this);
+
+  @override
+  String toString() => r'trackConnectionProvider';
+}
+
+abstract class _$TrackConnection extends $Notifier<TrackConnectionState> {
+  late final _$args = ref.$arg as TrackId;
+  TrackId get trackId => _$args;
+
+  TrackConnectionState build(TrackId trackId);
+  @$mustCallSuper
+  @override
+  WhenComplete runBuild() {
+    final ref = this.ref as $Ref<TrackConnectionState, TrackConnectionState>;
+    final element =
+        ref.element
+            as $ClassProviderElement<
+              AnyNotifier<TrackConnectionState, TrackConnectionState>,
+              TrackConnectionState,
+              Object?,
+              Object?
+            >;
+    return element.handleCreate(ref, () => build(_$args));
+  }
+}
+
+/// 원시 이벤트 스트림 — 에러/종료 시 지수 백오프(+지터) 후 재연결을 반복해 구독자에게는
+/// 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임). 연결 상태(배너 표시)는
+/// 도메인 알림 도착 여부가 아니라 SseClient의 연결/해제 콜백으로 직접 판단한다(TrackConnection).
 
 @ProviderFor(trackEvents)
 final trackEventsProvider = TrackEventsFamily._();
 
-/// 원시 이벤트 스트림 — 에러/종료 시 짧은 backoff 후 재연결을 반복해
-/// 구독자에게는 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임).
+/// 원시 이벤트 스트림 — 에러/종료 시 지수 백오프(+지터) 후 재연결을 반복해 구독자에게는
+/// 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임). 연결 상태(배너 표시)는
+/// 도메인 알림 도착 여부가 아니라 SseClient의 연결/해제 콜백으로 직접 판단한다(TrackConnection).
 
 final class TrackEventsProvider
     extends
@@ -25,8 +125,9 @@ final class TrackEventsProvider
           Stream<SSENotification>
         >
     with $FutureModifier<SSENotification>, $StreamProvider<SSENotification> {
-  /// 원시 이벤트 스트림 — 에러/종료 시 짧은 backoff 후 재연결을 반복해
-  /// 구독자에게는 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임).
+  /// 원시 이벤트 스트림 — 에러/종료 시 지수 백오프(+지터) 후 재연결을 반복해 구독자에게는
+  /// 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임). 연결 상태(배너 표시)는
+  /// 도메인 알림 도착 여부가 아니라 SseClient의 연결/해제 콜백으로 직접 판단한다(TrackConnection).
   TrackEventsProvider._({
     required TrackEventsFamily super.from,
     required TrackId super.argument,
@@ -71,10 +172,11 @@ final class TrackEventsProvider
   }
 }
 
-String _$trackEventsHash() => r'52016534ae8cc842cfc7a5d81044ecc8f8a4fae7';
+String _$trackEventsHash() => r'20f4c2d565465610cdc0f0cf7a619d332901370d';
 
-/// 원시 이벤트 스트림 — 에러/종료 시 짧은 backoff 후 재연결을 반복해
-/// 구독자에게는 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임).
+/// 원시 이벤트 스트림 — 에러/종료 시 지수 백오프(+지터) 후 재연결을 반복해 구독자에게는
+/// 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임). 연결 상태(배너 표시)는
+/// 도메인 알림 도착 여부가 아니라 SseClient의 연결/해제 콜백으로 직접 판단한다(TrackConnection).
 
 final class TrackEventsFamily extends $Family
     with $FunctionalFamilyOverride<Stream<SSENotification>, TrackId> {
@@ -87,109 +189,13 @@ final class TrackEventsFamily extends $Family
         isAutoDispose: true,
       );
 
-  /// 원시 이벤트 스트림 — 에러/종료 시 짧은 backoff 후 재연결을 반복해
-  /// 구독자에게는 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임).
+  /// 원시 이벤트 스트림 — 에러/종료 시 지수 백오프(+지터) 후 재연결을 반복해 구독자에게는
+  /// 끊기지 않는 스트림처럼 보이게 한다(좀비연결 감지는 SseClient 책임). 연결 상태(배너 표시)는
+  /// 도메인 알림 도착 여부가 아니라 SseClient의 연결/해제 콜백으로 직접 판단한다(TrackConnection).
 
   TrackEventsProvider call(TrackId trackId) =>
       TrackEventsProvider._(argument: trackId, from: this);
 
   @override
   String toString() => r'trackEventsProvider';
-}
-
-@ProviderFor(TrackConnection)
-final trackConnectionProvider = TrackConnectionFamily._();
-
-final class TrackConnectionProvider
-    extends $NotifierProvider<TrackConnection, TrackConnectionState> {
-  TrackConnectionProvider._({
-    required TrackConnectionFamily super.from,
-    required TrackId super.argument,
-  }) : super(
-         retry: null,
-         name: r'trackConnectionProvider',
-         isAutoDispose: true,
-         dependencies: null,
-         $allTransitiveDependencies: null,
-       );
-
-  @override
-  String debugGetCreateSourceHash() => _$trackConnectionHash();
-
-  @override
-  String toString() {
-    return r'trackConnectionProvider'
-        ''
-        '($argument)';
-  }
-
-  @$internal
-  @override
-  TrackConnection create() => TrackConnection();
-
-  /// {@macro riverpod.override_with_value}
-  Override overrideWithValue(TrackConnectionState value) {
-    return $ProviderOverride(
-      origin: this,
-      providerOverride: $SyncValueProvider<TrackConnectionState>(value),
-    );
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return other is TrackConnectionProvider && other.argument == argument;
-  }
-
-  @override
-  int get hashCode {
-    return argument.hashCode;
-  }
-}
-
-String _$trackConnectionHash() => r'ebc3def95f68f7d598f1e46e43d55895fe22dc69';
-
-final class TrackConnectionFamily extends $Family
-    with
-        $ClassFamilyOverride<
-          TrackConnection,
-          TrackConnectionState,
-          TrackConnectionState,
-          TrackConnectionState,
-          TrackId
-        > {
-  TrackConnectionFamily._()
-    : super(
-        retry: null,
-        name: r'trackConnectionProvider',
-        dependencies: null,
-        $allTransitiveDependencies: null,
-        isAutoDispose: true,
-      );
-
-  TrackConnectionProvider call(TrackId trackId) =>
-      TrackConnectionProvider._(argument: trackId, from: this);
-
-  @override
-  String toString() => r'trackConnectionProvider';
-}
-
-abstract class _$TrackConnection extends $Notifier<TrackConnectionState> {
-  late final _$args = ref.$arg as TrackId;
-  TrackId get trackId => _$args;
-
-  TrackConnectionState build(TrackId trackId);
-  @$mustCallSuper
-  @override
-  WhenComplete runBuild() {
-    final ref = this.ref as $Ref<TrackConnectionState, TrackConnectionState>;
-    final element =
-        ref.element
-            as $ClassProviderElement<
-              AnyNotifier<TrackConnectionState, TrackConnectionState>,
-              TrackConnectionState,
-              Object?,
-              Object?
-            >;
-    return element.handleCreate(ref, () => build(_$args));
-  }
 }

--- a/frontend/lib/shared/config/app_env.dart
+++ b/frontend/lib/shared/config/app_env.dart
@@ -22,4 +22,11 @@ class AppEnv {
     'SSE_HEARTBEAT_TIMEOUT_SECONDS',
     defaultValue: 40,
   );
+
+  /// 재연결 시도가 이 횟수만큼 연속으로 실패하면(그 사이 단 한 번도 재연결에 성공하지 못하면)
+  /// "죽은 연결"로 보고 연결 배너를 disconnected로 전환한다.
+  static const int sseMaxConsecutiveMisses = int.fromEnvironment(
+    'SSE_MAX_CONSECUTIVE_MISSES',
+    defaultValue: 3,
+  );
 }

--- a/frontend/lib/shared/network/network_reachability.dart
+++ b/frontend/lib/shared/network/network_reachability.dart
@@ -1,0 +1,26 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'network_reachability.g.dart';
+
+/// [stream]은 "네트워크가 쓸 수 있는 상태로 바뀜" 이벤트만 걸러낸 broadcast 스트림이다.
+/// `@riverpod Stream&lt;void&gt;`로 직접 선언하지 않는 이유: 그렇게 하면 Riverpod이 이 provider를
+/// StreamProvider(AsyncValue&lt;void&gt; 래핑)로 취급해 원시 Stream을 꺼낼 방법이 없어진다
+/// (riverpod 3.x는 `.stream` modifier를 제공하지 않음). 그래서 평범한 값 provider로 감싼다.
+class NetworkReachability {
+  NetworkReachability(this.stream);
+
+  final Stream<void> stream;
+}
+
+/// connectivity_plus의 원시 이벤트(예: none→wifi, wifi→mobile)를 그대로 넘기지 않고,
+/// "연결 가능한 상태로 바뀜"만 걸러서 내보낸다 — SSE 재연결 루프는 구체적인 인터페이스
+/// 종류(wifi/mobile)에는 관심 없고 "지금 재시도해볼 만하다"는 신호만 필요하기 때문이다.
+@Riverpod(keepAlive: true)
+NetworkReachability networkReachability(Ref ref) {
+  final connectivity = Connectivity();
+  final stream = connectivity.onConnectivityChanged
+      .where((results) => !results.contains(ConnectivityResult.none))
+      .map((_) {});
+  return NetworkReachability(stream);
+}

--- a/frontend/lib/shared/network/network_reachability.g.dart
+++ b/frontend/lib/shared/network/network_reachability.g.dart
@@ -1,0 +1,68 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'network_reachability.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// connectivity_plus의 원시 이벤트(예: none→wifi, wifi→mobile)를 그대로 넘기지 않고,
+/// "연결 가능한 상태로 바뀜"만 걸러서 내보낸다 — SSE 재연결 루프는 구체적인 인터페이스
+/// 종류(wifi/mobile)에는 관심 없고 "지금 재시도해볼 만하다"는 신호만 필요하기 때문이다.
+
+@ProviderFor(networkReachability)
+final networkReachabilityProvider = NetworkReachabilityProvider._();
+
+/// connectivity_plus의 원시 이벤트(예: none→wifi, wifi→mobile)를 그대로 넘기지 않고,
+/// "연결 가능한 상태로 바뀜"만 걸러서 내보낸다 — SSE 재연결 루프는 구체적인 인터페이스
+/// 종류(wifi/mobile)에는 관심 없고 "지금 재시도해볼 만하다"는 신호만 필요하기 때문이다.
+
+final class NetworkReachabilityProvider
+    extends
+        $FunctionalProvider<
+          NetworkReachability,
+          NetworkReachability,
+          NetworkReachability
+        >
+    with $Provider<NetworkReachability> {
+  /// connectivity_plus의 원시 이벤트(예: none→wifi, wifi→mobile)를 그대로 넘기지 않고,
+  /// "연결 가능한 상태로 바뀜"만 걸러서 내보낸다 — SSE 재연결 루프는 구체적인 인터페이스
+  /// 종류(wifi/mobile)에는 관심 없고 "지금 재시도해볼 만하다"는 신호만 필요하기 때문이다.
+  NetworkReachabilityProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'networkReachabilityProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$networkReachabilityHash();
+
+  @$internal
+  @override
+  $ProviderElement<NetworkReachability> $createElement(
+    $ProviderPointer pointer,
+  ) => $ProviderElement(pointer);
+
+  @override
+  NetworkReachability create(Ref ref) {
+    return networkReachability(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NetworkReachability value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NetworkReachability>(value),
+    );
+  }
+}
+
+String _$networkReachabilityHash() =>
+    r'fdfdaeca6a810d0d82c32b3296cb37f21252cdcb';

--- a/frontend/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/frontend/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import connectivity_plus
 import device_info_plus
 import flutter_secure_storage_darwin
 import mobile_scanner
@@ -12,6 +13,7 @@ import printing
 import share_plus
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -177,6 +177,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  connectivity_plus:
+    dependency: "direct main"
+    description:
+      name: connectivity_plus
+      sha256: "25cebb79dfe304022550e0c3c893ae051ded07183d2607f7b88473cb3ade33cb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.0"
+  connectivity_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: connectivity_plus_platform_interface
+      sha256: "3c09627c536d22fd24691a905cdd8b14520de69da52c7a97499c8be5284a32ed"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   convert:
     dependency: transitive
     description:
@@ -232,6 +248,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.8"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: "792974a4007974fbc5c1b5433eb2330a9db3e368c3f906253af4c007d0f49a91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.13"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -596,6 +620,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.6.4"
+  nm:
+    dependency: transitive
+    description:
+      name: nm
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   cornermon_api_gen:
     path: lib/shared/api/gen
   device_info_plus: ^12.4.0
+  connectivity_plus: ^7.3.0
 
 dev_dependencies:
   flutter_test:

--- a/frontend/test/shared/api/sse/reconnect_backoff_test.dart
+++ b/frontend/test/shared/api/sse/reconnect_backoff_test.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:cornermon/shared/api/sse/reconnect_backoff.dart';
+
+/// 지터를 없애 매 호출의 delay를 결정론적으로 만드는 fake Random (항상 0을 반환 → jitterRatio 0.8x).
+class _ZeroRandom implements Random {
+  @override
+  double nextDouble() => 0;
+
+  @override
+  bool nextBool() => false;
+
+  @override
+  int nextInt(int max) => 0;
+}
+
+void main() {
+  group('ReconnectBackoff', () {
+    test('ShouldDoubleDelayOnEachConsecutiveFailure', () {
+      // arrange — 지터를 0.8x로 고정해 지수 증가분만 검증한다.
+      final backoff = ReconnectBackoff(
+        initialDelay: const Duration(milliseconds: 300),
+        maxDelay: const Duration(seconds: 5),
+        random: _ZeroRandom(),
+      );
+
+      // act
+      final delays = List.generate(4, (_) => backoff.nextDelay());
+
+      // assert — 300ms, 600ms, 1200ms, 2400ms에 각각 0.8배.
+      expect(delays[0], const Duration(milliseconds: 240));
+      expect(delays[1], const Duration(milliseconds: 480));
+      expect(delays[2], const Duration(milliseconds: 960));
+      expect(delays[3], const Duration(milliseconds: 1920));
+    });
+
+    test('ShouldCapDelayAtMaxDelay', () {
+      // arrange
+      final backoff = ReconnectBackoff(
+        initialDelay: const Duration(milliseconds: 300),
+        maxDelay: const Duration(seconds: 5),
+        random: _ZeroRandom(),
+      );
+
+      // act — 실패를 충분히 반복해 지수 증가가 상한을 넘어서게 만든다.
+      Duration? lastDelay;
+      for (var i = 0; i < 10; i++) {
+        lastDelay = backoff.nextDelay();
+      }
+
+      // assert — 상한(5초)의 0.8배를 넘지 않는다.
+      expect(lastDelay! <= const Duration(seconds: 5), isTrue);
+      expect(lastDelay, const Duration(milliseconds: 4000)); // 5000ms * 0.8
+    });
+
+    test('ShouldRestartFromInitialDelayAfterReset', () {
+      // arrange
+      final backoff = ReconnectBackoff(
+        initialDelay: const Duration(milliseconds: 300),
+        maxDelay: const Duration(seconds: 5),
+        random: _ZeroRandom(),
+      );
+      backoff.nextDelay();
+      backoff.nextDelay();
+      backoff.nextDelay();
+
+      // act
+      backoff.reset();
+      final delayAfterReset = backoff.nextDelay();
+
+      // assert — reset() 후엔 다시 initialDelay(×0.8) 근처로 돌아온다.
+      expect(delayAfterReset, const Duration(milliseconds: 240));
+    });
+
+    test('ShouldApplyJitterWithinConfiguredRange', () {
+      // arrange — 실제 Random을 써서 매 호출마다 값이 달라지는지, 범위 안인지 확인한다.
+      final backoff = ReconnectBackoff(
+        initialDelay: const Duration(seconds: 1),
+        maxDelay: const Duration(seconds: 5),
+      );
+
+      // act
+      final delay = backoff.nextDelay();
+
+      // assert — 1초 * [0.8, 1.2] 범위.
+      expect(delay.inMilliseconds, greaterThanOrEqualTo(800));
+      expect(delay.inMilliseconds, lessThanOrEqualTo(1200));
+    });
+
+    test('ShouldSkipRemainingDelayWhenReachabilityEmitsFirst', () async {
+      // arrange — 아주 긴 백오프 대기 중에 reachability 이벤트가 먼저 도착하면 즉시 반환돼야 한다.
+      final backoff = ReconnectBackoff(
+        initialDelay: const Duration(seconds: 10),
+        maxDelay: const Duration(seconds: 10),
+      );
+      final reachability = StreamController<void>();
+      addTearDown(reachability.close);
+
+      // act
+      final future = backoff.waitOrFastRetryOn(reachability.stream);
+      reachability.add(null);
+
+      // assert — 10초를 기다리지 않고 훨씬 빨리 반환된다.
+      await expectLater(future, completes).timeout(const Duration(seconds: 1));
+    });
+
+    test('ShouldWaitFullDelayWhenReachabilityNeverEmits', () async {
+      // arrange
+      final backoff = ReconnectBackoff(
+        initialDelay: const Duration(milliseconds: 50),
+        maxDelay: const Duration(milliseconds: 50),
+        random: _ZeroRandom(),
+      );
+      final reachability = StreamController<void>();
+      addTearDown(reachability.close);
+
+      // act
+      final stopwatch = Stopwatch()..start();
+      await backoff.waitOrFastRetryOn(reachability.stream);
+      stopwatch.stop();
+
+      // assert — jitterRatio 0.8x이므로 40ms 근처에서 반환된다.
+      expect(stopwatch.elapsedMilliseconds, greaterThanOrEqualTo(30));
+    });
+
+    test('ShouldFallBackToDelayWhenReachabilityStreamCompletesWithoutEmitting', () async {
+      // arrange — 이벤트 없이 곧바로 끝나는 스트림(reachability.first가 StateError를 던지는
+      // 상황)을 흉내낸다. 이 에러가 waitOrFastRetryOn 밖으로 새어나가면 재연결 루프 전체가
+      // 죽어버리므로, 여기선 조용히 무시되고 nextDelay()만으로 정상 완료돼야 한다.
+      final backoff = ReconnectBackoff(
+        initialDelay: const Duration(milliseconds: 50),
+        maxDelay: const Duration(milliseconds: 50),
+        random: _ZeroRandom(),
+      );
+
+      // act & assert — 에러 없이 완료돼야 한다.
+      await expectLater(
+        backoff.waitOrFastRetryOn(const Stream.empty()),
+        completes,
+      ).timeout(const Duration(seconds: 1));
+    });
+  });
+}

--- a/frontend/test/shared/api/sse/sse_client_test.dart
+++ b/frontend/test/shared/api/sse/sse_client_test.dart
@@ -34,6 +34,21 @@ class _FakeStreamAdapter implements HttpClientAdapter {
   void close({bool force = false}) {}
 }
 
+/// 최초 HTTP 요청 자체가 실패하는 상황(연결 거부 등)을 재현하는 fake adapter.
+class _ThrowingAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) {
+    throw DioException(requestOptions: options, error: 'connection refused');
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
 Dio _buildFakeDio(Stream<Uint8List> Function() streamFactory) {
   final dio = Dio(BaseOptions(baseUrl: 'http://test.local'))
     ..httpClientAdapter = _FakeStreamAdapter(streamFactory);
@@ -115,6 +130,88 @@ void main() {
       expect(events, hasLength(1));
       expect(events.single.event, SSENotificationEventEnum.groupsUpdated);
       expect(events.single.scope?.kind, SSEScopeKindEnum.camp);
+    });
+
+    test('ShouldCallOnConnectedOnceWhenHttpResponseArrivesRegardlessOfDataArrival', () async {
+      // arrange — 데이터를 전혀 안 보내는 스트림이라도 HTTP 응답 자체는 성공한다.
+      final neverEmitting = StreamController<Uint8List>();
+      addTearDown(neverEmitting.close);
+      final dio = _buildFakeDio(() => neverEmitting.stream);
+      final sseClient = SseClient(dio, heartbeatTimeout: const Duration(seconds: 5));
+      var connectedCount = 0;
+
+      // act
+      final sub = sseClient
+          .connect('/events/track/t1', onConnected: () => connectedCount++)
+          .listen((_) {});
+      addTearDown(sub.cancel);
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      // assert — 도메인 알림이 하나도 없어도 onConnected는 이미 1회 호출돼 있어야 한다.
+      expect(connectedCount, 1);
+    });
+
+    test('ShouldCallOnDisconnectedOnceWhenHeartbeatTimeoutElapses', () async {
+      // arrange
+      final neverEmitting = StreamController<Uint8List>();
+      addTearDown(neverEmitting.close);
+      final dio = _buildFakeDio(() => neverEmitting.stream);
+      final sseClient = SseClient(dio, heartbeatTimeout: const Duration(milliseconds: 50));
+      var disconnectedCount = 0;
+
+      // act
+      final stream = sseClient.connect(
+        '/events/track/t1',
+        onDisconnected: () => disconnectedCount++,
+      );
+
+      // assert
+      await expectLater(
+        stream,
+        emitsError(isA<TimeoutException>()),
+      ).timeout(const Duration(milliseconds: 500));
+      expect(disconnectedCount, 1);
+    });
+
+    test('ShouldCallOnDisconnectedOnceWhenStreamEndsNormally', () async {
+      // arrange
+      const frame = 'event: track_updated\ndata: {"event":"track_updated","scope":{"kind":"track","trackId":"t1"}}\n\n';
+      final dio = _buildFakeDio(() => Stream.value(_bytes(frame)));
+      final sseClient = SseClient(dio);
+      var connectedCount = 0;
+      var disconnectedCount = 0;
+
+      // act
+      final events = await sseClient
+          .connect(
+            '/events/track/t1',
+            onConnected: () => connectedCount++,
+            onDisconnected: () => disconnectedCount++,
+          )
+          .toList();
+
+      // assert — onDone도 실패(재연결 필요) 취급이므로 onDisconnected가 정확히 1회 불려야 한다.
+      expect(events, hasLength(1));
+      expect(connectedCount, 1);
+      expect(disconnectedCount, 1);
+    });
+
+    test('ShouldCallOnDisconnectedOnceWhenInitialHttpRequestFails', () async {
+      // arrange
+      final dio = Dio(BaseOptions(baseUrl: 'http://test.local'))
+        ..httpClientAdapter = _ThrowingAdapter();
+      final sseClient = SseClient(dio);
+      var disconnectedCount = 0;
+
+      // act
+      final stream = sseClient.connect(
+        '/events/track/t1',
+        onDisconnected: () => disconnectedCount++,
+      );
+
+      // assert
+      await expectLater(stream, emitsError(isA<Object>()));
+      expect(disconnectedCount, 1);
     });
   });
 }

--- a/frontend/test/shared/api/sse/track_event_stream_test.dart
+++ b/frontend/test/shared/api/sse/track_event_stream_test.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+
+import 'package:cornermon_api_gen/cornermon_api_gen.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/sse/sse_client.dart';
+import 'package:cornermon/shared/api/sse/track_event_stream.dart';
+import 'package:cornermon/shared/network/network_reachability.dart';
+
+/// 실제 HTTP/워치독 로직(sse_client_test.dart에서 이미 검증됨) 없이, connect() 호출마다
+/// 미리 정해둔 각본(성공/실패)대로 onConnected/onDisconnected를 호출하고 스트림을 돌려주는 fake.
+/// SseClient의 실제 계약(실패마다 onDisconnected 정확히 1회 → 에러)을 그대로 흉내낸다.
+///
+/// [onCall]로 "N번째 connect() 호출이 끝났다"는 신호를 내보내, 테스트가 지수 백오프의 실제
+/// 대기시간을 어림짐작해 sleep하지 않고도 정확한 시점에 상태를 검증할 수 있게 한다.
+class _ScriptedSseClient extends SseClient {
+  _ScriptedSseClient(this._script) : super(Dio());
+
+  final List<bool> _script; // true=성공(연결 유지), false=실패
+  int callCount = 0;
+  final _callController = StreamController<int>.broadcast();
+  Stream<int> get onCall => _callController.stream;
+
+  @override
+  Stream<SSENotification> connect(
+    String path, {
+    void Function()? onConnected,
+    void Function()? onDisconnected,
+  }) {
+    final index = callCount;
+    final succeed = index < _script.length ? _script[index] : _script.last;
+    final controller = StreamController<SSENotification>();
+
+    if (succeed) {
+      onConnected?.call();
+      // 연결을 계속 살아있게 둔다(도메인 이벤트는 이 테스트의 관심사가 아님) — controller를
+      // 절대 close/addError하지 않는다.
+      addTearDown(controller.close);
+    } else {
+      onDisconnected?.call();
+      scheduleMicrotask(() {
+        controller.addError(Exception('scripted failure'));
+        controller.close();
+      });
+    }
+
+    // 상태 갱신(onConnected/onDisconnected)이 이미 반영된 뒤에 호출 카운트를 알린다 —
+    // 테스트가 firstWhere로 대기를 풀었을 때 상태가 아직 안 바뀐 상태로 관측되는 일이 없게.
+    callCount = index + 1;
+    _callController.add(callCount);
+    return controller.stream;
+  }
+}
+
+void main() {
+  final trackId = TrackId('t1');
+
+  ({ProviderContainer container, _ScriptedSseClient client}) buildContainer(
+    List<bool> script,
+  ) {
+    final client = _ScriptedSseClient(script);
+    addTearDown(client._callController.close);
+    final container = ProviderContainer(
+      overrides: [
+        sseClientProvider.overrideWithValue(client),
+        networkReachabilityProvider.overrideWithValue(
+          NetworkReachability(const Stream.empty()), // 이 테스트들은 reachability 경합을 다루지 않음
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+    return (container: container, client: client);
+  }
+
+  group('TrackConnection', () {
+    test('ShouldBecomeConnectedAssoonAsSseClientConnectsWithoutAnyDomainEvent', () async {
+      // arrange — 연결은 되지만 도메인 이벤트는 전혀 오지 않는 스트림(하트비트만 있는 상황과 동일).
+      final ctx = buildContainer([true]);
+      final sub = ctx.container.listen(trackEventsProvider(trackId), (_, _) {});
+      addTearDown(sub.close);
+
+      // act
+      await ctx.client.onCall.first;
+
+      // assert
+      expect(
+        ctx.container.read(trackConnectionProvider(trackId)),
+        TrackConnectionState.connected,
+      );
+    });
+
+    test('ShouldStayReconnectingAfterFewerThanThresholdConsecutiveFailures', () async {
+      // arrange — 2번 연속 실패 후 성공. disconnected 임계값(3)에는 못 미친다.
+      final ctx = buildContainer([false, false, true]);
+      final sub = ctx.container.listen(trackEventsProvider(trackId), (_, _) {});
+      addTearDown(sub.close);
+
+      // act
+      await ctx.client.onCall.firstWhere((count) => count >= 3);
+
+      // assert
+      expect(
+        ctx.container.read(trackConnectionProvider(trackId)),
+        TrackConnectionState.connected,
+      );
+    });
+
+    test('ShouldBecomeDisconnectedAfterThreeConsecutiveFailuresWithoutAnySuccess', () async {
+      // arrange — 항상 실패.
+      final ctx = buildContainer([false]);
+      final sub = ctx.container.listen(trackEventsProvider(trackId), (_, _) {});
+      addTearDown(sub.close);
+
+      // act — "3번째에서만" disconnected가 되는지(=중복 카운트 없이 정확히 1:1로 세는지)
+      // 2번째 실패 직후 상태를 먼저 확인한다.
+      await ctx.client.onCall.firstWhere((count) => count >= 2);
+      final afterTwoFailures = ctx.container.read(trackConnectionProvider(trackId));
+
+      await ctx.client.onCall.firstWhere((count) => count >= 3);
+      final afterThreeFailures = ctx.container.read(trackConnectionProvider(trackId));
+
+      // assert
+      expect(afterTwoFailures, TrackConnectionState.reconnecting);
+      expect(afterThreeFailures, TrackConnectionState.disconnected);
+    });
+
+    test('ShouldResetConsecutiveMissCounterOnSuccessfulReconnect', () async {
+      // arrange — 실패 2번 → 성공 → 실패 2번을 반복해도, 중간 성공이 카운터를 리셋하므로
+      // 두 번째 구간의 실패 2번만으로는 disconnected에 도달하지 않아야 한다.
+      final ctx = buildContainer([false, false, true, false, false, true]);
+      final sub = ctx.container.listen(trackEventsProvider(trackId), (_, _) {});
+      addTearDown(sub.close);
+
+      // act
+      await ctx.client.onCall.firstWhere((count) => count >= 6);
+
+      // assert — 마지막 시도가 성공이므로 connected로 돌아와 있어야 한다.
+      expect(
+        ctx.container.read(trackConnectionProvider(trackId)),
+        TrackConnectionState.connected,
+      );
+    });
+  });
+}

--- a/frontend/windows/flutter/generated_plugin_registrant.cc
+++ b/frontend/windows/flutter/generated_plugin_registrant.cc
@@ -6,12 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <printing/printing_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  ConnectivityPlusWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   PrintingPluginRegisterWithRegistrar(

--- a/frontend/windows/flutter/generated_plugins.cmake
+++ b/frontend/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  connectivity_plus
   flutter_secure_storage_windows
   printing
   share_plus


### PR DESCRIPTION
## Summary
- 트랙 SSE 연결 상태(재연결 배너)가 도메인 알림(SSENotification) 도착 여부로만 판단되던 것을, 전송 계층(HTTP 스트림) 연결/해제 시점으로 판단하도록 변경. 트랙에 실제 이벤트가 뜸하면(best-effort 알림) 연결이 정상인데도 배너가 무기한 "재연결 시도 중…"에 고정되던 게 원인.
- `SseClient.connect()`에 `onConnected`/`onDisconnected` 콜백 추가.
- 연속 실패 횟수(`AppEnv.sseMaxConsecutiveMisses`, 기본 3)를 세어 기존엔 발생 로직이 없던 `disconnected` 상태를 실제로 만들어냄.
- 코드 리뷰 피드백 반영: 재연결에 지수 백오프+지터(`ReconnectBackoff`) 적용, `connectivity_plus` 기반 `NetworkReachability`로 OS 네트워크 상태 변경 시 백오프를 건너뛰고 즉시 재연결.
- 구현/테스트 중 발견해 함께 고친 문제 2건: `TrackConnection`의 autoDispose 경쟁으로 상태 갱신이 고아 인스턴스에만 반영되던 버그(`keepAlive: true`로 해결), reachability 스트림 에러가 재연결 루프 전체를 죽일 수 있던 버그.
- 상세 원인 분석·설계·구현 로그는 `frontend/docs/artifacts/plan/재연결배너_상태버그_수정_plan_20260720.md` 참고.

## Test plan
- [x] `flutter test` 전체 167개 통과 (신규/수정 테스트 19개 포함, `test/shared/api/sse/`)
- [x] `dart analyze lib/ test/` 클린
- [x] `lib/shared/api/gen` 손상 확인·복구(build_runner 실행 후)
- [ ] 실기기/에뮬레이터 수동 확인(이 환경에는 기기가 없어 미실행 — plan 문서 5.3 참고)

🤖 Generated with [Claude Code](https://claude.com/claude-code)