### PR TITLE
fix: 배지 등록 책임을 유즈케이스로 이동

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -172,7 +172,7 @@ func main() {
 	cornerHandler := web.NewCornerHandler(cornerService, cornerViewQuerier)
 	trackHandler := web.NewTrackHandler(trackService)
 	groupHandler := web.NewGroupHandler(groupService)
-	badgeHandler := web.NewBadgeHandler(badgeService, groupService, campRepo)
+	badgeHandler := web.NewBadgeHandler(badgeService, groupService)
 	visitHandler := web.NewVisitHandler(visitService)
 
 	eventHandler := web.NewEventHandler(broadcaster, trackRepo, cornerRepo)

--- a/backend/docs/artifacts/plan/20260721_badge_assignment_usecase_boundary_plan_.md
+++ b/backend/docs/artifacts/plan/20260721_badge_assignment_usecase_boundary_plan_.md
@@ -1,0 +1,36 @@
+# 배지 등록 유즈케이스 경계 정리 계획
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| P0 | AssignBadge | 등록 가능한 캠프(PENDING/ACTIVE)를 선택하고 배지 ID로 조를 생성·배정한다. | 프로덕션 핵심 로직 |
+| P0 | ScanAssignBadge | 등록 가능한 캠프(PENDING/ACTIVE)를 선택하고 QR payload로 조를 생성·배정한다. | 프로덕션 핵심 로직 |
+
+```go
+func (s *GroupService) AssignBadge(ctx context.Context, badgeID domain.BadgeID, groupName string) (*domain.Group, error)
+func (s *GroupService) ScanAssignBadge(ctx context.Context, qrPayload, groupName string) (*domain.Group, error)
+```
+
+## 구현
+
+1. `/home/lsjtop10/projects/cornermon/backend/internal/usecase/group.go` (기존 파일 확장)
+   - 캠프 목록에서 PENDING 또는 ACTIVE 캠프를 선택하는 책임과 배지 단건 조회를 `GroupService`에 둔다.
+   - 두 진입점은 공통 등록 흐름(코너 순회표 구성, 배지 상태 전이, 트랜잭션 저장, 감사 로그)을 공유한다.
+   - 등록 가능한 캠프가 없으면 `domain.ErrCampNotFound`를 반환한다.
+
+2. `/home/lsjtop10/projects/cornermon/backend/internal/infrastructure/web/badge_handler.go` (기존 파일 축소)
+   - `AssignBadge`와 `ScanAssignBadge`는 요청 파싱, 유즈케이스 호출, 응답 DTO 변환만 수행한다.
+   - 핸들러의 캠프 repository 및 배지 목록 순회 로직을 제거한다.
+
+3. `/home/lsjtop10/projects/cornermon/backend/internal/usecase/group_test.go` (기존 파일 확장)
+   - 배지 ID 배정, QR 스캔 배정, PENDING 캠프 배정, 등록 가능한 캠프 부재를 검증한다.
+
+## 검증 체크리스트
+
+- [x] 수동 배정이 `BadgeRepository.Get` 단건 조회를 통해 수행된다.
+- [x] 스캔 배정이 QR payload 단건 조회를 통해 수행된다.
+- [x] PENDING 및 ACTIVE 캠프에서 등록할 수 있다.
+- [x] ENDED 캠프만 있거나 캠프가 없으면 등록하지 못한다.
+- [x] Handler는 상태 판단·repository 조회·도메인 조율을 수행하지 않는다.
+- [x] `cd backend && go test ./...` 및 `go vet ./...`를 통과한다.

--- a/backend/internal/infrastructure/web/badge_handler.go
+++ b/backend/internal/infrastructure/web/badge_handler.go
@@ -1,7 +1,7 @@
 package web
 
 import (
-	"context"
+	"errors"
 	"net/http"
 
 	"cornermon/backend/internal/domain"
@@ -13,7 +13,6 @@ import (
 type BadgeHandler struct {
 	badgeUC *usecase.BadgeService
 	groupUC *usecase.GroupService
-	camps   usecase.CampRepository
 }
 
 type BadgeResponse struct {
@@ -27,27 +26,11 @@ type BadgeResponse struct {
 func NewBadgeHandler(
 	badgeUC *usecase.BadgeService,
 	groupUC *usecase.GroupService,
-	camps usecase.CampRepository,
 ) *BadgeHandler {
 	return &BadgeHandler{
 		badgeUC: badgeUC,
 		groupUC: groupUC,
-		camps:   camps,
 	}
-}
-
-// getActiveCamp is a helper to find the currently active camp
-func (h *BadgeHandler) getActiveCamp(ctx context.Context) (*domain.Camp, error) {
-	camps, err := h.camps.List(ctx)
-	if err != nil {
-		return nil, err
-	}
-	for _, camp := range camps {
-		if camp.Status() == domain.CampActive {
-			return camp, nil
-		}
-	}
-	return nil, nil
 }
 
 func mapBadgeToDTO(b *domain.Badge) BadgeResponse {
@@ -158,34 +141,9 @@ func (h *BadgeHandler) AssignBadge(c echo.Context) error {
 		return err
 	}
 
-	camp, err := h.getActiveCamp(c.Request().Context())
+	group, err := h.groupUC.AssignBadge(c.Request().Context(), id, req.GroupName)
 	if err != nil {
-		return err
-	}
-	if camp == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "active camp not found")
-	}
-
-	// We need a badge's QRPayload to use GroupService.RegisterBadge, or we add RegisterBadgeByID to GroupService.
-	// Since GroupService.RegisterBadge uses qrPayload, let's get the badge first.
-	badges, err := h.badgeUC.ListBadges(c.Request().Context())
-	if err != nil {
-		return err
-	}
-	var qrPayload string
-	for _, b := range badges {
-		if b.ID() == id {
-			qrPayload = b.QRPayload()
-			break
-		}
-	}
-	if qrPayload == "" {
-		return echo.ErrNotFound
-	}
-
-	group, err := h.groupUC.RegisterBadge(c.Request().Context(), camp.ID(), qrPayload, req.GroupName)
-	if err != nil {
-		return err
+		return badgeAssignmentHTTPError(err)
 	}
 
 	return c.JSON(http.StatusCreated, mapGroupToDTO(group))
@@ -211,18 +169,23 @@ func (h *BadgeHandler) ScanAssignBadge(c echo.Context) error {
 		return err
 	}
 
-	camp, err := h.getActiveCamp(c.Request().Context())
+	group, err := h.groupUC.ScanAssignBadge(c.Request().Context(), req.QRPayload, req.GroupName)
 	if err != nil {
-		return err
-	}
-	if camp == nil {
-		return echo.NewHTTPError(http.StatusNotFound, "active camp not found")
-	}
-
-	group, err := h.groupUC.RegisterBadge(c.Request().Context(), camp.ID(), req.QRPayload, req.GroupName)
-	if err != nil {
-		return err
+		return badgeAssignmentHTTPError(err)
 	}
 
 	return c.JSON(http.StatusCreated, mapGroupToDTO(group))
+}
+
+func badgeAssignmentHTTPError(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrCampNotFound):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "CAMP_NOT_FOUND", Message: err.Error()}).SetInternal(err)
+	case errors.Is(err, domain.ErrBadgeNotAssigned):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "BADGE_NOT_FOUND", Message: err.Error()}).SetInternal(err)
+	case errors.Is(err, domain.ErrBadgeAlreadyAssigned):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "BADGE_ALREADY_ASSIGNED", Message: err.Error()}).SetInternal(err)
+	default:
+		return err
+	}
 }

--- a/backend/internal/usecase/group.go
+++ b/backend/internal/usecase/group.go
@@ -47,21 +47,31 @@ func NewGroupService(
 	}
 }
 
-// RegisterBadge - UC-19
-func (s *GroupService) RegisterBadge(
+// AssignBadge creates a group and assigns the badge identified by its ID to it.
+// The group belongs to the current registration camp (PENDING or ACTIVE).
+func (s *GroupService) AssignBadge(
 	ctx context.Context,
-	campID domain.CampID,
-	qrPayload string,
+	badgeID domain.BadgeID,
 	groupName string,
 ) (*domain.Group, error) {
-	camp, err := s.camps.Get(ctx, campID)
+	badge, err := s.badges.Get(ctx, badgeID)
 	if err != nil {
 		return nil, err
 	}
-	if camp == nil || camp.Status() == domain.CampEnded {
-		return nil, domain.ErrCampInvalidTransition
+	if badge == nil {
+		return nil, domain.ErrBadgeNotAssigned
 	}
 
+	return s.registerBadge(ctx, badge, groupName)
+}
+
+// ScanAssignBadge creates a group and assigns the badge identified by its QR payload.
+// The group belongs to the current registration camp (PENDING or ACTIVE).
+func (s *GroupService) ScanAssignBadge(
+	ctx context.Context,
+	qrPayload string,
+	groupName string,
+) (*domain.Group, error) {
 	badge, err := s.badges.GetByQRPayload(ctx, qrPayload)
 	if err != nil {
 		return nil, err
@@ -69,10 +79,23 @@ func (s *GroupService) RegisterBadge(
 	if badge == nil {
 		return nil, domain.ErrBadgeNotAssigned
 	}
+
+	return s.registerBadge(ctx, badge, groupName)
+}
+
+func (s *GroupService) registerBadge(ctx context.Context, badge *domain.Badge, groupName string) (*domain.Group, error) {
+	camp, err := s.registrationCamp(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if camp == nil {
+		return nil, domain.ErrCampNotFound
+	}
 	if badge.Status() == domain.BadgeAssigned {
 		return nil, domain.ErrBadgeAlreadyAssigned
 	}
 
+	campID := camp.ID()
 	corners, err := s.corners.ListByCamp(ctx, campID)
 	if err != nil {
 		return nil, err
@@ -113,6 +136,24 @@ func (s *GroupService) RegisterBadge(
 
 	s.recordAuditLog(ctx, "admin", ActionGroupCreate, string(groupID), true, map[string]any{"campID": string(campID), "badgeID": string(badge.ID())})
 	return group, nil
+}
+
+func (s *GroupService) registrationCamp(ctx context.Context) (*domain.Camp, error) {
+	camps, err := s.camps.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var pendingCamp *domain.Camp
+	for _, camp := range camps {
+		switch camp.Status() {
+		case domain.CampActive:
+			return camp, nil
+		case domain.CampPending:
+			pendingCamp = camp
+		}
+	}
+	return pendingCamp, nil
 }
 
 // ListGroups

--- a/backend/internal/usecase/group_test.go
+++ b/backend/internal/usecase/group_test.go
@@ -8,8 +8,8 @@ import (
 	"cornermon/backend/internal/domain"
 )
 
-func TestGroupService_RegisterBadge(t *testing.T) {
-	t.Run("ShouldRegisterBadgeSuccessfullyWhenBadgeIsUnassigned", func(t *testing.T) {
+func TestGroupService_AssignBadge(t *testing.T) {
+	t.Run("ShouldAssignBadgeSuccessfullyWhenBadgeIsUnassigned", func(t *testing.T) {
 		// Arrange
 		now := time.Now()
 		camps := NewMockCampRepository()
@@ -41,7 +41,7 @@ func TestGroupService_RegisterBadge(t *testing.T) {
 		s.uuidFn = func() string { return "group-uuid" }
 
 		// Act
-		group, err := s.RegisterBadge(context.Background(), "camp-1", "qr-1", "1조")
+		group, err := s.AssignBadge(context.Background(), "badge-1", "1조")
 
 		// Assert
 		if err != nil {
@@ -63,12 +63,14 @@ func TestGroupService_RegisterBadge(t *testing.T) {
 		}
 	})
 
-	t.Run("ShouldFailRegisterBadgeWhenCampIsEnded", func(t *testing.T) {
+	t.Run("ShouldAssignBadgeWhenOnlyPendingCampExists", func(t *testing.T) {
 		// Arrange
 		camps := NewMockCampRepository()
-		camp := domain.NewCampFromProps(domain.CampProps{ID: "camp-1", Status: domain.CampEnded})
+		camp := domain.NewCampFromProps(domain.CampProps{ID: "camp-1", Status: domain.CampPending})
 		camps.Save(context.Background(), camp)
 
+		corners := NewMockCornerRepository()
+		corners.Save(context.Background(), domain.NewCornerFromProps(domain.CornerProps{ID: "corner-1", CampID: "camp-1"}))
 		badges := NewMockBadgeRepository()
 		badge := domain.NewBadgeFromProps(domain.BadgeProps{ID: "badge-1",
 			QRPayload: "qr-1",
@@ -81,14 +83,56 @@ func TestGroupService_RegisterBadge(t *testing.T) {
 		auditLogs := &MockAuditLogRepository{}
 		tx := &MockTxManager{}
 
-		s := NewGroupService(camps, nil, NewMockTrackRepository(), groups, badges, visits, auditLogs, tx)
+		s := NewGroupService(camps, corners, NewMockTrackRepository(), groups, badges, visits, auditLogs, tx)
+		s.uuidFn = func() string { return "group-uuid" }
 
 		// Act
-		_, err := s.RegisterBadge(context.Background(), "camp-1", "qr-1", "1조")
+		group, err := s.AssignBadge(context.Background(), "badge-1", "1조")
 
 		// Assert
-		if err != domain.ErrCampInvalidTransition {
-			t.Errorf("expected ErrCampInvalidTransition, got %v", err)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if group == nil || group.CampID() != "camp-1" {
+			t.Fatalf("expected group assigned to pending camp, got %+v", group)
+		}
+	})
+
+	t.Run("ShouldReturnCampNotFoundWhenNoPendingOrActiveCampExists", func(t *testing.T) {
+		// Arrange
+		camps := NewMockCampRepository()
+		_ = camps.Save(context.Background(), domain.NewCampFromProps(domain.CampProps{ID: "camp-1", Status: domain.CampEnded}))
+		badges := NewMockBadgeRepository()
+		_ = badges.Save(context.Background(), domain.NewBadgeFromProps(domain.BadgeProps{ID: "badge-1", QRPayload: "qr-1", Status: domain.BadgeUnassigned}))
+		service := NewGroupService(camps, NewMockCornerRepository(), NewMockTrackRepository(), NewMockGroupRepository(), badges, NewMockVisitRepository(), &MockAuditLogRepository{}, &MockTxManager{})
+
+		// Act
+		_, err := service.AssignBadge(context.Background(), "badge-1", "1조")
+
+		// Assert
+		if err != domain.ErrCampNotFound {
+			t.Fatalf("expected ErrCampNotFound, got %v", err)
+		}
+	})
+
+	t.Run("ShouldAssignBadgeWhenQRPayloadMatches", func(t *testing.T) {
+		// Arrange
+		camps := NewMockCampRepository()
+		_ = camps.Save(context.Background(), domain.NewCampFromProps(domain.CampProps{ID: "camp-1", Status: domain.CampActive}))
+		badges := NewMockBadgeRepository()
+		_ = badges.Save(context.Background(), domain.NewBadgeFromProps(domain.BadgeProps{ID: "badge-1", QRPayload: "qr-1", Status: domain.BadgeUnassigned}))
+		service := NewGroupService(camps, NewMockCornerRepository(), NewMockTrackRepository(), NewMockGroupRepository(), badges, NewMockVisitRepository(), &MockAuditLogRepository{}, &MockTxManager{})
+		service.uuidFn = func() string { return "group-uuid" }
+
+		// Act
+		group, err := service.ScanAssignBadge(context.Background(), "qr-1", "1조")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if group == nil || group.BadgeID() != "badge-1" {
+			t.Fatalf("expected badge assignment from QR payload, got %+v", group)
 		}
 	})
 }


### PR DESCRIPTION
## 변경 사항
- 수동 배정과 QR 스캔 배정의 캠프 선택·배지 조회를 GroupService로 이동했습니다.
- 수동 배정은 배지 ID 단건 조회를, 스캔 배정은 QR payload 단건 조회를 사용합니다.
- 등록 대상 캠프를 ACTIVE 우선, 없으면 PENDING으로 선택하도록 했습니다.
- 배지 미존재(404), 캠프 미존재(404), 중복 배정(409) HTTP 오류 응답을 정리했습니다.

## 변경 이유
핸들러가 캠프 상태를 판단하고 배지 목록을 순회해 QR payload를 변환하는 비즈니스 조율을 수행하고 있었습니다. 이 책임을 유즈케이스로 옮겨 HTTP 계층은 요청·응답 변환만 담당하도록 분리했습니다.

## 검증
- backend 전체 Go 테스트 통과
- backend Go vet 통과
- git diff --check 통과
- PENDING 캠프 등록, 등록 가능 캠프 부재, QR 스캔 배정 유즈케이스 테스트 추가