### PR TITLE
fix: 진행자 메인 상단바 안전 여백 추가

### DIFF
--- a/frontend/docs/artifacts/plan/20260721_관리자_상단바_안전_여백_plan_.md
+++ b/frontend/docs/artifacts/plan/20260721_관리자_상단바_안전_여백_plan_.md
@@ -1,0 +1,38 @@
+# 관리자 상단바 안전 여백 보정 계획
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-1: 관리자 공용 셸 안전 영역 | 상태바·노치 inset 뒤에 관리자 사이드바 및 캠프 시작·종료 상단 액션을 배치한다. | 프로덕션 핵심 UI |
+
+## 확인 결과
+
+- `AdminScaffold`는 관리자 캠프 내부 라우트의 공용 셸이며, 현재 최상단 `Row`에 `SafeArea`가 없다.
+- Flutter 공식 SafeArea 지침에 따라 시스템 inset은 `SafeArea`로 처리하고, UI 간격은 별도 8dp 패딩으로 둔다.
+
+## 구현 단계
+
+### Phase A: 공용 셸 상단 여백 적용 (예상 소요: 10분)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| A-1 | `AdminScaffold`의 공용 `Row`를 `SafeArea`로 감싸고, 그 아래에 8dp 상단 패딩을 둔다. | `/Users/lsjtop10/projects/cornermon/.claude/worktrees/fix-facilitator-top-safe-area/frontend/lib/admin/widgets/admin_scaffold.dart` (기존 파일 확장) |
+| A-2 | 상태바 inset이 있는 뷰포트에서 준비 모드의 상단 시작 액션이 안전 영역 및 추가 여백 아래에 렌더링되는지 검증한다. | `/Users/lsjtop10/projects/cornermon/.claude/worktrees/fix-facilitator-top-safe-area/frontend/test/admin/features/start_camp/start_camp_button_test.dart` (기존 파일 확장) |
+
+```dart
+SafeArea(
+  child: Padding(
+    padding: const EdgeInsets.only(top: AppSpacing.space2),
+    child: Row(children: [AdminSidebar(...), ...]),
+  ),
+)
+```
+
+## 검증 체크리스트
+
+- [x] 상태바/노치 inset이 있는 화면에서 관리자 공용 셸 콘텐츠가 시스템 UI 아래에 놓인다.
+- [x] 공용 셸과 안전 영역 사이에 8dp 추가 여백이 있다.
+- [x] 관련 관리자 위젯 테스트를 통과한다.
+- [x] `flutter analyze lib/admin/widgets/admin_scaffold.dart`를 통과한다.
+- [x] 변경 범위가 `frontend/`에 한정된다.

--- a/frontend/docs/artifacts/plan/20260721_진행자_메인_상단바_여백_plan_.md
+++ b/frontend/docs/artifacts/plan/20260721_진행자_메인_상단바_여백_plan_.md
@@ -1,0 +1,39 @@
+# 진행자 메인 상단바 여백 보정 계획
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-1: 안전 영역 아래 헤더 표시 | 상태바·노치 inset 뒤에 추가 상단 여백을 둬 진행자 메인 헤더와 시스템 상단바가 겹쳐 보이지 않게 한다. | 프로덕션 핵심 UI |
+
+## 확인 결과
+
+- `MainTrackScreen`은 이미 `SafeArea`로 시스템 침범 영역을 피한다.
+- Flutter 공식 SafeArea 지침에 따라 시스템 inset은 `SafeArea`에 맡기고, 디자인상 필요한 간격은 콘텐츠 레이아웃에 별도로 둔다.
+- Context7 MCP는 이 실행 환경에 연결되어 있지 않아 Flutter 공식 문서(`SafeArea & MediaQuery`)를 기준으로 확인했다.
+
+## 구현 단계
+
+### Phase A: 상단 여백 적용 (예상 소요: 10분)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| A-1 | `SafeArea` 내부 메인 컬럼에 8dp 상단 여백을 적용한다. `SafeArea`가 상태바/노치 inset을 처리한 뒤 추가되므로 기기별 안전 영역과 중복 계산하지 않는다. | `/Users/lsjtop10/projects/cornermon/.claude/worktrees/fix-facilitator-top-safe-area/frontend/lib/facilitator/features/main_track/main_track_screen.dart` (기존 파일 확장) |
+| A-2 | 상태바 inset이 있는 테스트 뷰포트에서 헤더의 y 위치가 시스템 inset과 추가 여백 이상인지 검증한다. | `/Users/lsjtop10/projects/cornermon/.claude/worktrees/fix-facilitator-top-safe-area/frontend/test/facilitator/features/main_track_test.dart` (기존 파일 확장) |
+
+```dart
+SafeArea(
+  child: Padding(
+    padding: const EdgeInsets.only(top: AppSpacing.space2),
+    child: Column(children: [MainTrackHeader(trackId: trackId), ...]),
+  ),
+)
+```
+
+## 검증 체크리스트
+
+- [x] 상태바/노치 inset이 있는 화면에서 메인 헤더가 시스템 UI 아래에 놓인다.
+- [x] 메인 헤더와 안전 영역 사이에 8dp 추가 여백이 있다.
+- [ ] `flutter test test/facilitator/features/main_track_test.dart`를 통과한다. 기존 `ShouldClearBroadcastBadgeWhenRefreshedMessagesAreRead`가 두 번째 `pumpWidget` 뒤에도 이전 배지를 유지해 실패한다. 이번 변경과 무관하며, 추가한 `ShouldRenderHeaderAndIdleBodyWhenAuthenticatedAndIdle`는 단독 통과했다.
+- [x] `flutter analyze lib/facilitator/features/main_track`를 통과한다.
+- [x] 변경 범위가 `frontend/`에 한정된다.

--- a/frontend/lib/admin/widgets/admin_scaffold.dart
+++ b/frontend/lib/admin/widgets/admin_scaffold.dart
@@ -5,6 +5,7 @@ import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/admin/widgets/sidebar/admin_sidebar.dart';
 import 'package:cornermon/admin/features/end_camp/end_camp_bar_button.dart';
 import 'package:cornermon/admin/features/start_camp/start_camp_button.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 
 class AdminScaffold extends ConsumerWidget {
   const AdminScaffold({required this.body, super.key});
@@ -26,34 +27,41 @@ class AdminScaffold extends ConsumerWidget {
           );
         }
         return Scaffold(
-          body: Row(
-            children: [
-              AdminSidebar(mode: sidebarModeFor(camp!.status!)),
-              const VerticalDivider(width: 1),
-              Expanded(
-                child: Column(
-                  children: [
-                    if (sidebarModeFor(camp.status!) == SidebarMode.preparing)
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: Padding(
-                          padding: const EdgeInsets.all(12),
-                          child: StartCampButton(),
-                        ),
-                      ),
-                    if (sidebarModeFor(camp.status!) == SidebarMode.operating)
-                      Align(
-                        alignment: Alignment.centerRight,
-                        child: Padding(
-                          padding: const EdgeInsets.all(12),
-                          child: EndCampBarButton(),
-                        ),
-                      ),
-                    Expanded(child: body),
-                  ],
-                ),
+          body: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.only(top: AppSpacing.space2),
+              child: Row(
+                children: [
+                  AdminSidebar(mode: sidebarModeFor(camp!.status!)),
+                  const VerticalDivider(width: 1),
+                  Expanded(
+                    child: Column(
+                      children: [
+                        if (sidebarModeFor(camp.status!) ==
+                            SidebarMode.preparing)
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: Padding(
+                              padding: const EdgeInsets.all(12),
+                              child: StartCampButton(),
+                            ),
+                          ),
+                        if (sidebarModeFor(camp.status!) ==
+                            SidebarMode.operating)
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: Padding(
+                              padding: const EdgeInsets.all(12),
+                              child: EndCampBarButton(),
+                            ),
+                          ),
+                        Expanded(child: body),
+                      ],
+                    ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
         );
       },

--- a/frontend/lib/facilitator/features/main_track/main_track_screen.dart
+++ b/frontend/lib/facilitator/features/main_track/main_track_screen.dart
@@ -64,32 +64,35 @@ class _MainTrackScreenState extends ConsumerState<MainTrackScreen> {
       body: SafeArea(
         child: Stack(
           children: [
-            Column(
-              children: [
-                MainTrackHeader(trackId: trackId),
-                Expanded(
-                  child: MainTrackBody(
-                    trackId: trackId,
-                    currentVisit: currentVisit,
-                    cornerName: session.corner.name ?? '',
-                    trackNo: session.track.trackNo ?? 0,
-                    targetMinutes: targetMinutes,
-                    onVisitEnded: (summary) =>
-                        setState(() => _visitJustCompleted = summary),
-                  ),
-                ),
-                if (isIdle)
-                  Padding(
-                    padding: const EdgeInsets.all(AppSpacing.space4),
-                    child: AppButton(
-                      variant: AppButtonVariant.secondary,
-                      size: AppButtonSize.comfortable,
-                      width: AppButtonWidth.fill,
-                      label: '수동으로 처리',
-                      onPressed: () => context.go('/main/manual'),
+            Padding(
+              padding: const EdgeInsets.only(top: AppSpacing.space2),
+              child: Column(
+                children: [
+                  MainTrackHeader(trackId: trackId),
+                  Expanded(
+                    child: MainTrackBody(
+                      trackId: trackId,
+                      currentVisit: currentVisit,
+                      cornerName: session.corner.name ?? '',
+                      trackNo: session.track.trackNo ?? 0,
+                      targetMinutes: targetMinutes,
+                      onVisitEnded: (summary) =>
+                          setState(() => _visitJustCompleted = summary),
                     ),
                   ),
-              ],
+                  if (isIdle)
+                    Padding(
+                      padding: const EdgeInsets.all(AppSpacing.space4),
+                      child: AppButton(
+                        variant: AppButtonVariant.secondary,
+                        size: AppButtonSize.comfortable,
+                        width: AppButtonWidth.fill,
+                        label: '수동으로 처리',
+                        onPressed: () => context.go('/main/manual'),
+                      ),
+                    ),
+                ],
+              ),
             ),
             if (_visitJustCompleted != null)
               Positioned.fill(

--- a/frontend/test/admin/features/start_camp/start_camp_button_test.dart
+++ b/frontend/test/admin/features/start_camp/start_camp_button_test.dart
@@ -5,6 +5,7 @@ import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/admin/widgets/admin_scaffold.dart';
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/camp_providers.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon_api_gen/cornermon_api_gen.dart';
 import 'package:flutter/material.dart';
@@ -56,6 +57,47 @@ void main() {
 
     // assert
     expect(find.text('코너학습 시작'), findsNothing);
+  });
+
+  testWidgets('ShouldPositionStartActionBelowSystemTopInsetWhenPreparing', (
+    tester,
+  ) async {
+    // arrange
+    final campId = CampId('camp-1');
+    final router = GoRouter(
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (_, _) => const AdminScaffold(body: Text('body')),
+        ),
+      ],
+    );
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
+          selectedCampProvider.overrideWith(
+            (ref) async => _camp(CampResponseStatusEnum.PENDING),
+          ),
+        ],
+        child: MaterialApp.router(
+          routerConfig: router,
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(
+              context,
+            ).copyWith(padding: const EdgeInsets.only(top: 24.0)),
+            child: child!,
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // act
+    final actionTopLeft = tester.getTopLeft(find.byType(StartCampButton));
+
+    // assert
+    expect(actionTopLeft.dy, 24.0 + AppSpacing.space2 + 12.0);
   });
 
   testWidgets('ShoudShowDialogAndNotStartCampWhenCancelTapped', (tester) async {

--- a/frontend/test/facilitator/features/main_track_test.dart
+++ b/frontend/test/facilitator/features/main_track_test.dart
@@ -12,6 +12,7 @@ import 'package:cornermon/shared/api/providers/group_providers.dart';
 import 'package:cornermon/shared/api/providers/visit_providers.dart';
 import 'package:cornermon/shared/api/sse/track_event_stream.dart';
 import 'package:cornermon/shared/design_system/tokens/colors.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -294,7 +295,12 @@ void main() {
 
       await tester.pumpWidget(
         buildTestable(
-          const MainTrackScreen(),
+          MediaQuery(
+            data: const MediaQueryData(
+              padding: EdgeInsets.only(top: 24.0),
+            ),
+            child: const MainTrackScreen(),
+          ),
           overrides: [
             trackSessionProvider.overrideWith(() => _FakeTrackSession(authenticatedState)),
             currentVisitProvider(trackId).overrideWith((ref) => null),
@@ -321,6 +327,9 @@ void main() {
       expect(find.text('3번 트랙'), findsOneWidget);
       expect(find.text('스캔 시작'), findsOneWidget);
       expect(find.text('수동으로 처리'), findsOneWidget);
+
+      final headerTopLeft = tester.getTopLeft(find.byType(MainTrackHeader));
+      expect(headerTopLeft.dy, AppSpacing.space2 + 24.0);
     });
   });
 }


### PR DESCRIPTION
## 변경 사항
- 진행자 메인 트랙 화면의 SafeArea 내부에 8dp 상단 여백을 추가했습니다.
- 관리자 공용 AdminScaffold에 SafeArea 및 8dp 상단 여백을 추가해 사이드바와 캠프 시작·종료 상단 액션을 시스템 상단바 아래에 배치했습니다.
- 상태바·노치 inset이 있는 환경의 위치 검증과 작업 계획을 추가했습니다.

## 검증
- flutter test test/admin/features/start_camp/start_camp_button_test.dart 통과
- flutter analyze lib/admin/widgets/admin_scaffold.dart 통과
- flutter test test/facilitator/features/main_track_test.dart --plain-name ShouldRenderHeaderAndIdleBodyWhenAuthenticatedAndIdle 통과
- flutter analyze lib/facilitator/features/main_track 통과
- 전체 main_track_test.dart는 기존 ShouldClearBroadcastBadgeWhenRefreshedMessagesAreRead가 두 번째 pumpWidget 뒤에도 이전 배지를 유지해 실패합니다. 이번 변경과 무관합니다.

## 종료 조건
- 진행자 및 관리자 공용 상단 콘텐츠가 상태바/노치와 겹치지 않습니다.
- 두 앱 모두 안전 영역 아래에 8dp 추가 여백이 적용됩니다.