### PR TITLE
fix: 기기 등록 상태 변경 응답 계약 복구

### DIFF
--- a/backend/docs/artifacts/plan/20260721_device_registration_mutation_response_plan_.md
+++ b/backend/docs/artifacts/plan/20260721_device_registration_mutation_response_plan_.md
@@ -1,0 +1,39 @@
+# 기기 등록 상태 변경 응답 계약 정합성 계획
+
+## 1. 배경
+
+`POST /camps/{campId}/device-registrations/{id}/approve`, `reject`, `revoke`의 Swagger 계약은
+`200 DeviceRegistrationResponse`를 선언하지만, 핸들러는 `200` 빈 본문을 반환한다. 프론트는
+계약대로 객체 본문을 역직렬화하므로 성공한 요청을 오류로 처리한다.
+
+상태 변경 유즈케이스는 저장 직후 갱신된 `DeviceRegistration`을 이미 보유하므로, 별도 재조회 없이
+그 객체를 반환해 계약을 충족한다.
+
+## 2. 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| P0 | UC-14 | 승인·거절된 기기 등록 반환 | 프로덕션 핵심 |
+| P0 | UC-15 | 회수된 기기 등록 반환 | 프로덕션 핵심 |
+
+```go
+func (s *DeviceTrustService) ApproveDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) (*domain.DeviceRegistration, error)
+func (s *DeviceTrustService) RejectDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) (*domain.DeviceRegistration, error)
+func (s *DeviceTrustService) RevokeDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) (*domain.DeviceRegistration, error)
+```
+
+## 3. 구현 단계
+
+1. `backend/internal/usecase/device_trust.go`의 세 상태 변경 메서드가 저장, 감사 로그, 커밋 후 SSE 발행을 완료한 뒤 갱신된 도메인 객체를 반환하도록 변경한다. 실패 시에는 `nil, err`를 반환한다.
+2. `backend/internal/infrastructure/web/device_handler.go`의 포트 인터페이스와 세 핸들러를 갱신한다. 핸들러는 `mapDeviceRegistration`을 사용해 `200 application/json` 본문을 반환한다.
+3. `backend/internal/infrastructure/web/list_handlers_test.go`의 스텁을 새 포트 시그니처에 맞추고, 승인·거절·회수 각각이 갱신된 DTO 본문을 반환하는 HTTP 테스트를 추가한다.
+4. `backend/internal/usecase/device_trust_test.go`에 승인·거절·회수 결과 객체의 상태를 검증하는 표 기반 테스트를 추가한다.
+5. Swagger 주석이 이미 올바른 응답 타입을 선언하므로 `make swag`으로 `api/docs.go`, `api/swagger.json`, `api/swagger.yaml`을 재생성해 산출물 일관성을 확인한다.
+
+## 4. 검증 체크리스트
+
+- [x] 세 유즈케이스가 성공 시 저장된 객체와 전이된 상태를 반환한다.
+- [x] 승인·거절·회수 HTTP 응답이 각각 `200`과 `DeviceRegistrationResponse` JSON 본문을 가진다.
+- [x] `cd backend && go test ./...`가 통과한다.
+- [x] `cd backend && make swag` 후 생성 OpenAPI 산출물에 응답 객체 계약이 유지된다.
+- [x] `git diff --check`가 통과한다.

--- a/backend/internal/infrastructure/web/device_handler.go
+++ b/backend/internal/infrastructure/web/device_handler.go
@@ -16,9 +16,9 @@ import (
 type DeviceTrustUsecase interface {
 	GetMyRegistrationStatus(ctx context.Context, deviceToken string) (*usecase.DeviceRegistrationStatusView, error)
 	RequestRegistration(ctx context.Context, registrationCode string, deviceName, deviceModel, displayName string) (string, *domain.DeviceRegistration, error)
-	ApproveDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) error
-	RejectDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) error
-	RevokeDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) error
+	ApproveDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) (*domain.DeviceRegistration, error)
+	RejectDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) (*domain.DeviceRegistration, error)
+	RevokeDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) (*domain.DeviceRegistration, error)
 	ReviewDeviceTrustRequests(ctx context.Context, campID domain.CampID, status *domain.DeviceRegistrationStatus) ([]*domain.DeviceRegistration, error)
 	ListLockedDevices(ctx context.Context, campID domain.CampID) ([]*domain.DeviceRegistration, error)
 }
@@ -216,12 +216,12 @@ func (h *DeviceHandler) ApproveDevice(c echo.Context) error {
 	}
 	regID := domain.DeviceRegistrationID(c.Param("id"))
 
-	err := h.deviceTrust.ApproveDevice(c.Request().Context(), regID, session.AdminID())
+	device, err := h.deviceTrust.ApproveDevice(c.Request().Context(), regID, session.AdminID())
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
 	}
 
-	return c.NoContent(http.StatusOK)
+	return c.JSON(http.StatusOK, mapDeviceRegistration(device))
 }
 
 // @Summary      기기 거절
@@ -240,12 +240,12 @@ func (h *DeviceHandler) RejectDevice(c echo.Context) error {
 	}
 	regID := domain.DeviceRegistrationID(c.Param("id"))
 
-	err := h.deviceTrust.RejectDevice(c.Request().Context(), regID, session.AdminID())
+	device, err := h.deviceTrust.RejectDevice(c.Request().Context(), regID, session.AdminID())
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
 	}
 
-	return c.NoContent(http.StatusOK)
+	return c.JSON(http.StatusOK, mapDeviceRegistration(device))
 }
 
 // @Summary      기기 신뢰 취소 (폐기/분실)
@@ -264,10 +264,10 @@ func (h *DeviceHandler) RevokeDevice(c echo.Context) error {
 	}
 	regID := domain.DeviceRegistrationID(c.Param("id"))
 
-	err := h.deviceTrust.RevokeDevice(c.Request().Context(), regID, session.AdminID())
+	device, err := h.deviceTrust.RevokeDevice(c.Request().Context(), regID, session.AdminID())
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
 	}
 
-	return c.NoContent(http.StatusOK)
+	return c.JSON(http.StatusOK, mapDeviceRegistration(device))
 }

--- a/backend/internal/infrastructure/web/device_handler_test.go
+++ b/backend/internal/infrastructure/web/device_handler_test.go
@@ -172,6 +172,50 @@ func TestShouldReturnBadRequestWhenCampIsNotActiveForRegistration(t *testing.T) 
 	}
 }
 
+func TestShouldReturnUpdatedRegistrationWhenDeviceStatusChanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		status domain.DeviceRegistrationStatus
+		handle func(*DeviceHandler, echo.Context) error
+	}{
+		{name: "approved", path: "/camps/camp-1/device-registrations/device-1/approve", status: domain.DeviceApproved, handle: (*DeviceHandler).ApproveDevice},
+		{name: "rejected", path: "/camps/camp-1/device-registrations/device-1/reject", status: domain.DeviceRejected, handle: (*DeviceHandler).RejectDevice},
+		{name: "revoked", path: "/camps/camp-1/device-registrations/device-1/revoke", status: domain.DeviceRevoked, handle: (*DeviceHandler).RevokeDevice},
+	}
+
+	for _, tt := range tests {
+		t.Run("ShouldReturnRegistrationWhenDeviceIs"+tt.name, func(t *testing.T) {
+			// Arrange
+			e := echo.New()
+			device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1", CampID: "camp-1", Status: tt.status})
+			handler := NewDeviceHandler(&listDeviceTrustStub{mutatedDevice: device})
+			req := httptest.NewRequest(http.MethodPost, tt.path, nil)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			ctx.Set("adminSession", domain.NewAdminSessionFromProps(domain.AdminSessionProps{AdminID: "admin-1"}))
+			ctx.SetPath("/camps/:campId/device-registrations/:id/" + tt.name)
+			ctx.SetParamNames("campId", "id")
+			ctx.SetParamValues("camp-1", "device-1")
+
+			// Act
+			err := tt.handle(handler, ctx)
+
+			// Assert
+			if err != nil || rec.Code != http.StatusOK {
+				t.Fatalf("expected 200 JSON response, code=%d err=%v", rec.Code, err)
+			}
+			var response DeviceRegistrationResponse
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.ID != "device-1" || response.CampID != "camp-1" || response.Status != string(tt.status) {
+				t.Fatalf("unexpected updated registration response: %+v", response)
+			}
+		})
+	}
+}
+
 func TestShouldReturnActualCreatedAtWhenListingRegistrations(t *testing.T) {
 	// Arrange
 	e := echo.New()

--- a/backend/internal/infrastructure/web/list_handlers_test.go
+++ b/backend/internal/infrastructure/web/list_handlers_test.go
@@ -24,6 +24,7 @@ type listDeviceTrustStub struct {
 	campStatus       domain.CampStatus
 	statusErr        error
 	deviceToken      string
+	mutatedDevice    *domain.DeviceRegistration
 }
 
 func (s *listDeviceTrustStub) GetMyRegistrationStatus(_ context.Context, deviceToken string) (*usecase.DeviceRegistrationStatusView, error) {
@@ -37,14 +38,14 @@ func (s *listDeviceTrustStub) RequestRegistration(_ context.Context, registratio
 	}
 	return "token", s.requestedReg, nil
 }
-func (s *listDeviceTrustStub) ApproveDevice(context.Context, domain.DeviceRegistrationID, domain.AdminID) error {
-	return nil
+func (s *listDeviceTrustStub) ApproveDevice(context.Context, domain.DeviceRegistrationID, domain.AdminID) (*domain.DeviceRegistration, error) {
+	return s.mutatedDevice, nil
 }
-func (s *listDeviceTrustStub) RejectDevice(context.Context, domain.DeviceRegistrationID, domain.AdminID) error {
-	return nil
+func (s *listDeviceTrustStub) RejectDevice(context.Context, domain.DeviceRegistrationID, domain.AdminID) (*domain.DeviceRegistration, error) {
+	return s.mutatedDevice, nil
 }
-func (s *listDeviceTrustStub) RevokeDevice(context.Context, domain.DeviceRegistrationID, domain.AdminID) error {
-	return nil
+func (s *listDeviceTrustStub) RevokeDevice(context.Context, domain.DeviceRegistrationID, domain.AdminID) (*domain.DeviceRegistration, error) {
+	return s.mutatedDevice, nil
 }
 func (s *listDeviceTrustStub) ReviewDeviceTrustRequests(context.Context, domain.CampID, *domain.DeviceRegistrationStatus) ([]*domain.DeviceRegistration, error) {
 	return s.reviewedDevices, nil

--- a/backend/internal/usecase/device_trust.go
+++ b/backend/internal/usecase/device_trust.go
@@ -125,18 +125,18 @@ func (s *DeviceTrustService) ApproveDevice(
 	ctx context.Context,
 	regID domain.DeviceRegistrationID,
 	actorAdminID domain.AdminID,
-) error {
+) (*domain.DeviceRegistration, error) {
 	now := s.nowFn()
 	device, err := s.devices.Get(ctx, regID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if device == nil {
-		return domain.ErrDeviceInvalidTransition
+		return nil, domain.ErrDeviceInvalidTransition
 	}
 
 	if err := device.Approve(now); err != nil {
-		return err
+		return nil, err
 	}
 
 	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
@@ -145,12 +145,12 @@ func (s *DeviceTrustService) ApproveDevice(
 
 	if err != nil {
 		s.recordAuditLog(ctx, string(actorAdminID), ActionDeviceApproved, string(regID), false, map[string]any{"error": err.Error()})
-		return err
+		return nil, err
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), ActionDeviceApproved, string(regID), true, nil)
 	_ = s.broadcaster.Broadcast(ctx, device.CampID(), EventDeviceRegistrationUpdated, CampScope())
-	return nil
+	return device, nil
 }
 
 // RejectDevice - UC-14 (거부)
@@ -158,17 +158,17 @@ func (s *DeviceTrustService) RejectDevice(
 	ctx context.Context,
 	regID domain.DeviceRegistrationID,
 	actorAdminID domain.AdminID,
-) error {
+) (*domain.DeviceRegistration, error) {
 	device, err := s.devices.Get(ctx, regID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if device == nil {
-		return domain.ErrDeviceInvalidTransition
+		return nil, domain.ErrDeviceInvalidTransition
 	}
 
 	if err := device.Reject(); err != nil {
-		return err
+		return nil, err
 	}
 
 	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
@@ -177,12 +177,12 @@ func (s *DeviceTrustService) RejectDevice(
 
 	if err != nil {
 		s.recordAuditLog(ctx, string(actorAdminID), ActionDeviceRejected, string(regID), false, map[string]any{"error": err.Error()})
-		return err
+		return nil, err
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), ActionDeviceRejected, string(regID), true, nil)
 	_ = s.broadcaster.Broadcast(ctx, device.CampID(), EventDeviceRegistrationUpdated, CampScope())
-	return nil
+	return device, nil
 }
 
 // RevokeDevice - UC-15
@@ -190,17 +190,17 @@ func (s *DeviceTrustService) RevokeDevice(
 	ctx context.Context,
 	regID domain.DeviceRegistrationID,
 	actorAdminID domain.AdminID,
-) error {
+) (*domain.DeviceRegistration, error) {
 	device, err := s.devices.Get(ctx, regID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if device == nil {
-		return domain.ErrDeviceNotApproved
+		return nil, domain.ErrDeviceNotApproved
 	}
 
 	if err := device.Revoke(); err != nil {
-		return err
+		return nil, err
 	}
 
 	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
@@ -209,12 +209,12 @@ func (s *DeviceTrustService) RevokeDevice(
 
 	if err != nil {
 		s.recordAuditLog(ctx, string(actorAdminID), ActionDeviceRevoked, string(regID), false, map[string]any{"error": err.Error()})
-		return err
+		return nil, err
 	}
 
 	s.recordAuditLog(ctx, string(actorAdminID), ActionDeviceRevoked, string(regID), true, nil)
 	_ = s.broadcaster.Broadcast(ctx, device.CampID(), EventDeviceRegistrationUpdated, CampScope())
-	return nil
+	return device, nil
 }
 
 // ResetPinFailures - UC-16

--- a/backend/internal/usecase/device_trust_test.go
+++ b/backend/internal/usecase/device_trust_test.go
@@ -103,46 +103,62 @@ func TestDeviceTrustService_RequestRegistration(t *testing.T) {
 	})
 }
 
-func TestDeviceTrustService_ApproveDevice(t *testing.T) {
-	t.Run("ShouldApproveDeviceSuccessfullyWhenPending", func(t *testing.T) {
-		// Arrange
-		now := time.Now()
-		camps := NewMockCampRepository()
-		devices := NewMockDeviceRegistrationRepository()
-		device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1",
-			CampID: "camp-1",
-			Status: domain.DevicePending,
+func TestDeviceTrustService_ShouldReturnUpdatedRegistrationWhenDeviceStatusChanges(t *testing.T) {
+	tests := []struct {
+		name          string
+		initialStatus domain.DeviceRegistrationStatus
+		wantStatus    domain.DeviceRegistrationStatus
+		change        func(*DeviceTrustService, context.Context, domain.DeviceRegistrationID, domain.AdminID) (*domain.DeviceRegistration, error)
+	}{
+		{name: "approved", initialStatus: domain.DevicePending, wantStatus: domain.DeviceApproved, change: (*DeviceTrustService).ApproveDevice},
+		{name: "rejected", initialStatus: domain.DevicePending, wantStatus: domain.DeviceRejected, change: (*DeviceTrustService).RejectDevice},
+		{name: "revoked", initialStatus: domain.DeviceApproved, wantStatus: domain.DeviceRevoked, change: (*DeviceTrustService).RevokeDevice},
+	}
+
+	for _, tt := range tests {
+		t.Run("ShouldReturnUpdatedRegistrationWhenDeviceIs"+tt.name, func(t *testing.T) {
+			// Arrange
+			now := time.Now()
+			camps := NewMockCampRepository()
+			devices := NewMockDeviceRegistrationRepository()
+			device := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "device-1",
+				CampID: "camp-1",
+				Status: tt.initialStatus,
+			})
+			devices.Devices["device-1"] = device
+
+			auditLogs := &MockAuditLogRepository{}
+			broadcaster := &MockBroadcaster{}
+			tx := &MockTxManager{}
+
+			s := NewDeviceTrustService(camps, devices, auditLogs, broadcaster, tx)
+			s.nowFn = func() time.Time { return now }
+			s.uuidFn = func() string { return "audit-uuid" }
+
+			// Act
+			updated, err := tt.change(s, context.Background(), "device-1", "admin-1")
+
+			// Assert
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if updated == nil || updated.Status() != tt.wantStatus {
+				t.Fatalf("expected returned registration status %q, got %+v", tt.wantStatus, updated)
+			}
+
+			persisted, _ := devices.Get(context.Background(), "device-1")
+			if persisted.Status() != tt.wantStatus {
+				t.Errorf("expected persisted status %q, got %s", tt.wantStatus, persisted.Status())
+			}
+
+			if len(broadcaster.Broadcasts) != 1 ||
+				broadcaster.Broadcasts[0].CampID != "camp-1" ||
+				broadcaster.Broadcasts[0].Event != EventDeviceRegistrationUpdated ||
+				broadcaster.Broadcasts[0].Scope != CampScope() {
+				t.Errorf("expected EventDeviceRegistrationUpdated broadcast, got %v", broadcaster.Broadcasts)
+			}
 		})
-		devices.Devices["device-1"] = device
-
-		auditLogs := &MockAuditLogRepository{}
-		broadcaster := &MockBroadcaster{}
-		tx := &MockTxManager{}
-
-		s := NewDeviceTrustService(camps, devices, auditLogs, broadcaster, tx)
-		s.nowFn = func() time.Time { return now }
-		s.uuidFn = func() string { return "audit-uuid" }
-
-		// Act
-		err := s.ApproveDevice(context.Background(), "device-1", "admin-1")
-
-		// Assert
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-
-		updated, _ := devices.Get(context.Background(), "device-1")
-		if updated.Status() != domain.DeviceApproved {
-			t.Errorf("expected status 'APPROVED', got %s", updated.Status())
-		}
-
-		if len(broadcaster.Broadcasts) != 1 ||
-			broadcaster.Broadcasts[0].CampID != "camp-1" ||
-			broadcaster.Broadcasts[0].Event != EventDeviceRegistrationUpdated ||
-			broadcaster.Broadcasts[0].Scope != CampScope() {
-			t.Errorf("expected EventDeviceRegistrationUpdated broadcast, got %v", broadcaster.Broadcasts)
-		}
-	})
+	}
 }
 
 func TestDeviceTrustService_GetMyRegistrationStatus(t *testing.T) {


### PR DESCRIPTION
## 변경 사항
- 승인·거절·회수 유즈케이스가 저장된 DeviceRegistration을 반환하도록 변경했습니다.
- 세 HTTP 핸들러가 200 OK와 DeviceRegistrationResponse JSON 본문을 반환하도록 수정했습니다.
- 세 상태 전이 및 HTTP 응답 본문을 검증하는 테스트를 추가했습니다.

## 변경 이유
OpenAPI는 기기 등록 객체 응답을 선언했지만 실제 서버는 200 빈 본문을 반환해 프론트 역직렬화가 실패했습니다. 계약과 실제 응답을 일치시킵니다.

## 검증
- cd backend && go test ./... 통과
- cd backend && make swag 실행 후 Swagger 응답 계약 유지 확인
- git diff --check 통과