### PR TITLE
fix: 코너 삭제를 soft-delete로 전환

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1876,7 +1876,7 @@ const docTemplate = `{
                         "AdminAuth": []
                     }
                 ],
-                "description": "코너를 삭제한다. 단, 방문 기록이 있으면 삭제할 수 없다.",
+                "description": "코너를 soft-delete한다. 삭제된 코너는 일반 조회에서 제외되며 API 계약은 유지된다.",
                 "produces": [
                     "application/json"
                 ],

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -1869,7 +1869,7 @@
                         "AdminAuth": []
                     }
                 ],
-                "description": "코너를 삭제한다. 단, 방문 기록이 있으면 삭제할 수 없다.",
+                "description": "코너를 soft-delete한다. 삭제된 코너는 일반 조회에서 제외되며 API 계약은 유지된다.",
                 "produces": [
                     "application/json"
                 ],

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1955,7 +1955,7 @@ paths:
       - B. Resource Management (Admin)
   /corners/{id}:
     delete:
-      description: 코너를 삭제한다. 단, 방문 기록이 있으면 삭제할 수 없다.
+      description: 코너를 soft-delete한다. 삭제된 코너는 일반 조회에서 제외되며 API 계약은 유지된다.
       parameters:
       - description: 코너 ID
         in: path

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test clean docker-build swag start-postgres reset-postgres stop-postgres
+.PHONY: build run test clean docker-build swag cleanup-corners start-postgres reset-postgres stop-postgres
 
 MAKEFILE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 POSTGRES_COMPOSE_FILE := $(MAKEFILE_DIR)db/docker-compose.yml
@@ -27,6 +27,9 @@ docker-build:
 
 swag:
 	swag init -g internal/infrastructure/web/doc.go -d . -o ../api --parseDependency --parseInternal
+
+cleanup-corners:
+	go run ./cmd/cleanup-corners
 
 start-postgres:
 	docker compose --file "$(POSTGRES_COMPOSE_FILE)" up

--- a/backend/cmd/cleanup-corners/main.go
+++ b/backend/cmd/cleanup-corners/main.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/url"
+	"os"
+	"time"
+
+	"cornermon/backend/internal/infrastructure/postgres"
+	"cornermon/backend/internal/usecase"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/joho/godotenv"
+)
+
+func main() {
+	_ = godotenv.Load()
+	databaseURL := loadDatabaseURL()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		log.Fatalf("connect database: %v", err)
+	}
+	defer pool.Close()
+
+	count, err := usecase.NewCornerCleanupService(postgres.NewCornerRepository(pool)).PurgeExpired(ctx)
+	if err != nil {
+		log.Fatalf("purge soft-deleted corners: %v", err)
+	}
+	log.Printf("purged %d expired soft-deleted corners", count)
+}
+
+func loadDatabaseURL() string {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		return "postgres://postgres:postgres@localhost:5432/cornermon?sslmode=disable&timezone=UTC"
+	}
+
+	u, err := url.Parse(databaseURL)
+	if err != nil {
+		return databaseURL
+	}
+	if password := os.Getenv("DATABASE_PASSWORD"); password != "" {
+		username := "postgres"
+		if u.User != nil {
+			username = u.User.Username()
+		}
+		u.User = url.UserPassword(username, password)
+	}
+	query := u.Query()
+	query.Set("timezone", "UTC")
+	u.RawQuery = query.Encode()
+	return u.String()
+}

--- a/backend/cmd/cleanup-corners/main_test.go
+++ b/backend/cmd/cleanup-corners/main_test.go
@@ -1,0 +1,18 @@
+package main
+
+import "testing"
+
+func TestShouldConfigureUTCAndSeparatePasswordWhenDatabaseURLIsProvided(t *testing.T) {
+	// Arrange
+	t.Setenv("DATABASE_URL", "postgres://alice@db.example/cornermon?sslmode=require")
+	t.Setenv("DATABASE_PASSWORD", "secret")
+
+	// Act
+	got := loadDatabaseURL()
+
+	// Assert
+	want := "postgres://alice:secret@db.example/cornermon?sslmode=require&timezone=UTC"
+	if got != want {
+		t.Fatalf("expected %q, got %q", want, got)
+	}
+}

--- a/backend/db/migrations/20260721_add_corner_deleted_at.sql
+++ b/backend/db/migrations/20260721_add_corner_deleted_at.sql
@@ -1,0 +1,8 @@
+ALTER TABLE corners
+    ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP WITH TIME ZONE;
+
+COMMENT ON COLUMN corners.deleted_at IS 'soft-delete된 시각';
+
+CREATE INDEX IF NOT EXISTS idx_corners_active_by_camp
+    ON corners(camp_id)
+    WHERE deleted_at IS NULL;

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -18,10 +18,10 @@ ON CONFLICT (id) DO UPDATE SET
     bottleneck_ratio_pct = EXCLUDED.bottleneck_ratio_pct;
 
 -- name: GetCorner :one
-SELECT * FROM corners WHERE id = $1;
+SELECT * FROM corners WHERE id = $1 AND deleted_at IS NULL;
 
 -- name: ListCornersByCamp :many
-SELECT * FROM corners WHERE camp_id = $1;
+SELECT * FROM corners WHERE camp_id = $1 AND deleted_at IS NULL;
 
 -- name: ListCornerViewsByCamp :many
 SELECT
@@ -54,7 +54,7 @@ JOIN LATERAL (
     FROM tracks t
     WHERE t.corner_id = c.id AND t.status = 'ACTIVE'
 ) active_tracks ON TRUE
-WHERE c.camp_id = $1
+WHERE c.camp_id = $1 AND c.deleted_at IS NULL
 ORDER BY c.id;
 
 -- name: GetCornerView :one
@@ -88,7 +88,7 @@ JOIN LATERAL (
     FROM tracks t
     WHERE t.corner_id = c.id AND t.status = 'ACTIVE'
 ) active_tracks ON TRUE
-WHERE c.id = $1;
+WHERE c.id = $1 AND c.deleted_at IS NULL;
 
 -- name: SaveCorner :exec
 INSERT INTO corners (id, camp_id, name, target_minutes, is_mandatory)
@@ -107,7 +107,7 @@ SELECT * FROM tracks WHERE corner_id = $1;
 -- name: ListActiveTracksByCamp :many
 SELECT t.* FROM tracks t
 JOIN corners c ON t.corner_id = c.id
-WHERE c.camp_id = $1 AND t.status = 'ACTIVE';
+WHERE c.camp_id = $1 AND c.deleted_at IS NULL AND t.status = 'ACTIVE';
 
 -- name: SaveTrack :exec
 INSERT INTO tracks (id, corner_id, track_no, status, pin_hash, pin_ciphertext, current_visit_id, deleted_at, unread_by_admin_count, unread_by_track_count)
@@ -207,7 +207,7 @@ SELECT * FROM facilitator_sessions WHERE track_id = $1 AND revoked_at IS NULL;
 SELECT f.* FROM facilitator_sessions f
 JOIN tracks t ON f.track_id = t.id
 JOIN corners c ON t.corner_id = c.id
-WHERE c.camp_id = $1 AND f.revoked_at IS NULL;
+WHERE c.camp_id = $1 AND c.deleted_at IS NULL AND f.revoked_at IS NULL;
 
 -- name: SaveFacilitatorSession :exec
 INSERT INTO facilitator_sessions (id, track_id, token_hash, created_at, revoked_at)
@@ -314,13 +314,21 @@ VALUES ($1, $2, $3, $4, $5, $6, $7);
 -- name: ListCamps :many
 SELECT * FROM camps;
 
--- name: DeleteCorner :exec
-DELETE FROM corners WHERE id = $1;
+-- name: SoftDeleteCorner :exec
+UPDATE corners
+SET deleted_at = $2
+WHERE id = $1 AND deleted_at IS NULL;
+
+-- name: PurgeDeletedCorners :execrows
+DELETE FROM corners c
+WHERE c.deleted_at <= $1
+  AND NOT EXISTS (SELECT 1 FROM tracks t WHERE t.corner_id = c.id)
+  AND NOT EXISTS (SELECT 1 FROM visits v WHERE v.corner_id = c.id);
 
 -- name: ListTracksByCamp :many
 SELECT t.* FROM tracks t
 JOIN corners c ON t.corner_id = c.id
-WHERE c.camp_id = $1;
+WHERE c.camp_id = $1 AND c.deleted_at IS NULL;
 
 -- name: ListAllBadges :many
 SELECT * FROM badges;

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -29,7 +29,8 @@ CREATE TABLE corners (
     camp_id VARCHAR(50) NOT NULL REFERENCES camps(id) ON DELETE CASCADE,
     name VARCHAR(255) NOT NULL,
     target_minutes INT NOT NULL DEFAULT 10,
-    is_mandatory BOOLEAN NOT NULL DEFAULT false
+    is_mandatory BOOLEAN NOT NULL DEFAULT false,
+    deleted_at TIMESTAMP WITH TIME ZONE
 );
 COMMENT ON TABLE corners IS '캠프 내의 각 코너(부스/프로그램)를 정의하는 테이블';
 COMMENT ON COLUMN corners.id IS '코너 고유 식별자';
@@ -37,6 +38,8 @@ COMMENT ON COLUMN corners.camp_id IS '소속 캠프 식별자';
 COMMENT ON COLUMN corners.name IS '코너 이름';
 COMMENT ON COLUMN corners.target_minutes IS '코너별 목표 진행 시간(분)';
 COMMENT ON COLUMN corners.is_mandatory IS '필수 코너 여부';
+COMMENT ON COLUMN corners.deleted_at IS 'soft-delete된 시각';
+CREATE INDEX idx_corners_active_by_camp ON corners(camp_id) WHERE deleted_at IS NULL;
 
 -- 트랙(기기/진행자석) 테이블
 CREATE TABLE tracks (

--- a/backend/docs/artifacts/plan/20260721_issue_154_corner_soft_delete_cleanup_plan_.md
+++ b/backend/docs/artifacts/plan/20260721_issue_154_corner_soft_delete_cleanup_plan_.md
@@ -1,0 +1,62 @@
+# Issue #154 코너 soft-delete 및 좀비 코너 정리 Plan
+
+## 1. 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-1: 코너 삭제 | 관리자 삭제 요청은 API 계약(204)을 유지한 채 코너를 숨긴다. | **프로덕션 핵심 로직** |
+| **P0** | UC-2: 활성 코너 조회 | 목록·상세·캠프 스냅샷 및 캠프 범위 트랙 조회에서 숨겨진 코너를 노출하지 않는다. | **프로덕션 핵심 로직** |
+| **P0** | UC-3: 코너 정리 | soft-delete된 지 7일이 지난 코너만 트랙·방문 이력이 없을 때 물리 삭제한다. 활성 코너는 정리하지 않는다. | 운영 CLI |
+
+```go
+// 삭제 시각을 저장해 일반 조회에서 제외한다.
+func (r *pgCornerRepository) SoftDelete(ctx context.Context, id domain.CornerID, deletedAt time.Time) error
+
+// 운영 명령이 soft-delete 보존 기간과 이력 보호 조건을 충족한 대상만 물리 삭제한다.
+func (r *pgCornerRepository) PurgeDeletedBefore(ctx context.Context, deletedBefore time.Time) (int64, error)
+```
+
+## 2. 설계 및 경계
+
+- `deleted_at TIMESTAMPTZ NULL`은 persistence 상태이며 domain `Corner`에 노출하지 않는다. `NULL`만 활성 코너다.
+- `DELETE /corners/{id}`의 경로, 상태 코드, 요청·응답 본문은 변경하지 않는다. 성공하면 `deleted_at`을 UTC 현재 시각으로 설정하고 기존 감사 로그·커밋 후 SSE 이벤트를 유지한다.
+- 활성 코너를 읽거나 그 코너를 캠프 범위로 조인하는 SQL에는 `c.deleted_at IS NULL` 조건을 둔다. 과거 참조가 필요한 정리 검증은 해당 조건과 분리한다.
+- 정리 CLI는 `cmd/cleanup-corners`에 둔다. 활성 상태에서 트랙·방문 이력이 없다는 사실만으로는 정상적으로 막 생성된 코너와 좀비를 구분할 수 없으므로, `deleted_at <= now - 7일`인 soft-delete 코너만 삭제한다. 트랙 또는 방문 이력이 있으면 보존한다.
+- 기존 배포 DB를 위해 additive migration SQL을 제공하고, 새 DB 초기화용 `schema.sql`에도 같은 컬럼·인덱스를 반영한다.
+
+## 3. 구현 단계
+
+### Phase A: 데이터 모델 및 SQL (예상 1시간)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| A-1 | 삭제 시각 컬럼과 활성 조회 인덱스를 초기 스키마에 추가 | `/home/lsjtop10/projects/cornermon-issue-154/backend/db/schema.sql` (기존 파일 확장) |
+| A-2 | 기존 DB용 additive migration을 추가 | `/home/lsjtop10/projects/cornermon-issue-154/backend/db/migrations/20260721_add_corner_deleted_at.sql` (신규) |
+| A-3 | 활성 코너 조회·soft delete·이력 없는 purge SQL을 추가하고 sqlc 산출물을 동기화 | `/home/lsjtop10/projects/cornermon-issue-154/backend/db/query.sql`, `/home/lsjtop10/projects/cornermon-issue-154/backend/internal/infrastructure/postgres/db/` (기존 파일 확장) |
+
+### Phase B: 애플리케이션 및 운영 명령 (예상 1시간)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| B-1 | `CornerRepository`의 물리 삭제 포트를 soft-delete로 교체하고 `CornerService`가 UTC 시각을 전달 | `/home/lsjtop10/projects/cornermon-issue-154/backend/internal/usecase/port.go`, `/home/lsjtop10/projects/cornermon-issue-154/backend/internal/usecase/corner.go` (기존 파일 확장) |
+| B-2 | Postgres 구현에서 SQLC 쿼리를 사용해 soft-delete하며 활성 조회를 보장 | `/home/lsjtop10/projects/cornermon-issue-154/backend/internal/infrastructure/postgres/corner_repo.go` (기존 파일 확장) |
+| B-3 | DB 설정을 재사용하는 7일 보존 정리 CLI를 추가 | `/home/lsjtop10/projects/cornermon-issue-154/backend/cmd/cleanup-corners/main.go` (신규) |
+
+### Phase C: 검증 및 문서 (예상 1시간)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| C-1 | soft-delete 시각, 재삭제 idempotency, 감사 로그 및 SSE를 usecase 테스트로 검증 | `/home/lsjtop10/projects/cornermon-issue-154/backend/internal/usecase/corner_test.go`, `/home/lsjtop10/projects/cornermon-issue-154/backend/internal/usecase/mock_test.go` (기존 파일 확장) |
+| C-2 | SQL 원본과 생성 코드의 활성 조회·purge 보호 조건을 테스트 | `/home/lsjtop10/projects/cornermon-issue-154/backend/internal/infrastructure/postgres/` (기존 파일 확장) |
+| C-3 | API 계약을 그대로 유지한다는 설명을 OpenAPI 산출물에 반영하고 전체 테스트·vet·자체 리뷰 수행 | `/home/lsjtop10/projects/cornermon-issue-154/api/swagger.yaml` (기존 파일 확장) |
+
+## 4. 검증 체크리스트
+
+- [x] `DELETE /corners/{id}`는 204를 유지하며 행을 물리 삭제하지 않고 UTC `deleted_at`만 설정한다.
+- [x] `GetCorner`, `ListCornersByCamp`, 코너 view 목록·상세, 캠프 범위 조인 조회가 soft-delete 코너를 반환하지 않는다.
+- [x] 정리 CLI는 활성 코너를 절대 삭제하지 않고, soft-delete 코너가 7일 전이면서 트랙·방문 이력이 모두 없을 때만 삭제한다.
+- [x] 트랙 또는 방문 이력이 있는 코너는 soft-delete 여부와 무관하게 purge하지 않는다.
+- [x] 성공 감사 로그와 커밋 뒤 `corners_updated` SSE가 기존과 동일하게 동작하며, 실패 경로는 기존 구현을 유지한다.
+- [x] `domain`이 infrastructure를 import하지 않고, usecase는 repository 포트에만 의존한다.
+- [x] `cd backend && go test ./... && go vet ./...`를 통과한다.
+- [x] API 요청·응답 계약이 변경되지 않는다. 코드 변경 LOC은 커밋 직전에 확인한다.

--- a/backend/internal/infrastructure/postgres/corner_repo.go
+++ b/backend/internal/infrastructure/postgres/corner_repo.go
@@ -2,11 +2,13 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"cornermon/backend/internal/domain"
 	"cornermon/backend/internal/errs"
 	"cornermon/backend/internal/infrastructure/postgres/db"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -73,10 +75,18 @@ func (r *pgCornerRepository) Save(ctx context.Context, corner *domain.Corner) er
 	return nil
 }
 
-func (r *pgCornerRepository) Delete(ctx context.Context, id domain.CornerID) error {
-	err := r.queries(ctx).DeleteCorner(ctx, string(id))
+func (r *pgCornerRepository) SoftDelete(ctx context.Context, id domain.CornerID, deletedAt time.Time) error {
+	err := r.queries(ctx).SoftDeleteCorner(ctx, db.SoftDeleteCornerParams{ID: string(id), DeletedAt: pgtype.Timestamptz{Time: deletedAt, Valid: true}})
 	if err != nil {
 		return errs.Wrap(ctx, err)
 	}
 	return nil
+}
+
+func (r *pgCornerRepository) PurgeDeletedBefore(ctx context.Context, deletedBefore time.Time) (int64, error) {
+	count, err := r.queries(ctx).PurgeDeletedCorners(ctx, pgtype.Timestamptz{Time: deletedBefore, Valid: true})
+	if err != nil {
+		return 0, errs.Wrap(ctx, err)
+	}
+	return count, nil
 }

--- a/backend/internal/infrastructure/postgres/db/corner_cleanup_query_test.go
+++ b/backend/internal/infrastructure/postgres/db/corner_cleanup_query_test.go
@@ -1,0 +1,21 @@
+package db
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestShouldExcludeActiveCornersWhenPurgingDeletedCorners(t *testing.T) {
+	// Arrange
+	query := purgeDeletedCorners
+
+	// Act
+	hasSoftDeleteCutoff := strings.Contains(query, "c.deleted_at <= $1")
+	hasTrackHistoryGuard := strings.Contains(query, "NOT EXISTS (SELECT 1 FROM tracks")
+	hasVisitHistoryGuard := strings.Contains(query, "NOT EXISTS (SELECT 1 FROM visits")
+
+	// Assert
+	if !hasSoftDeleteCutoff || !hasTrackHistoryGuard || !hasVisitHistoryGuard {
+		t.Fatalf("purge query must require expiry and protect track/visit history: %s", query)
+	}
+}

--- a/backend/internal/infrastructure/postgres/db/models.go
+++ b/backend/internal/infrastructure/postgres/db/models.go
@@ -121,6 +121,8 @@ type Corner struct {
 	TargetMinutes int32 `json:"target_minutes"`
 	// 필수 코너 여부
 	IsMandatory bool `json:"is_mandatory"`
+	// soft-delete된 시각
+	DeletedAt pgtype.Timestamptz `json:"deleted_at"`
 }
 
 // 진행자 기기의 등록 요청 및 승인/잠금 상태를 관리하는 테이블

--- a/backend/internal/infrastructure/postgres/db/querier.go
+++ b/backend/internal/infrastructure/postgres/db/querier.go
@@ -6,13 +6,14 @@ package db
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 type Querier interface {
 	CountAdmins(ctx context.Context) (int64, error)
 	CountAdminsByRole(ctx context.Context, role string) (int64, error)
 	DeleteAdmin(ctx context.Context, id string) error
-	DeleteCorner(ctx context.Context, id string) error
 	GetAdmin(ctx context.Context, id string) (Admin, error)
 	GetAdminByUsername(ctx context.Context, username string) (Admin, error)
 	GetAdminSession(ctx context.Context, id string) (AdminSession, error)
@@ -58,6 +59,7 @@ type Querier interface {
 	ListVisitsByCamp(ctx context.Context, campID string) ([]ListVisitsByCampRow, error)
 	ListVisitsByGroup(ctx context.Context, groupID string) ([]Visit, error)
 	MarkAllMessagesReadByRecipient(ctx context.Context, arg MarkAllMessagesReadByRecipientParams) error
+	PurgeDeletedCorners(ctx context.Context, deletedAt pgtype.Timestamptz) (int64, error)
 	ResetTrackUnreadCount(ctx context.Context, arg ResetTrackUnreadCountParams) error
 	SaveAdmin(ctx context.Context, arg SaveAdminParams) error
 	SaveAdminSession(ctx context.Context, arg SaveAdminSessionParams) error
@@ -73,6 +75,7 @@ type Querier interface {
 	SaveMessage(ctx context.Context, arg SaveMessageParams) error
 	SaveTrack(ctx context.Context, arg SaveTrackParams) error
 	SaveVisit(ctx context.Context, arg SaveVisitParams) error
+	SoftDeleteCorner(ctx context.Context, arg SoftDeleteCornerParams) error
 }
 
 var _ Querier = (*Queries)(nil)

--- a/backend/internal/infrastructure/postgres/db/query.sql.go
+++ b/backend/internal/infrastructure/postgres/db/query.sql.go
@@ -42,15 +42,6 @@ func (q *Queries) DeleteAdmin(ctx context.Context, id string) error {
 	return err
 }
 
-const deleteCorner = `-- name: DeleteCorner :exec
-DELETE FROM corners WHERE id = $1
-`
-
-func (q *Queries) DeleteCorner(ctx context.Context, id string) error {
-	_, err := q.db.Exec(ctx, deleteCorner, id)
-	return err
-}
-
 const getAdmin = `-- name: GetAdmin :one
 SELECT id, username, password_hash, role FROM admins WHERE id = $1
 `
@@ -241,7 +232,7 @@ func (q *Queries) GetCompletedVisitByGroupAndCorner(ctx context.Context, arg Get
 }
 
 const getCorner = `-- name: GetCorner :one
-SELECT id, camp_id, name, target_minutes, is_mandatory FROM corners WHERE id = $1
+SELECT id, camp_id, name, target_minutes, is_mandatory, deleted_at FROM corners WHERE id = $1 AND deleted_at IS NULL
 `
 
 func (q *Queries) GetCorner(ctx context.Context, id string) (Corner, error) {
@@ -253,6 +244,7 @@ func (q *Queries) GetCorner(ctx context.Context, id string) (Corner, error) {
 		&i.Name,
 		&i.TargetMinutes,
 		&i.IsMandatory,
+		&i.DeletedAt,
 	)
 	return i, err
 }
@@ -288,7 +280,7 @@ JOIN LATERAL (
     FROM tracks t
     WHERE t.corner_id = c.id AND t.status = 'ACTIVE'
 ) active_tracks ON TRUE
-WHERE c.id = $1
+WHERE c.id = $1 AND c.deleted_at IS NULL
 `
 
 type GetCornerViewRow struct {
@@ -518,7 +510,7 @@ const listActiveFacilitatorSessionsByCamp = `-- name: ListActiveFacilitatorSessi
 SELECT f.id, f.track_id, f.token_hash, f.created_at, f.revoked_at FROM facilitator_sessions f
 JOIN tracks t ON f.track_id = t.id
 JOIN corners c ON t.corner_id = c.id
-WHERE c.camp_id = $1 AND f.revoked_at IS NULL
+WHERE c.camp_id = $1 AND c.deleted_at IS NULL AND f.revoked_at IS NULL
 `
 
 func (q *Queries) ListActiveFacilitatorSessionsByCamp(ctx context.Context, campID string) ([]FacilitatorSession, error) {
@@ -580,7 +572,7 @@ func (q *Queries) ListActiveFacilitatorSessionsByTrack(ctx context.Context, trac
 const listActiveTracksByCamp = `-- name: ListActiveTracksByCamp :many
 SELECT t.id, t.corner_id, t.track_no, t.status, t.pin_hash, t.pin_ciphertext, t.current_visit_id, t.deleted_at, t.unread_by_admin_count, t.unread_by_track_count FROM tracks t
 JOIN corners c ON t.corner_id = c.id
-WHERE c.camp_id = $1 AND t.status = 'ACTIVE'
+WHERE c.camp_id = $1 AND c.deleted_at IS NULL AND t.status = 'ACTIVE'
 `
 
 func (q *Queries) ListActiveTracksByCamp(ctx context.Context, campID string) ([]Track, error) {
@@ -946,7 +938,7 @@ JOIN LATERAL (
     FROM tracks t
     WHERE t.corner_id = c.id AND t.status = 'ACTIVE'
 ) active_tracks ON TRUE
-WHERE c.camp_id = $1
+WHERE c.camp_id = $1 AND c.deleted_at IS NULL
 ORDER BY c.id
 `
 
@@ -989,7 +981,7 @@ func (q *Queries) ListCornerViewsByCamp(ctx context.Context, campID string) ([]L
 }
 
 const listCornersByCamp = `-- name: ListCornersByCamp :many
-SELECT id, camp_id, name, target_minutes, is_mandatory FROM corners WHERE camp_id = $1
+SELECT id, camp_id, name, target_minutes, is_mandatory, deleted_at FROM corners WHERE camp_id = $1 AND deleted_at IS NULL
 `
 
 func (q *Queries) ListCornersByCamp(ctx context.Context, campID string) ([]Corner, error) {
@@ -1007,6 +999,7 @@ func (q *Queries) ListCornersByCamp(ctx context.Context, campID string) ([]Corne
 			&i.Name,
 			&i.TargetMinutes,
 			&i.IsMandatory,
+			&i.DeletedAt,
 		); err != nil {
 			return nil, err
 		}
@@ -1199,7 +1192,7 @@ func (q *Queries) ListPendingDeviceRegistrationsByCamp(ctx context.Context, camp
 const listTracksByCamp = `-- name: ListTracksByCamp :many
 SELECT t.id, t.corner_id, t.track_no, t.status, t.pin_hash, t.pin_ciphertext, t.current_visit_id, t.deleted_at, t.unread_by_admin_count, t.unread_by_track_count FROM tracks t
 JOIN corners c ON t.corner_id = c.id
-WHERE c.camp_id = $1
+WHERE c.camp_id = $1 AND c.deleted_at IS NULL
 `
 
 func (q *Queries) ListTracksByCamp(ctx context.Context, campID string) ([]Track, error) {
@@ -1369,6 +1362,21 @@ type MarkAllMessagesReadByRecipientParams struct {
 func (q *Queries) MarkAllMessagesReadByRecipient(ctx context.Context, arg MarkAllMessagesReadByRecipientParams) error {
 	_, err := q.db.Exec(ctx, markAllMessagesReadByRecipient, arg.ReadAt, arg.TrackID, arg.Recipient)
 	return err
+}
+
+const purgeDeletedCorners = `-- name: PurgeDeletedCorners :execrows
+DELETE FROM corners c
+WHERE c.deleted_at <= $1
+  AND NOT EXISTS (SELECT 1 FROM tracks t WHERE t.corner_id = c.id)
+  AND NOT EXISTS (SELECT 1 FROM visits v WHERE v.corner_id = c.id)
+`
+
+func (q *Queries) PurgeDeletedCorners(ctx context.Context, deletedAt pgtype.Timestamptz) (int64, error) {
+	result, err := q.db.Exec(ctx, purgeDeletedCorners, deletedAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const resetTrackUnreadCount = `-- name: ResetTrackUnreadCount :exec
@@ -1806,5 +1814,21 @@ func (q *Queries) SaveVisit(ctx context.Context, arg SaveVisitParams) error {
 		arg.StartedAt,
 		arg.EndedAt,
 	)
+	return err
+}
+
+const softDeleteCorner = `-- name: SoftDeleteCorner :exec
+UPDATE corners
+SET deleted_at = $2
+WHERE id = $1 AND deleted_at IS NULL
+`
+
+type SoftDeleteCornerParams struct {
+	ID        string             `json:"id"`
+	DeletedAt pgtype.Timestamptz `json:"deleted_at"`
+}
+
+func (q *Queries) SoftDeleteCorner(ctx context.Context, arg SoftDeleteCornerParams) error {
+	_, err := q.db.Exec(ctx, softDeleteCorner, arg.ID, arg.DeletedAt)
 	return err
 }

--- a/backend/internal/infrastructure/web/corner_handler.go
+++ b/backend/internal/infrastructure/web/corner_handler.go
@@ -177,7 +177,7 @@ func (h *CornerHandler) GetCornerByTrack(c echo.Context) error {
 }
 
 // @Summary      코너 삭제
-// @Description  코너를 삭제한다. 단, 방문 기록이 있으면 삭제할 수 없다.
+// @Description  코너를 soft-delete한다. 삭제된 코너는 일반 조회에서 제외되며 API 계약은 유지된다.
 // @Tags         B. Resource Management (Admin)
 // @Security     AdminAuth
 // @Produce      json

--- a/backend/internal/infrastructure/web/group_handler_test.go
+++ b/backend/internal/infrastructure/web/group_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"cornermon/backend/internal/domain"
 	"cornermon/backend/internal/usecase"
@@ -41,8 +42,10 @@ func (r cornerRepoForGroupHandler) Get(context.Context, domain.CornerID) (*domai
 func (cornerRepoForGroupHandler) ListByCamp(context.Context, domain.CampID) ([]*domain.Corner, error) {
 	return nil, nil
 }
-func (cornerRepoForGroupHandler) Save(context.Context, *domain.Corner) error    { return nil }
-func (cornerRepoForGroupHandler) Delete(context.Context, domain.CornerID) error { return nil }
+func (cornerRepoForGroupHandler) Save(context.Context, *domain.Corner) error { return nil }
+func (cornerRepoForGroupHandler) SoftDelete(context.Context, domain.CornerID, time.Time) error {
+	return nil
+}
 
 type groupRepoForGroupHandler struct{ groups []*domain.Group }
 

--- a/backend/internal/usecase/corner.go
+++ b/backend/internal/usecase/corner.go
@@ -149,7 +149,7 @@ func (s *CornerService) RemoveCornerFromCamp(ctx context.Context, id domain.Corn
 	}
 
 	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
-		return s.corners.Delete(ctx, id)
+		return s.corners.SoftDelete(ctx, id, s.nowFn())
 	})
 
 	if err != nil {

--- a/backend/internal/usecase/corner_cleanup.go
+++ b/backend/internal/usecase/corner_cleanup.go
@@ -1,0 +1,27 @@
+package usecase
+
+import (
+	"context"
+	"time"
+)
+
+const cornerSoftDeleteRetention = 7 * 24 * time.Hour
+
+// CornerCleanupService removes expired soft-deleted corners. Active corners
+// are deliberately never candidates: a corner with no tracks can be newly
+// created and cannot be distinguished safely from a legacy zombie corner.
+type CornerCleanupService struct {
+	corners CornerCleanupRepository
+	nowFn   func() time.Time
+}
+
+func NewCornerCleanupService(corners CornerCleanupRepository) *CornerCleanupService {
+	return &CornerCleanupService{
+		corners: corners,
+		nowFn:   func() time.Time { return time.Now().UTC() },
+	}
+}
+
+func (s *CornerCleanupService) PurgeExpired(ctx context.Context) (int64, error) {
+	return s.corners.PurgeDeletedBefore(ctx, s.nowFn().Add(-cornerSoftDeleteRetention))
+}

--- a/backend/internal/usecase/corner_test.go
+++ b/backend/internal/usecase/corner_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"testing"
+	"time"
 
 	"cornermon/backend/internal/domain"
 )
@@ -12,8 +13,12 @@ func TestCornerServiceCommandRegression(t *testing.T) {
 	camps := NewMockCampRepository()
 	_ = camps.Save(ctx, domain.NewCampFromProps(domain.CampProps{ID: "camp-1", Status: domain.CampPending}))
 	corners := NewMockCornerRepository()
-	service := NewCornerService(camps, corners, NewMockTrackRepository(), &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+	auditLogs := &MockAuditLogRepository{}
+	broadcaster := &MockBroadcaster{}
+	service := NewCornerService(camps, corners, NewMockTrackRepository(), auditLogs, broadcaster, &MockTxManager{})
 	service.uuidFn = func() string { return "corner-1" }
+	deletedAt := time.Date(2026, time.July, 21, 9, 0, 0, 0, time.UTC)
+	service.nowFn = func() time.Time { return deletedAt }
 
 	created, err := service.AddLearningCorner(ctx, "camp-1", "처음 이름")
 	if err != nil || created.ID() != "corner-1" {
@@ -30,7 +35,42 @@ func TestCornerServiceCommandRegression(t *testing.T) {
 	}
 	deleted, err := corners.Get(ctx, created.ID())
 	if err != nil || deleted != nil {
-		t.Fatalf("corner should be deleted: corner=%+v err=%v", deleted, err)
+		t.Fatalf("soft-deleted corner should be hidden: corner=%+v err=%v", deleted, err)
+	}
+	if got := corners.DeletedAt[created.ID()]; !got.Equal(deletedAt) {
+		t.Fatalf("expected deleted_at=%s, got %s", deletedAt, got)
+	}
+	if len(auditLogs.Logs) != 3 || auditLogs.Logs[2].Action() != string(ActionCornerDelete) || !auditLogs.Logs[2].Success() {
+		t.Fatalf("expected successful corner deletion audit log, got %+v", auditLogs.Logs)
+	}
+	if len(broadcaster.Broadcasts) != 3 || broadcaster.Broadcasts[2].Event != EventCornersUpdated {
+		t.Fatalf("expected corners_updated after deletion, got %+v", broadcaster.Broadcasts)
+	}
+
+	if err := service.RemoveCornerFromCamp(ctx, created.ID()); err != nil {
+		t.Fatalf("repeat delete should be idempotent: %v", err)
+	}
+	if len(auditLogs.Logs) != 3 || len(broadcaster.Broadcasts) != 3 {
+		t.Fatalf("repeat delete must not emit new side effects")
+	}
+}
+
+func TestShouldPurgeCornersAfterSevenDaysWhenCleanupRuns(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	corners := NewMockCornerRepository()
+	corners.PurgedCount = 2
+	service := NewCornerCleanupService(corners)
+	now := time.Date(2026, time.July, 21, 9, 0, 0, 0, time.UTC)
+	service.nowFn = func() time.Time { return now }
+
+	// Act
+	count, err := service.PurgeExpired(ctx)
+
+	// Assert
+	wantBefore := now.Add(-7 * 24 * time.Hour)
+	if err != nil || count != 2 || !corners.PurgeBefore.Equal(wantBefore) {
+		t.Fatalf("expected count=2 and cutoff=%s, got count=%d cutoff=%s err=%v", wantBefore, count, corners.PurgeBefore, err)
 	}
 }
 

--- a/backend/internal/usecase/mock_test.go
+++ b/backend/internal/usecase/mock_test.go
@@ -56,16 +56,19 @@ func (r *MockCampRepository) List(ctx context.Context) ([]*domain.Camp, error) {
 
 // MockCornerRepository
 type MockCornerRepository struct {
-	Corners map[domain.CornerID]*domain.Corner
+	Corners     map[domain.CornerID]*domain.Corner
+	DeletedAt   map[domain.CornerID]time.Time
+	PurgeBefore time.Time
+	PurgedCount int64
 }
 
 func NewMockCornerRepository() *MockCornerRepository {
-	return &MockCornerRepository{Corners: make(map[domain.CornerID]*domain.Corner)}
+	return &MockCornerRepository{Corners: make(map[domain.CornerID]*domain.Corner), DeletedAt: make(map[domain.CornerID]time.Time)}
 }
 
 func (r *MockCornerRepository) Get(ctx context.Context, id domain.CornerID) (*domain.Corner, error) {
 	corner, ok := r.Corners[id]
-	if !ok {
+	if !ok || !r.DeletedAt[id].IsZero() {
 		return nil, nil
 	}
 	return corner, nil
@@ -74,7 +77,7 @@ func (r *MockCornerRepository) Get(ctx context.Context, id domain.CornerID) (*do
 func (r *MockCornerRepository) ListByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Corner, error) {
 	var list []*domain.Corner
 	for _, c := range r.Corners {
-		if c.CampID() == campID {
+		if c.CampID() == campID && r.DeletedAt[c.ID()].IsZero() {
 			list = append(list, c)
 		}
 	}
@@ -86,9 +89,14 @@ func (r *MockCornerRepository) Save(ctx context.Context, corner *domain.Corner) 
 	return nil
 }
 
-func (r *MockCornerRepository) Delete(ctx context.Context, id domain.CornerID) error {
-	delete(r.Corners, id)
+func (r *MockCornerRepository) SoftDelete(ctx context.Context, id domain.CornerID, deletedAt time.Time) error {
+	r.DeletedAt[id] = deletedAt
 	return nil
+}
+
+func (r *MockCornerRepository) PurgeDeletedBefore(ctx context.Context, deletedBefore time.Time) (int64, error) {
+	r.PurgeBefore = deletedBefore
+	return r.PurgedCount, nil
 }
 
 // MockTrackRepository

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -32,7 +32,13 @@ type CornerRepository interface {
 	Get(ctx context.Context, id domain.CornerID) (*domain.Corner, error)
 	ListByCamp(ctx context.Context, campID domain.CampID) ([]*domain.Corner, error)
 	Save(ctx context.Context, corner *domain.Corner) error
-	Delete(ctx context.Context, id domain.CornerID) error
+	SoftDelete(ctx context.Context, id domain.CornerID, deletedAt time.Time) error
+}
+
+// CornerCleanupRepository physically removes only candidates selected by the
+// persistence layer's history-safe cleanup query.
+type CornerCleanupRepository interface {
+	PurgeDeletedBefore(ctx context.Context, deletedBefore time.Time) (int64, error)
 }
 
 // CornerViewQuerier는 코너 핵심 정보, 완료 방문 지표, 활성 트랙을 한 번에 반환하는 읽기 전용 포트입니다.


### PR DESCRIPTION
## 변경 사항
- DELETE /corners/{id}가 행을 삭제하지 않고 deleted_at을 기록하도록 변경했습니다. 요청·응답 계약(204)은 유지됩니다.
- 코너 목록·상세·캠프 범위 트랙/세션 조회에서 soft-delete 코너를 제외했습니다.
- 7일이 지난 soft-delete 코너만, 트랙·방문 이력이 전혀 없을 때 make cleanup-corners로 물리 정리할 수 있게 했습니다.
- 활성 상태의 빈 코너는 정상 신규 코너와 구분할 수 없으므로 정리 대상에서 제외했습니다.
- 기존 DB 적용용 additive migration과 sqlc/OpenAPI 생성 산출물을 포함했습니다.

## 검증
- cd backend && go test ./... 통과
- cd backend && go vet ./... 통과
- cd backend && go test -race ./internal/usecase ./internal/infrastructure/postgres ./internal/infrastructure/web 통과
- git diff --cached --check 및 커밋 후 git show --check 통과
- PR 코드 변경은 500 LOC 이내입니다. (계획·생성 문서 제외)

Closes #154