### PR TITLE
fix: 핸들러별 예상 오류를 HTTP 4xx로 변환

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -492,6 +492,12 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "성공"
+                    },
+                    "409": {
+                        "description": "DEVICE_INVALID_TRANSITION: 존재하지 않거나 잠금 해제할 수 없는 기기",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -540,19 +546,19 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "잘못된 PIN (지연 가능)",
+                        "description": "INVALID_PIN: PIN이 올바르지 않음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
                     "403": {
-                        "description": "신뢰 기기 아님 또는 캠프 미시작",
+                        "description": "DEVICE_NOT_APPROVED: 기기가 승인되지 않음; CAMP_NOT_AVAILABLE: 캠프가 로그인 가능한 상태가 아님",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
                     "429": {
-                        "description": "PIN 잠금(지연) 중",
+                        "description": "DEVICE_LOCKED: PIN 실패 횟수 초과로 기기가 일시 잠김",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -578,6 +584,12 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "성공"
+                    },
+                    "401": {
+                        "description": "SESSION_REVOKED: 세션이 이미 취소됨",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1097,6 +1109,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/DeviceRegistrationResponse"
                         }
+                    },
+                    "409": {
+                        "description": "DEVICE_INVALID_TRANSITION: PENDING 상태가 아닌 기기는 승인할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1138,6 +1156,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/DeviceRegistrationResponse"
                         }
+                    },
+                    "409": {
+                        "description": "DEVICE_INVALID_TRANSITION: PENDING 상태가 아닌 기기는 거절할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1178,6 +1202,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/DeviceRegistrationResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "DEVICE_NOT_APPROVED: APPROVED 상태가 아닌 기기는 신뢰를 취소할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
                         }
                     }
                 }
@@ -1314,7 +1344,13 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Bad Request",
+                        "description": "BAD_REQUEST: 요청 본문 또는 campId가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "CAMP_NOT_ACTIVE: ACTIVE 캠프에서만 공지를 보낼 수 있음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1352,6 +1388,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/CampReportResponse"
                         }
+                    },
+                    "404": {
+                        "description": "CAMP_NOT_FOUND: 캠프가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1385,6 +1427,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/CampReportResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "CAMP_NOT_FOUND: 캠프가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
                         }
                     }
                 }
@@ -1420,6 +1468,18 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/CampReportResponse"
                         }
+                    },
+                    "404": {
+                        "description": "CAMP_NOT_FOUND: 캠프가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "CAMP_NOT_ENDED: 종료된 캠프에서만 최종 리포트를 생성할 수 있음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1453,6 +1513,12 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/CampSummaryStatsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "CAMP_NOT_FOUND: 캠프가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
                         }
                     }
                 }
@@ -1577,19 +1643,19 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Bad Request",
+                        "description": "CAMP_INVALID_SETTINGS: 설정 값이 유효하지 않음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
                     "404": {
-                        "description": "Not Found",
+                        "description": "CAMP_NOT_FOUND: 대상 캠프가 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
                     "409": {
-                        "description": "Conflict",
+                        "description": "CAMP_SETTINGS_LOCKED: 종료된 캠프는 수정할 수 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1635,7 +1701,7 @@ const docTemplate = `{
                         }
                     },
                     "409": {
-                        "description": "Conflict",
+                        "description": "CAMP_STATE_CONFLICT: 종료할 수 없는 캠프 상태 또는 정리 중인 방문 충돌",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1681,7 +1747,7 @@ const docTemplate = `{
                         }
                     },
                     "409": {
-                        "description": "이미 활성화됨 또는 필수 조건 미충족",
+                        "description": "CAMP_STATE_CONFLICT: 이미 활성화되었거나 활성화할 수 없는 상태",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1736,6 +1802,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
+                    },
+                    "409": {
+                        "description": "CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 생성할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1785,8 +1857,14 @@ const docTemplate = `{
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "CORNER_NOT_FOUND: 수정할 코너가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
                     "409": {
-                        "description": "Conflict",
+                        "description": "CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 수정할 수 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1863,7 +1941,7 @@ const docTemplate = `{
                         }
                     },
                     "404": {
-                        "description": "Not Found",
+                        "description": "CORNER_NOT_FOUND: 대상 코너가 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1904,7 +1982,7 @@ const docTemplate = `{
                         }
                     },
                     "409": {
-                        "description": "활성화된 캠프이거나 종속 데이터가 존재함",
+                        "description": "CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 삭제할 수 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1941,6 +2019,18 @@ const docTemplate = `{
                         "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/DeviceRegistrationCreatedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "INVALID_TRANSITION: 종료된 캠프에는 기기를 등록할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "CAMP_NOT_FOUND: 등록 코드에 해당하는 캠프가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
                         }
                     }
                 }
@@ -2201,6 +2291,18 @@ const docTemplate = `{
                                 "$ref": "#/definitions/TrackPinResponse"
                             }
                         }
+                    },
+                    "404": {
+                        "description": "CORNER_NOT_FOUND: 대상 코너가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "CAMP_NOT_AVAILABLE: 종료된 캠프에는 트랙을 생성할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2237,6 +2339,18 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "성공적으로 삭제됨"
+                    },
+                    "404": {
+                        "description": "TRACK_NOT_FOUND: 대상 트랙이 없거나 이미 삭제됨",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "TRACK_DELETE_BLOCKED: 진행 중인 방문이 있어 삭제할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2413,6 +2527,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/TrackPinResponse"
                         }
+                    },
+                    "404": {
+                        "description": "TRACK_NOT_FOUND: 대상 트랙이 없거나 활성 상태가 아님",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2574,7 +2694,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "세션 트랙과 요청 트랙 불일치",
+                        "description": "TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -2638,7 +2758,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "세션 트랙과 요청 트랙 불일치",
+                        "description": "TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -2725,7 +2845,7 @@ const docTemplate = `{
                         }
                     },
                     "403": {
-                        "description": "세션 트랙과 요청 트랙 불일치",
+                        "description": "TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -2764,8 +2884,17 @@ const docTemplate = `{
                             "$ref": "#/definitions/VisitSummaryResponse"
                         }
                     },
+                    "401": {
+                        "description": "SESSION_REVOKED: 진행자 세션이 취소됨",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
                     "404": {
-                        "description": "진행 중인 방문 없음"
+                        "description": "VISIT_NOT_FOUND: 진행 중인 방문 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2801,8 +2930,14 @@ const docTemplate = `{
                             "$ref": "#/definitions/VisitSummaryResponse"
                         }
                     },
+                    "401": {
+                        "description": "SESSION_REVOKED: 진행자 세션이 취소됨",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
                     "409": {
-                        "description": "TRACK_NOT_BUSY 등",
+                        "description": "TRACK_NOT_BUSY, TRACK_NOT_ACTIVE, ITINERARY_CONFLICT: 현재 운영 상태에서 방문을 종료할 수 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -2853,8 +2988,20 @@ const docTemplate = `{
                             "$ref": "#/definitions/VisitSummaryResponse"
                         }
                     },
+                    "401": {
+                        "description": "SESSION_REVOKED: 진행자 세션이 취소됨",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "BADGE_NOT_ASSIGNED: 배지가 존재하지 않거나 조에 배정되지 않음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
                     "409": {
-                        "description": "TRACK_BUSY, DUPLICATE_VISIT 등",
+                        "description": "TRACK_BUSY, TRACK_NOT_ACTIVE, ITINERARY_CONFLICT, CAMP_NOT_ACTIVE: 현재 운영 상태에서 방문을 시작할 수 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -485,6 +485,12 @@
                 "responses": {
                     "204": {
                         "description": "성공"
+                    },
+                    "409": {
+                        "description": "DEVICE_INVALID_TRANSITION: 존재하지 않거나 잠금 해제할 수 없는 기기",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -533,19 +539,19 @@
                         }
                     },
                     "400": {
-                        "description": "잘못된 PIN (지연 가능)",
+                        "description": "INVALID_PIN: PIN이 올바르지 않음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
                     "403": {
-                        "description": "신뢰 기기 아님 또는 캠프 미시작",
+                        "description": "DEVICE_NOT_APPROVED: 기기가 승인되지 않음; CAMP_NOT_AVAILABLE: 캠프가 로그인 가능한 상태가 아님",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
                     "429": {
-                        "description": "PIN 잠금(지연) 중",
+                        "description": "DEVICE_LOCKED: PIN 실패 횟수 초과로 기기가 일시 잠김",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -571,6 +577,12 @@
                 "responses": {
                     "204": {
                         "description": "성공"
+                    },
+                    "401": {
+                        "description": "SESSION_REVOKED: 세션이 이미 취소됨",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1090,6 +1102,12 @@
                         "schema": {
                             "$ref": "#/definitions/DeviceRegistrationResponse"
                         }
+                    },
+                    "409": {
+                        "description": "DEVICE_INVALID_TRANSITION: PENDING 상태가 아닌 기기는 승인할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1131,6 +1149,12 @@
                         "schema": {
                             "$ref": "#/definitions/DeviceRegistrationResponse"
                         }
+                    },
+                    "409": {
+                        "description": "DEVICE_INVALID_TRANSITION: PENDING 상태가 아닌 기기는 거절할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1171,6 +1195,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/DeviceRegistrationResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "DEVICE_NOT_APPROVED: APPROVED 상태가 아닌 기기는 신뢰를 취소할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
                         }
                     }
                 }
@@ -1307,7 +1337,13 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request",
+                        "description": "BAD_REQUEST: 요청 본문 또는 campId가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "CAMP_NOT_ACTIVE: ACTIVE 캠프에서만 공지를 보낼 수 있음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1345,6 +1381,12 @@
                         "schema": {
                             "$ref": "#/definitions/CampReportResponse"
                         }
+                    },
+                    "404": {
+                        "description": "CAMP_NOT_FOUND: 캠프가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1378,6 +1420,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/CampReportResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "CAMP_NOT_FOUND: 캠프가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
                         }
                     }
                 }
@@ -1413,6 +1461,18 @@
                         "schema": {
                             "$ref": "#/definitions/CampReportResponse"
                         }
+                    },
+                    "404": {
+                        "description": "CAMP_NOT_FOUND: 캠프가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "CAMP_NOT_ENDED: 종료된 캠프에서만 최종 리포트를 생성할 수 있음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1446,6 +1506,12 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/CampSummaryStatsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "CAMP_NOT_FOUND: 캠프가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
                         }
                     }
                 }
@@ -1570,19 +1636,19 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request",
+                        "description": "CAMP_INVALID_SETTINGS: 설정 값이 유효하지 않음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
                     "404": {
-                        "description": "Not Found",
+                        "description": "CAMP_NOT_FOUND: 대상 캠프가 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
                     "409": {
-                        "description": "Conflict",
+                        "description": "CAMP_SETTINGS_LOCKED: 종료된 캠프는 수정할 수 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1628,7 +1694,7 @@
                         }
                     },
                     "409": {
-                        "description": "Conflict",
+                        "description": "CAMP_STATE_CONFLICT: 종료할 수 없는 캠프 상태 또는 정리 중인 방문 충돌",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1674,7 +1740,7 @@
                         }
                     },
                     "409": {
-                        "description": "이미 활성화됨 또는 필수 조건 미충족",
+                        "description": "CAMP_STATE_CONFLICT: 이미 활성화되었거나 활성화할 수 없는 상태",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1729,6 +1795,12 @@
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
+                    },
+                    "409": {
+                        "description": "CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 생성할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -1778,8 +1850,14 @@
                             "$ref": "#/definitions/ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "CORNER_NOT_FOUND: 수정할 코너가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
                     "409": {
-                        "description": "Conflict",
+                        "description": "CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 수정할 수 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1856,7 +1934,7 @@
                         }
                     },
                     "404": {
-                        "description": "Not Found",
+                        "description": "CORNER_NOT_FOUND: 대상 코너가 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1897,7 +1975,7 @@
                         }
                     },
                     "409": {
-                        "description": "활성화된 캠프이거나 종속 데이터가 존재함",
+                        "description": "CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 삭제할 수 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -1934,6 +2012,18 @@
                         "description": "Created",
                         "schema": {
                             "$ref": "#/definitions/DeviceRegistrationCreatedResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "INVALID_TRANSITION: 종료된 캠프에는 기기를 등록할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "CAMP_NOT_FOUND: 등록 코드에 해당하는 캠프가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
                         }
                     }
                 }
@@ -2194,6 +2284,18 @@
                                 "$ref": "#/definitions/TrackPinResponse"
                             }
                         }
+                    },
+                    "404": {
+                        "description": "CORNER_NOT_FOUND: 대상 코너가 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "CAMP_NOT_AVAILABLE: 종료된 캠프에는 트랙을 생성할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2230,6 +2332,18 @@
                 "responses": {
                     "204": {
                         "description": "성공적으로 삭제됨"
+                    },
+                    "404": {
+                        "description": "TRACK_NOT_FOUND: 대상 트랙이 없거나 이미 삭제됨",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "409": {
+                        "description": "TRACK_DELETE_BLOCKED: 진행 중인 방문이 있어 삭제할 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2406,6 +2520,12 @@
                         "schema": {
                             "$ref": "#/definitions/TrackPinResponse"
                         }
+                    },
+                    "404": {
+                        "description": "TRACK_NOT_FOUND: 대상 트랙이 없거나 활성 상태가 아님",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2567,7 +2687,7 @@
                         }
                     },
                     "403": {
-                        "description": "세션 트랙과 요청 트랙 불일치",
+                        "description": "TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -2631,7 +2751,7 @@
                         }
                     },
                     "403": {
-                        "description": "세션 트랙과 요청 트랙 불일치",
+                        "description": "TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -2718,7 +2838,7 @@
                         }
                     },
                     "403": {
-                        "description": "세션 트랙과 요청 트랙 불일치",
+                        "description": "TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -2757,8 +2877,17 @@
                             "$ref": "#/definitions/VisitSummaryResponse"
                         }
                     },
+                    "401": {
+                        "description": "SESSION_REVOKED: 진행자 세션이 취소됨",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
                     "404": {
-                        "description": "진행 중인 방문 없음"
+                        "description": "VISIT_NOT_FOUND: 진행 중인 방문 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
                     }
                 }
             }
@@ -2794,8 +2923,14 @@
                             "$ref": "#/definitions/VisitSummaryResponse"
                         }
                     },
+                    "401": {
+                        "description": "SESSION_REVOKED: 진행자 세션이 취소됨",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
                     "409": {
-                        "description": "TRACK_NOT_BUSY 등",
+                        "description": "TRACK_NOT_BUSY, TRACK_NOT_ACTIVE, ITINERARY_CONFLICT: 현재 운영 상태에서 방문을 종료할 수 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }
@@ -2846,8 +2981,20 @@
                             "$ref": "#/definitions/VisitSummaryResponse"
                         }
                     },
+                    "401": {
+                        "description": "SESSION_REVOKED: 진행자 세션이 취소됨",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "BADGE_NOT_ASSIGNED: 배지가 존재하지 않거나 조에 배정되지 않음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    },
                     "409": {
-                        "description": "TRACK_BUSY, DUPLICATE_VISIT 등",
+                        "description": "TRACK_BUSY, TRACK_NOT_ACTIVE, ITINERARY_CONFLICT, CAMP_NOT_ACTIVE: 현재 운영 상태에서 방문을 시작할 수 없음",
                         "schema": {
                             "$ref": "#/definitions/ErrorResponse"
                         }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -1171,6 +1171,10 @@ paths:
       responses:
         "204":
           description: 성공
+        "409":
+          description: 'DEVICE_INVALID_TRANSITION: 존재하지 않거나 잠금 해제할 수 없는 기기'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: 디바이스 락아웃 해제
@@ -1201,15 +1205,16 @@ paths:
           schema:
             $ref: '#/definitions/TrackLoginResponse'
         "400":
-          description: 잘못된 PIN (지연 가능)
+          description: 'INVALID_PIN: PIN이 올바르지 않음'
           schema:
             $ref: '#/definitions/ErrorResponse'
         "403":
-          description: 신뢰 기기 아님 또는 캠프 미시작
+          description: 'DEVICE_NOT_APPROVED: 기기가 승인되지 않음; CAMP_NOT_AVAILABLE: 캠프가
+            로그인 가능한 상태가 아님'
           schema:
             $ref: '#/definitions/ErrorResponse'
         "429":
-          description: PIN 잠금(지연) 중
+          description: 'DEVICE_LOCKED: PIN 실패 횟수 초과로 기기가 일시 잠김'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -1225,6 +1230,10 @@ paths:
       responses:
         "204":
           description: 성공
+        "401":
+          description: 'SESSION_REVOKED: 세션이 이미 취소됨'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - TrackAuth: []
       summary: 진행자 트랙 로그아웃
@@ -1504,6 +1513,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/DeviceRegistrationResponse'
+        "409":
+          description: 'DEVICE_INVALID_TRANSITION: PENDING 상태가 아닌 기기는 승인할 수 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: 기기 승인
@@ -1530,6 +1543,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/DeviceRegistrationResponse'
+        "409":
+          description: 'DEVICE_INVALID_TRANSITION: PENDING 상태가 아닌 기기는 거절할 수 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: 기기 거절
@@ -1556,6 +1573,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/DeviceRegistrationResponse'
+        "409":
+          description: 'DEVICE_NOT_APPROVED: APPROVED 상태가 아닌 기기는 신뢰를 취소할 수 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: 기기 신뢰 취소 (폐기/분실)
@@ -1668,7 +1689,11 @@ paths:
           schema:
             $ref: '#/definitions/MessageResponse'
         "400":
-          description: Bad Request
+          description: 'BAD_REQUEST: 요청 본문 또는 campId가 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "409":
+          description: 'CAMP_NOT_ACTIVE: ACTIVE 캠프에서만 공지를 보낼 수 있음'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -1692,6 +1717,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/CampReportResponse'
+        "404":
+          description: 'CAMP_NOT_FOUND: 캠프가 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: 현재 리포트 전체 조회
@@ -1713,6 +1742,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/CampReportResponse'
+        "404":
+          description: 'CAMP_NOT_FOUND: 캠프가 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: 현재 리포트 데이터 내보내기
@@ -1734,6 +1767,14 @@ paths:
           description: Created
           schema:
             $ref: '#/definitions/CampReportResponse'
+        "404":
+          description: 'CAMP_NOT_FOUND: 캠프가 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "409":
+          description: 'CAMP_NOT_ENDED: 종료된 캠프에서만 최종 리포트를 생성할 수 있음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: 과거 리포트 생성 및 저장
@@ -1755,6 +1796,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/CampSummaryStatsResponse'
+        "404":
+          description: 'CAMP_NOT_FOUND: 캠프가 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: 라이브 서머리 (대시보드 상단)
@@ -1832,15 +1877,15 @@ paths:
           schema:
             $ref: '#/definitions/CampResponse'
         "400":
-          description: Bad Request
+          description: 'CAMP_INVALID_SETTINGS: 설정 값이 유효하지 않음'
           schema:
             $ref: '#/definitions/ErrorResponse'
         "404":
-          description: Not Found
+          description: 'CAMP_NOT_FOUND: 대상 캠프가 없음'
           schema:
             $ref: '#/definitions/ErrorResponse'
         "409":
-          description: Conflict
+          description: 'CAMP_SETTINGS_LOCKED: 종료된 캠프는 수정할 수 없음'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -1869,7 +1914,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
         "409":
-          description: Conflict
+          description: 'CAMP_STATE_CONFLICT: 종료할 수 없는 캠프 상태 또는 정리 중인 방문 충돌'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -1898,7 +1943,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
         "409":
-          description: 이미 활성화됨 또는 필수 조건 미충족
+          description: 'CAMP_STATE_CONFLICT: 이미 활성화되었거나 활성화할 수 없는 상태'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -1931,6 +1976,10 @@ paths:
             $ref: '#/definitions/ErrorResponse'
         "401":
           description: Unauthorized
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "409":
+          description: 'CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 생성할 수 없음'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -1980,7 +2029,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
         "409":
-          description: 활성화된 캠프이거나 종속 데이터가 존재함
+          description: 'CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 삭제할 수 없음'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -2004,7 +2053,7 @@ paths:
           schema:
             $ref: '#/definitions/CornerResponse'
         "404":
-          description: Not Found
+          description: 'CORNER_NOT_FOUND: 대상 코너가 없음'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -2037,8 +2086,12 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: 'CORNER_NOT_FOUND: 수정할 코너가 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         "409":
-          description: Conflict
+          description: 'CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 수정할 수 없음'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -2065,6 +2118,14 @@ paths:
           description: Created
           schema:
             $ref: '#/definitions/DeviceRegistrationCreatedResponse'
+        "400":
+          description: 'INVALID_TRANSITION: 종료된 캠프에는 기기를 등록할 수 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: 'CAMP_NOT_FOUND: 등록 코드에 해당하는 캠프가 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       summary: 기기 등록 요청 (최초 앱 실행 시)
       tags:
       - A. Auth & Device Trust
@@ -2228,6 +2289,14 @@ paths:
             items:
               $ref: '#/definitions/TrackPinResponse'
             type: array
+        "404":
+          description: 'CORNER_NOT_FOUND: 대상 코너가 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "409":
+          description: 'CAMP_NOT_AVAILABLE: 종료된 캠프에는 트랙을 생성할 수 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: 트랙 일괄 생성
@@ -2317,6 +2386,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/TrackPinResponse'
+        "404":
+          description: 'TRACK_NOT_FOUND: 대상 트랙이 없거나 활성 상태가 아님'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: PIN 재발급
@@ -2420,7 +2493,7 @@ paths:
           schema:
             $ref: '#/definitions/ErrorResponse'
         "403":
-          description: 세션 트랙과 요청 트랙 불일치
+          description: 'TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치'
           schema:
             $ref: '#/definitions/ErrorResponse'
         "404":
@@ -2459,7 +2532,7 @@ paths:
               $ref: '#/definitions/MessageResponse'
             type: array
         "403":
-          description: 세션 트랙과 요청 트랙 불일치
+          description: 'TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -2513,7 +2586,7 @@ paths:
           schema:
             $ref: '#/definitions/UnreadCountResponse'
         "403":
-          description: 세션 트랙과 요청 트랙 불일치
+          description: 'TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -2538,8 +2611,14 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/VisitSummaryResponse'
+        "401":
+          description: 'SESSION_REVOKED: 진행자 세션이 취소됨'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         "404":
-          description: 진행 중인 방문 없음
+          description: 'VISIT_NOT_FOUND: 진행 중인 방문 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - TrackAuth: []
       summary: 현재 진행 중인 방문 상태 조회
@@ -2561,8 +2640,13 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/VisitSummaryResponse'
+        "401":
+          description: 'SESSION_REVOKED: 진행자 세션이 취소됨'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         "409":
-          description: TRACK_NOT_BUSY 등
+          description: 'TRACK_NOT_BUSY, TRACK_NOT_ACTIVE, ITINERARY_CONFLICT: 현재 운영
+            상태에서 방문을 종료할 수 없음'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -2594,8 +2678,17 @@ paths:
           description: Created
           schema:
             $ref: '#/definitions/VisitSummaryResponse'
+        "401":
+          description: 'SESSION_REVOKED: 진행자 세션이 취소됨'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "404":
+          description: 'BADGE_NOT_ASSIGNED: 배지가 존재하지 않거나 조에 배정되지 않음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
         "409":
-          description: TRACK_BUSY, DUPLICATE_VISIT 등
+          description: 'TRACK_BUSY, TRACK_NOT_ACTIVE, ITINERARY_CONFLICT, CAMP_NOT_ACTIVE:
+            현재 운영 상태에서 방문을 시작할 수 없음'
           schema:
             $ref: '#/definitions/ErrorResponse'
       security:
@@ -2620,6 +2713,14 @@ paths:
       responses:
         "204":
           description: 성공적으로 삭제됨
+        "404":
+          description: 'TRACK_NOT_FOUND: 대상 트랙이 없거나 이미 삭제됨'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        "409":
+          description: 'TRACK_DELETE_BLOCKED: 진행 중인 방문이 있어 삭제할 수 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
       security:
       - AdminAuth: []
       summary: 트랙 일괄 삭제

--- a/backend/docs/artifacts/plan/20260721_handler_local_error_mapping_workflow_plan_.md
+++ b/backend/docs/artifacts/plan/20260721_handler_local_error_mapping_workflow_plan_.md
@@ -1,0 +1,67 @@
+# 핸들러별 HTTP 오류 매핑 워크플로우 계획
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | 예상 실패의 HTTP 번역 | 각 API 핸들러가 호출한 유즈케이스의 예상 domain 오류를 API 문맥에 맞는 `ErrorResponse` 4xx로 변환한다. | **프로덕션 핵심 로직** |
+| **P0** | 오류 계약 문서화 | 엔드포인트 주석과 API 문서에 HTTP 상태, 안정적인 `ErrorResponse.code`, 클라이언트 대응 의미를 기록한다. | **프론트엔드 연동 계약** |
+| P1 | 회귀 검증 | sentinel 및 래핑 오류가 같은 응답으로 변환되고 미분류 오류만 500인지 검증한다. | 테스트/운영 안정성 |
+
+## 책임 규약
+
+- Domain/usecase는 HTTP와 Echo를 모른다.
+- 각 handler가 인증·권한·리소스·상태 전이라는 자신의 API 문맥으로 예상 오류를 해석한다.
+- private `xxxHTTPError(err error) error` helper는 `errors.Is`/`errors.As`로 분기하고 `echo.NewHTTPError(...).SetInternal(err)`를 반환한다.
+- helper가 모르는 오류는 원본을 반환하고 `ErrorHandler`만 500 직렬화·로깅을 담당한다. 전역 domain→HTTP 매퍼는 만들지 않는다.
+- `@Failure` 주석에는 상태, `ErrorResponse.code`, 클라이언트 의미를 함께 기록한다.
+
+```go
+func trackLoginHTTPError(err error) error {
+    if errors.Is(err, domain.ErrDeviceNotApproved) {
+        return echo.NewHTTPError(http.StatusForbidden, ErrorResponse{
+            Code: "DEVICE_NOT_APPROVED", Message: "device is not approved",
+        }).SetInternal(err)
+    }
+    return err
+}
+```
+
+## 단계
+
+### Phase A: 인증·기기 신뢰 (2시간)
+
+| 작업 | 파일 |
+| --- | --- |
+| Track PIN 로그인과 관리자 인증의 예상 오류를 4xx로 변환하고 주석·테스트를 추가한다. | `/home/lsjtop10/projects/cornermon/worktrees/handler-local-error-mapping/backend/internal/infrastructure/web/auth_handler.go` **(기존 파일 확장)** |
+| 기기 승인·거절·회수·잠금 해제에서 존재/상태 오류를 404/409으로 변환한다. | `/home/lsjtop10/projects/cornermon/worktrees/handler-local-error-mapping/backend/internal/infrastructure/web/device_handler.go` **(기존 파일 확장)** |
+
+### Phase B: 운영 상태 변경 (4시간)
+
+| 작업 | 파일 |
+| --- | --- |
+| 방문 시작·종료의 session/track/badge/group/camp 오류를 401/404/409로 변환한다. | `/home/lsjtop10/projects/cornermon/worktrees/handler-local-error-mapping/backend/internal/infrastructure/web/visit_handler.go` **(기존 파일 확장)** |
+| 트랙 생성·삭제·교체·PIN 관리 및 캠프·코너 변경의 오류를 404/409로 변환한다. | `/home/lsjtop10/projects/cornermon/worktrees/handler-local-error-mapping/backend/internal/infrastructure/web/track_handler.go`, `camp_handler.go`, `corner_handler.go` **(기존 파일 확장)** |
+
+### Phase C: 조회·메시지·권한 범위 (3시간)
+
+| 작업 | 파일 |
+| --- | --- |
+| 리포트, 공지/다이렉트 메시지, 조/배지/이벤트 조회의 예상 오류를 API 문맥별 4xx로 변환한다. | `/home/lsjtop10/projects/cornermon/worktrees/handler-local-error-mapping/backend/internal/infrastructure/web/report_handler.go`, `message_handler.go`, `group_handler.go`, `badge_handler.go`, `event_handler.go` **(기존 파일 확장)** |
+
+### Phase D: 계약·회귀 검증 (2시간)
+
+| 작업 | 파일 |
+| --- | --- |
+| 수정 엔드포인트의 Swagger 주석/API 문서를 동기화하고, 정상 sentinel·래핑 sentinel·미분류 오류를 실제 `ErrorHandler` 경로로 테스트한다. | `/home/lsjtop10/projects/cornermon/worktrees/handler-local-error-mapping/backend/internal/infrastructure/web/*_handler.go`, `*_handler_test.go`, `/home/lsjtop10/projects/cornermon/worktrees/handler-local-error-mapping/api/`, `/home/lsjtop10/projects/cornermon/worktrees/handler-local-error-mapping/backend/docs/` |
+
+## 검증 체크리스트
+
+- [x] `domain`/`usecase`에 HTTP 또는 Echo 의존성을 추가하지 않는다.
+- [x] 상태 코드 결정은 전역 매퍼가 아닌 해당 핸들러 private helper에 있다.
+- [x] helper는 원인 오류를 보존하고 예상 밖 오류만 500으로 남긴다.
+- [x] 모든 변경 4xx는 안정적인 `ErrorResponse.code` 및 `@Failure` 설명을 가진다.
+- [x] 각 수정 핸들러는 정상 sentinel, 래핑 sentinel, 미분류 오류를 테스트한다.
+- [x] `cd /home/lsjtop10/projects/cornermon/worktrees/handler-local-error-mapping/backend && go test ./...`
+- [x] `cd /home/lsjtop10/projects/cornermon/worktrees/handler-local-error-mapping/backend && go vet ./...`
+- [x] `git diff --check`

--- a/backend/internal/infrastructure/web/auth_handler.go
+++ b/backend/internal/infrastructure/web/auth_handler.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -223,9 +224,9 @@ func (h *AuthHandler) RevokeAdminSession(c echo.Context) error {
 // @Param        X-Device-Token header string true "기기 신뢰 토큰 (opaque token, 값을 그대로 전달)"
 // @Param        request body TrackLoginRequest true "6자리 숫자 트랙 PIN"
 // @Success      200 {object} TrackLoginResponse "로그인 성공 — 트랙 세션 토큰 발급"
-// @Failure      400 {object} ErrorResponse "잘못된 PIN (지연 가능)"
-// @Failure      403 {object} ErrorResponse "신뢰 기기 아님 또는 캠프 미시작"
-// @Failure      429 {object} ErrorResponse "PIN 잠금(지연) 중"
+// @Failure      400 {object} ErrorResponse "INVALID_PIN: PIN이 올바르지 않음"
+// @Failure      403 {object} ErrorResponse "DEVICE_NOT_APPROVED: 기기가 승인되지 않음; CAMP_NOT_AVAILABLE: 캠프가 로그인 가능한 상태가 아님"
+// @Failure      429 {object} ErrorResponse "DEVICE_LOCKED: PIN 실패 횟수 초과로 기기가 일시 잠김"
 // @Router       /auth/track/login [post]
 func (h *AuthHandler) TrackLogin(c echo.Context) error {
 	var req TrackLoginRequest
@@ -240,7 +241,7 @@ func (h *AuthHandler) TrackLogin(c echo.Context) error {
 
 	res, err := h.facilitatorAuth.Login(c.Request().Context(), deviceToken, req.PIN)
 	if err != nil {
-		return err
+		return trackLoginHTTPError(err)
 	}
 
 	return c.JSON(http.StatusOK, TrackLoginResponse{
@@ -261,12 +262,28 @@ func (h *AuthHandler) TrackLogin(c echo.Context) error {
 	})
 }
 
+func trackLoginHTTPError(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrDeviceNotApproved):
+		return echo.NewHTTPError(http.StatusForbidden, ErrorResponse{Code: "DEVICE_NOT_APPROVED", Message: "device is not approved"}).SetInternal(err)
+	case errors.Is(err, domain.ErrDeviceLocked):
+		return echo.NewHTTPError(http.StatusTooManyRequests, ErrorResponse{Code: "DEVICE_LOCKED", Message: "device is temporarily locked"}).SetInternal(err)
+	case errors.Is(err, domain.ErrInvalidPin):
+		return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: "INVALID_PIN", Message: "invalid pin"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampInvalidTransition):
+		return echo.NewHTTPError(http.StatusForbidden, ErrorResponse{Code: "CAMP_NOT_AVAILABLE", Message: "camp is not available for track login"}).SetInternal(err)
+	default:
+		return err
+	}
+}
+
 // @Summary      진행자 트랙 로그아웃
 // @Description  트랙 진행자가 스스로 로그아웃한다.
 // @Tags         A. Auth & Device Trust
 // @Security     TrackAuth
 // @Produce      json
 // @Success      204 "성공"
+// @Failure      401 {object} ErrorResponse "SESSION_REVOKED: 세션이 이미 취소됨"
 // @Router       /auth/track/logout [post]
 func (h *AuthHandler) TrackLogout(c echo.Context) error {
 	session, ok := c.Get("facilitatorSession").(*domain.FacilitatorSession)
@@ -276,6 +293,9 @@ func (h *AuthHandler) TrackLogout(c echo.Context) error {
 
 	err := h.facilitatorAuth.Logout(c.Request().Context(), session.ID())
 	if err != nil {
+		if errors.Is(err, domain.ErrSessionRevoked) {
+			return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: "SESSION_REVOKED", Message: "session is revoked"}).SetInternal(err)
+		}
 		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
 	}
 
@@ -312,6 +332,7 @@ func (h *AuthHandler) ForceTrackLogout(c echo.Context) error {
 // @Produce      json
 // @Param        deviceId path string true "기기 ID"
 // @Success      204 "성공"
+// @Failure      409 {object} ErrorResponse "DEVICE_INVALID_TRANSITION: 존재하지 않거나 잠금 해제할 수 없는 기기"
 // @Router       /auth/track/lockout/{deviceId}/release [post]
 func (h *AuthHandler) ReleaseLockout(c echo.Context) error {
 	session, ok := c.Get("adminSession").(*domain.AdminSession)
@@ -322,6 +343,9 @@ func (h *AuthHandler) ReleaseLockout(c echo.Context) error {
 
 	err := h.deviceTrust.ResetPinFailures(c.Request().Context(), deviceID, session.AdminID())
 	if err != nil {
+		if errors.Is(err, domain.ErrDeviceInvalidTransition) {
+			return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "DEVICE_INVALID_TRANSITION", Message: "device registration cannot reset pin failures"}).SetInternal(err)
+		}
 		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
 	}
 
@@ -345,8 +369,8 @@ func (h *AuthHandler) MigrateSession(c echo.Context) error {
 
 	res, err := h.facilitatorAuth.MigrateSession(c.Request().Context(), sessionToken)
 	if err != nil {
-		if err == domain.ErrSessionRevoked {
-			return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: err.Error()}).SetInternal(err)
+		if errors.Is(err, domain.ErrSessionRevoked) {
+			return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: "SESSION_REVOKED", Message: "session is revoked"}).SetInternal(err)
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
 	}

--- a/backend/internal/infrastructure/web/auth_handler_test.go
+++ b/backend/internal/infrastructure/web/auth_handler_test.go
@@ -1,0 +1,66 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/usecase"
+
+	"github.com/labstack/echo/v4"
+)
+
+type trackLoginUsecaseStub struct{ err error }
+
+func (s trackLoginUsecaseStub) Login(context.Context, string, string) (*usecase.TrackLoginResult, error) {
+	return nil, s.err
+}
+func (trackLoginUsecaseStub) Logout(context.Context, domain.FacilitatorSessionID) error { return nil }
+func (trackLoginUsecaseStub) MigrateSession(context.Context, string) (*usecase.TrackLoginResult, error) {
+	return nil, nil
+}
+func (trackLoginUsecaseStub) ListActiveSessions(context.Context, domain.CampID) ([]*domain.FacilitatorSession, error) {
+	return nil, nil
+}
+
+func TestTrackLoginShouldMapExpectedDomainErrorsToHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantBody string
+	}{
+		{name: "device not approved", err: domain.ErrDeviceNotApproved, wantCode: http.StatusForbidden, wantBody: "DEVICE_NOT_APPROVED"},
+		{name: "device locked", err: domain.NewDeviceLockedErrorFromProps(domain.DeviceLockedErrorProps{}), wantCode: http.StatusTooManyRequests, wantBody: "DEVICE_LOCKED"},
+		{name: "invalid pin", err: domain.NewInvalidPinErrorFromProps(domain.InvalidPinErrorProps{}), wantCode: http.StatusBadRequest, wantBody: "INVALID_PIN"},
+		{name: "wrapped unavailable camp", err: fmt.Errorf("login failed: %w", domain.ErrCampInvalidTransition), wantCode: http.StatusForbidden, wantBody: "CAMP_NOT_AVAILABLE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// arrange
+			e := echo.New()
+			e.HTTPErrorHandler = ErrorHandler()
+			e.POST("/api/v1/auth/track/login", NewAuthHandler(nil, trackLoginUsecaseStub{err: tt.err}, nil).TrackLogin)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/track/login", strings.NewReader(`{"pin":"123456"}`))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			req.Header.Set("X-Device-Token", "device-token")
+			rec := httptest.NewRecorder()
+
+			// act
+			e.ServeHTTP(rec, req)
+
+			// assert
+			if rec.Code != tt.wantCode {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantCode, rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tt.wantBody) {
+				t.Fatalf("expected response body to contain %q, got %s", tt.wantBody, rec.Body.String())
+			}
+		})
+	}
+}

--- a/backend/internal/infrastructure/web/badge_handler.go
+++ b/backend/internal/infrastructure/web/badge_handler.go
@@ -82,7 +82,7 @@ type BulkGenerateBadgesRequest struct {
 func (h *BadgeHandler) BulkGenerateBadges(c echo.Context) error {
 	var req BulkGenerateBadgesRequest
 	if err := c.Bind(&req); err != nil {
-		return err
+		return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "invalid request"}).SetInternal(err)
 	}
 	badges, err := h.badgeUC.IssueInitialBadges(c.Request().Context(), req.Count)
 	if err != nil {
@@ -138,7 +138,7 @@ func (h *BadgeHandler) AssignBadge(c echo.Context) error {
 		GroupName string `json:"groupName"`
 	}
 	if err := c.Bind(&req); err != nil {
-		return err
+		return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "invalid request"}).SetInternal(err)
 	}
 
 	group, err := h.groupUC.AssignBadge(c.Request().Context(), id, req.GroupName)
@@ -166,7 +166,7 @@ type ScanAssignBadgeRequest struct {
 func (h *BadgeHandler) ScanAssignBadge(c echo.Context) error {
 	var req ScanAssignBadgeRequest
 	if err := c.Bind(&req); err != nil {
-		return err
+		return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "invalid request"}).SetInternal(err)
 	}
 
 	group, err := h.groupUC.ScanAssignBadge(c.Request().Context(), req.QRPayload, req.GroupName)

--- a/backend/internal/infrastructure/web/camp_handler.go
+++ b/backend/internal/infrastructure/web/camp_handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -42,9 +43,9 @@ type UpdateCampRequest struct {
 // @Param        id path string true "캠프 ID"
 // @Param        request body UpdateCampRequest true "부분 수정할 캠프 설정"
 // @Success      200 {object} CampResponse
-// @Failure      400 {object} ErrorResponse
-// @Failure      404 {object} ErrorResponse
-// @Failure      409 {object} ErrorResponse
+// @Failure      400 {object} ErrorResponse "CAMP_INVALID_SETTINGS: 설정 값이 유효하지 않음"
+// @Failure      404 {object} ErrorResponse "CAMP_NOT_FOUND: 대상 캠프가 없음"
+// @Failure      409 {object} ErrorResponse "CAMP_SETTINGS_LOCKED: 종료된 캠프는 수정할 수 없음"
 // @Router       /camps/{id} [patch]
 func (h *CampHandler) UpdateCamp(c echo.Context) error {
 	var req UpdateCampRequest
@@ -71,7 +72,7 @@ func (h *CampHandler) UpdateCamp(c echo.Context) error {
 
 	camp, err := h.svc.UpdateCampSettings(c.Request().Context(), domain.CampID(c.Param("id")), getAdminID(c), patch)
 	if err != nil {
-		return err
+		return campHTTPError(err)
 	}
 	return c.JSON(http.StatusOK, mapDomainCampToDTO(camp))
 }
@@ -150,10 +151,7 @@ func (h *CampHandler) CreateCamp(c echo.Context) error {
 	}
 	camp, err := h.svc.OpenNewCamp(c.Request().Context(), req.Name, req.StartAt, req.EndAt)
 	if err != nil {
-		if err == domain.ErrCampInvalidSettings {
-			return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: err.Error()}).SetInternal(err)
-		}
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
+		return campHTTPError(err)
 	}
 	return c.JSON(http.StatusCreated, mapDomainCampToDTO(camp))
 }
@@ -187,17 +185,14 @@ func (h *CampHandler) GetCamp(c echo.Context) error {
 // @Param        id path string true "캠프 ID"
 // @Success      200 {object} CampResponse
 // @Failure      400 {object} ErrorResponse
-// @Failure      409 {object} ErrorResponse "이미 활성화됨 또는 필수 조건 미충족"
+// @Failure      409 {object} ErrorResponse "CAMP_STATE_CONFLICT: 이미 활성화되었거나 활성화할 수 없는 상태"
 // @Router       /camps/{id}/start [post]
 func (h *CampHandler) StartCamp(c echo.Context) error {
 	id := domain.CampID(c.Param("id"))
 	adminID := getAdminID(c)
 	err := h.svc.ActivateCamp(c.Request().Context(), id, adminID)
 	if err != nil {
-		if err == domain.ErrCampInvalidTransition {
-			return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "CONFLICT", Message: err.Error()}).SetInternal(err)
-		}
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
+		return campHTTPError(err)
 	}
 	camp, _ := h.svc.GetCamp(c.Request().Context(), id)
 	return c.JSON(http.StatusOK, mapDomainCampToDTO(camp))
@@ -211,18 +206,30 @@ func (h *CampHandler) StartCamp(c echo.Context) error {
 // @Param        id path string true "캠프 ID"
 // @Success      200 {object} CampResponse
 // @Failure      400 {object} ErrorResponse
-// @Failure      409 {object} ErrorResponse
+// @Failure      409 {object} ErrorResponse "CAMP_STATE_CONFLICT: 종료할 수 없는 캠프 상태 또는 정리 중인 방문 충돌"
 // @Router       /camps/{id}/end [post]
 func (h *CampHandler) EndCamp(c echo.Context) error {
 	id := domain.CampID(c.Param("id"))
 	adminID := getAdminID(c)
 	err := h.svc.EndCamp(c.Request().Context(), id, adminID)
 	if err != nil {
-		if err == domain.ErrCampInvalidTransition {
-			return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "CONFLICT", Message: err.Error()}).SetInternal(err)
-		}
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
+		return campHTTPError(err)
 	}
 	camp, _ := h.svc.GetCamp(c.Request().Context(), id)
 	return c.JSON(http.StatusOK, mapDomainCampToDTO(camp))
+}
+
+func campHTTPError(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrCampNotFound):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "CAMP_NOT_FOUND", Message: "camp not found"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampInvalidSettings):
+		return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: "CAMP_INVALID_SETTINGS", Message: "camp settings are invalid"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampSettingsLocked):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "CAMP_SETTINGS_LOCKED", Message: "camp settings are locked"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampInvalidTransition), errors.Is(err, domain.ErrCornerNotInItinerary), errors.Is(err, domain.ErrTrackNotActive):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "CAMP_STATE_CONFLICT", Message: "camp cannot make that state transition"}).SetInternal(err)
+	default:
+		return err
+	}
 }

--- a/backend/internal/infrastructure/web/corner_handler.go
+++ b/backend/internal/infrastructure/web/corner_handler.go
@@ -110,6 +110,7 @@ type CreateCornerRequest struct {
 // @Success      201 {object} CornerResponse
 // @Failure      400 {object} ErrorResponse
 // @Failure      401 {object} ErrorResponse
+// @Failure      409 {object} ErrorResponse "CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 생성할 수 없음"
 // @Router       /corners [post]
 func (h *CornerHandler) CreateCorner(c echo.Context) error {
 	var req CreateCornerRequest
@@ -118,7 +119,7 @@ func (h *CornerHandler) CreateCorner(c echo.Context) error {
 	}
 	corner, err := h.svc.AddLearningCorner(c.Request().Context(), domain.CampID(req.CampID), req.Name)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
+		return cornerHTTPError(err)
 	}
 	return c.JSON(http.StatusCreated, mapDomainCornerToDTO(corner))
 }
@@ -130,16 +131,16 @@ func (h *CornerHandler) CreateCorner(c echo.Context) error {
 // @Produce      json
 // @Param        id path string true "코너 ID"
 // @Success      200 {object} CornerResponse
-// @Failure      404 {object} ErrorResponse
+// @Failure      404 {object} ErrorResponse "CORNER_NOT_FOUND: 대상 코너가 없음"
 // @Router       /corners/{id} [get]
 func (h *CornerHandler) GetCorner(c echo.Context) error {
 	id := domain.CornerID(c.Param("id"))
 	view, err := h.views.GetCornerView(c.Request().Context(), id)
 	if err != nil {
-		return err
+		return cornerHTTPError(err)
 	}
 	if view == nil {
-		return domain.ErrCornerNotFound
+		return cornerHTTPError(domain.ErrCornerNotFound)
 	}
 	return c.JSON(http.StatusOK, mapCornerViewToDTO(*view))
 }
@@ -184,13 +185,13 @@ func (h *CornerHandler) GetCornerByTrack(c echo.Context) error {
 // @Param        id path string true "코너 ID"
 // @Success      204 "성공적으로 삭제됨"
 // @Failure      400 {object} ErrorResponse
-// @Failure      409 {object} ErrorResponse "활성화된 캠프이거나 종속 데이터가 존재함"
+// @Failure      409 {object} ErrorResponse "CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 삭제할 수 없음"
 // @Router       /corners/{id} [delete]
 func (h *CornerHandler) DeleteCorner(c echo.Context) error {
 	id := domain.CornerID(c.Param("id"))
 	err := h.svc.RemoveCornerFromCamp(c.Request().Context(), id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
+		return cornerHTTPError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
 }
@@ -212,7 +213,8 @@ type BulkUpdateCornersRequest struct {
 // @Param        request body BulkUpdateCornersRequest true "수정할 코너 목록"
 // @Success      200 {array} CornerResponse
 // @Failure      400 {object} ErrorResponse
-// @Failure      409 {object} ErrorResponse
+// @Failure      404 {object} ErrorResponse "CORNER_NOT_FOUND: 수정할 코너가 없음"
+// @Failure      409 {object} ErrorResponse "CAMP_STATE_CONFLICT: 현재 캠프 상태에서는 코너를 수정할 수 없음"
 // @Router       /corners/bulk-update [put]
 func (h *CornerHandler) BulkUpdateCorners(c echo.Context) error {
 	var req BulkUpdateCornersRequest
@@ -223,9 +225,20 @@ func (h *CornerHandler) BulkUpdateCorners(c echo.Context) error {
 	for i, cr := range req.Corners {
 		updated, err := h.svc.ModifyCornerSpecification(c.Request().Context(), domain.CornerID(cr.ID), cr.Name)
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
+			return cornerHTTPError(err)
 		}
 		res[i] = mapDomainCornerToDTO(updated)
 	}
 	return c.JSON(http.StatusOK, res)
+}
+
+func cornerHTTPError(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrCornerNotFound), errors.Is(err, domain.ErrCornerNotInItinerary):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "CORNER_NOT_FOUND", Message: "corner not found"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampInvalidTransition), errors.Is(err, domain.ErrCampSettingsLocked):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "CAMP_STATE_CONFLICT", Message: "camp cannot modify corners in its current state"}).SetInternal(err)
+	default:
+		return err
+	}
 }

--- a/backend/internal/infrastructure/web/corner_handler_test.go
+++ b/backend/internal/infrastructure/web/corner_handler_test.go
@@ -77,7 +77,7 @@ func TestGetCornerShouldReturnViewAndNotFound(t *testing.T) {
 		}
 	})
 
-	t.Run("returns the domain not-found error", func(t *testing.T) {
+	t.Run("maps missing corner to not found HTTP error", func(t *testing.T) {
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/corners/missing", nil)
 		rec := httptest.NewRecorder()
@@ -87,8 +87,9 @@ func TestGetCornerShouldReturnViewAndNotFound(t *testing.T) {
 		c.SetParamValues("missing")
 
 		err := NewCornerHandler(nil, fakeCornerViewQuerier{}).GetCorner(c)
-		if err != domain.ErrCornerNotFound {
-			t.Fatalf("expected ErrCornerNotFound, got %v", err)
+		var httpErr *echo.HTTPError
+		if !errorsAsHTTPError(err, &httpErr) || httpErr.Code != http.StatusNotFound {
+			t.Fatalf("expected 404 HTTP error, got %v", err)
 		}
 	})
 }

--- a/backend/internal/infrastructure/web/device_handler.go
+++ b/backend/internal/infrastructure/web/device_handler.go
@@ -83,8 +83,11 @@ func (h *DeviceHandler) GetMyRegistrationStatus(c echo.Context) error {
 
 	status, err := h.deviceTrust.GetMyRegistrationStatus(c.Request().Context(), token)
 	if err != nil {
-		if err == domain.ErrDeviceNotApproved {
+		if errors.Is(err, domain.ErrDeviceNotApproved) {
 			return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: "UNAUTHORIZED", Message: err.Error()}).SetInternal(err)
+		}
+		if errors.Is(err, domain.ErrCampNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "CAMP_NOT_FOUND", Message: err.Error()}).SetInternal(err)
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
 	}
@@ -104,6 +107,8 @@ func (h *DeviceHandler) GetMyRegistrationStatus(c echo.Context) error {
 // @Produce      json
 // @Param        request body DeviceRegistrationRequest true "등록 정보"
 // @Success      201 {object} DeviceRegistrationCreatedResponse
+// @Failure      404 {object} ErrorResponse "CAMP_NOT_FOUND: 등록 코드에 해당하는 캠프가 없음"
+// @Failure      400 {object} ErrorResponse "INVALID_TRANSITION: 종료된 캠프에는 기기를 등록할 수 없음"
 // @Router       /device-registrations [post]
 func (h *DeviceHandler) RequestRegistration(c echo.Context) error {
 	var req DeviceRegistrationRequest
@@ -116,10 +121,7 @@ func (h *DeviceHandler) RequestRegistration(c echo.Context) error {
 		if errors.Is(err, domain.ErrCampNotFound) {
 			return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "CAMP_NOT_FOUND", Message: err.Error()}).SetInternal(err)
 		}
-		if errors.Is(err, domain.ErrCampInvalidTransition) {
-			return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: "INVALID_TRANSITION", Message: err.Error()}).SetInternal(err)
-		}
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
+		return deviceRegistrationHTTPError(err)
 	}
 
 	return c.JSON(http.StatusCreated, DeviceRegistrationCreatedResponse{
@@ -208,6 +210,7 @@ func mapDeviceRegistration(device *domain.DeviceRegistration) DeviceRegistration
 // @Param        campId path string true "캠프 ID"
 // @Param        id path string true "기기 등록 ID"
 // @Success      200 {object} DeviceRegistrationResponse
+// @Failure      409 {object} ErrorResponse "DEVICE_INVALID_TRANSITION: PENDING 상태가 아닌 기기는 승인할 수 없음"
 // @Router       /camps/{campId}/device-registrations/{id}/approve [post]
 func (h *DeviceHandler) ApproveDevice(c echo.Context) error {
 	session, ok := c.Get("adminSession").(*domain.AdminSession)
@@ -218,7 +221,7 @@ func (h *DeviceHandler) ApproveDevice(c echo.Context) error {
 
 	device, err := h.deviceTrust.ApproveDevice(c.Request().Context(), regID, session.AdminID())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
+		return deviceRegistrationHTTPError(err)
 	}
 
 	return c.JSON(http.StatusOK, mapDeviceRegistration(device))
@@ -232,6 +235,7 @@ func (h *DeviceHandler) ApproveDevice(c echo.Context) error {
 // @Param        campId path string true "캠프 ID"
 // @Param        id path string true "기기 등록 ID"
 // @Success      200 {object} DeviceRegistrationResponse
+// @Failure      409 {object} ErrorResponse "DEVICE_INVALID_TRANSITION: PENDING 상태가 아닌 기기는 거절할 수 없음"
 // @Router       /camps/{campId}/device-registrations/{id}/reject [post]
 func (h *DeviceHandler) RejectDevice(c echo.Context) error {
 	session, ok := c.Get("adminSession").(*domain.AdminSession)
@@ -242,7 +246,7 @@ func (h *DeviceHandler) RejectDevice(c echo.Context) error {
 
 	device, err := h.deviceTrust.RejectDevice(c.Request().Context(), regID, session.AdminID())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
+		return deviceRegistrationHTTPError(err)
 	}
 
 	return c.JSON(http.StatusOK, mapDeviceRegistration(device))
@@ -256,6 +260,7 @@ func (h *DeviceHandler) RejectDevice(c echo.Context) error {
 // @Param        campId path string true "캠프 ID"
 // @Param        id path string true "기기 등록 ID"
 // @Success      200 {object} DeviceRegistrationResponse
+// @Failure      409 {object} ErrorResponse "DEVICE_NOT_APPROVED: APPROVED 상태가 아닌 기기는 신뢰를 취소할 수 없음"
 // @Router       /camps/{campId}/device-registrations/{id}/revoke [post]
 func (h *DeviceHandler) RevokeDevice(c echo.Context) error {
 	session, ok := c.Get("adminSession").(*domain.AdminSession)
@@ -266,8 +271,23 @@ func (h *DeviceHandler) RevokeDevice(c echo.Context) error {
 
 	device, err := h.deviceTrust.RevokeDevice(c.Request().Context(), regID, session.AdminID())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
+		return deviceRegistrationHTTPError(err)
 	}
 
 	return c.JSON(http.StatusOK, mapDeviceRegistration(device))
+}
+
+func deviceRegistrationHTTPError(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrCampNotFound):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "CAMP_NOT_FOUND", Message: "camp not found"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampInvalidTransition):
+		return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: "INVALID_TRANSITION", Message: "camp is not available for device registration"}).SetInternal(err)
+	case errors.Is(err, domain.ErrDeviceInvalidTransition):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "DEVICE_INVALID_TRANSITION", Message: "device registration cannot make that transition"}).SetInternal(err)
+	case errors.Is(err, domain.ErrDeviceNotApproved):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "DEVICE_NOT_APPROVED", Message: "device is not approved"}).SetInternal(err)
+	default:
+		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: "internal server error"}).SetInternal(err)
+	}
 }

--- a/backend/internal/infrastructure/web/device_handler_test.go
+++ b/backend/internal/infrastructure/web/device_handler_test.go
@@ -3,6 +3,7 @@ package web
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -45,6 +46,44 @@ func TestShouldReturnActualCreatedAtWhenDeviceRegistrationRequested(t *testing.T
 	}
 	if response.CampID != "camp-1" {
 		t.Fatalf("expected campId camp-1, got %q", response.CampID)
+	}
+}
+
+func TestDeviceRegistrationMutationShouldMapExpectedDomainErrorsToConflict(t *testing.T) {
+	tests := []struct {
+		name   string
+		handle func(*DeviceHandler, echo.Context) error
+		err    error
+		code   string
+	}{
+		{name: "approve invalid transition", handle: (*DeviceHandler).ApproveDevice, err: fmt.Errorf("approve: %w", domain.ErrDeviceInvalidTransition), code: "DEVICE_INVALID_TRANSITION"},
+		{name: "reject invalid transition", handle: (*DeviceHandler).RejectDevice, err: domain.ErrDeviceInvalidTransition, code: "DEVICE_INVALID_TRANSITION"},
+		{name: "revoke non approved device", handle: (*DeviceHandler).RevokeDevice, err: domain.ErrDeviceNotApproved, code: "DEVICE_NOT_APPROVED"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// arrange
+			e := echo.New()
+			e.HTTPErrorHandler = ErrorHandler()
+			handler := NewDeviceHandler(&listDeviceTrustStub{mutationErr: tt.err})
+			req := httptest.NewRequest(http.MethodPost, "/camps/camp-1/device-registrations/device-1", nil)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+			ctx.Set("adminSession", domain.NewAdminSessionFromProps(domain.AdminSessionProps{AdminID: "admin-1"}))
+			ctx.SetParamNames("campId", "id")
+			ctx.SetParamValues("camp-1", "device-1")
+
+			// act
+			if err := tt.handle(handler, ctx); err != nil {
+				e.HTTPErrorHandler(err, ctx)
+			}
+
+			// assert
+			if rec.Code != http.StatusConflict || !bytes.Contains(rec.Body.Bytes(), []byte(tt.code)) {
+				t.Fatalf("expected 409 %s, got status=%d body=%s", tt.code, rec.Code, rec.Body.String())
+			}
+		})
 	}
 }
 

--- a/backend/internal/infrastructure/web/group_handler.go
+++ b/backend/internal/infrastructure/web/group_handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -80,7 +81,7 @@ func (h *GroupHandler) ListGroups(c echo.Context) error {
 // @Param        trackId path string true "트랙 ID"
 // @Success      200 {array} GroupResponse
 // @Failure      401 {object} ErrorResponse
-// @Failure      403 {object} ErrorResponse "세션 트랙과 요청 트랙 불일치"
+// @Failure      403 {object} ErrorResponse "TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치"
 // @Failure      404 {object} ErrorResponse "트랙 또는 코너 없음"
 // @Router       /tracks/{trackId}/groups [get]
 func (h *GroupHandler) ListGroupsByTrack(c echo.Context) error {
@@ -91,12 +92,12 @@ func (h *GroupHandler) ListGroupsByTrack(c echo.Context) error {
 
 	trackID := domain.TrackID(c.Param("trackId"))
 	if session.TrackID() != trackID {
-		return domain.ErrTrackScopeForbidden
+		return groupHTTPError(domain.ErrTrackScopeForbidden)
 	}
 
 	groups, err := h.groupUC.ListGroupsByTrack(c.Request().Context(), trackID)
 	if err != nil {
-		return err
+		return groupHTTPError(err)
 	}
 	res := make([]GroupResponse, len(groups))
 	for i, group := range groups {
@@ -117,7 +118,7 @@ func (h *GroupHandler) GetGroup(c echo.Context) error {
 	id := c.Param("id")
 	g, err := h.groupUC.RetrieveGroupRotationSchedule(c.Request().Context(), domain.GroupID(id))
 	if err != nil {
-		return err
+		return groupHTTPError(err)
 	}
 	if g == nil {
 		return echo.ErrNotFound
@@ -137,7 +138,7 @@ func (h *GroupHandler) ListGroupVisits(c echo.Context) error {
 	id := domain.GroupID(c.Param("id"))
 	details, err := h.groupUC.ListGroupVisitDetails(c.Request().Context(), id)
 	if err != nil {
-		return err
+		return groupHTTPError(err)
 	}
 
 	res := make([]VisitSummaryResponse, len(details))
@@ -175,4 +176,17 @@ func (h *GroupHandler) ListGroupVisits(c echo.Context) error {
 		}
 	}
 	return c.JSON(http.StatusOK, res)
+}
+
+func groupHTTPError(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrTrackScopeForbidden):
+		return echo.NewHTTPError(http.StatusForbidden, ErrorResponse{Code: "TRACK_SCOPE_FORBIDDEN", Message: "track session cannot access the requested track"}).SetInternal(err)
+	case errors.Is(err, domain.ErrTrackNotFound):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "TRACK_NOT_FOUND", Message: "track not found"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCornerNotFound), errors.Is(err, domain.ErrCornerNotInItinerary):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "GROUP_NOT_FOUND", Message: "group or related corner not found"}).SetInternal(err)
+	default:
+		return err
+	}
 }

--- a/backend/internal/infrastructure/web/group_handler_test.go
+++ b/backend/internal/infrastructure/web/group_handler_test.go
@@ -110,7 +110,8 @@ func TestListGroupsByTrackShoudRejectRequestWhenSessionTrackDiffers(t *testing.T
 	err := NewGroupHandler(nil).ListGroupsByTrack(c)
 
 	// Assert
-	if err != domain.ErrTrackScopeForbidden {
-		t.Fatalf("expected ErrTrackScopeForbidden, got %v", err)
+	var httpErr *echo.HTTPError
+	if !errorsAsHTTPError(err, &httpErr) || httpErr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 HTTP error, got %v", err)
 	}
 }

--- a/backend/internal/infrastructure/web/list_handlers_test.go
+++ b/backend/internal/infrastructure/web/list_handlers_test.go
@@ -25,6 +25,7 @@ type listDeviceTrustStub struct {
 	statusErr        error
 	deviceToken      string
 	mutatedDevice    *domain.DeviceRegistration
+	mutationErr      error
 }
 
 func (s *listDeviceTrustStub) GetMyRegistrationStatus(_ context.Context, deviceToken string) (*usecase.DeviceRegistrationStatusView, error) {
@@ -39,13 +40,13 @@ func (s *listDeviceTrustStub) RequestRegistration(_ context.Context, registratio
 	return "token", s.requestedReg, nil
 }
 func (s *listDeviceTrustStub) ApproveDevice(context.Context, domain.DeviceRegistrationID, domain.AdminID) (*domain.DeviceRegistration, error) {
-	return s.mutatedDevice, nil
+	return s.mutatedDevice, s.mutationErr
 }
 func (s *listDeviceTrustStub) RejectDevice(context.Context, domain.DeviceRegistrationID, domain.AdminID) (*domain.DeviceRegistration, error) {
-	return s.mutatedDevice, nil
+	return s.mutatedDevice, s.mutationErr
 }
 func (s *listDeviceTrustStub) RevokeDevice(context.Context, domain.DeviceRegistrationID, domain.AdminID) (*domain.DeviceRegistration, error) {
-	return s.mutatedDevice, nil
+	return s.mutatedDevice, s.mutationErr
 }
 func (s *listDeviceTrustStub) ReviewDeviceTrustRequests(context.Context, domain.CampID, *domain.DeviceRegistrationStatus) ([]*domain.DeviceRegistration, error) {
 	return s.reviewedDevices, nil

--- a/backend/internal/infrastructure/web/local_error_mapping_test.go
+++ b/backend/internal/infrastructure/web/local_error_mapping_test.go
@@ -1,0 +1,46 @@
+package web
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"cornermon/backend/internal/domain"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestLocalErrorMappersShouldPreserveExpectedAndUnexpectedErrorBoundaries(t *testing.T) {
+	tests := []struct {
+		name       string
+		mapError   func(error) error
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "camp wrapped not found", mapError: campHTTPError, err: fmt.Errorf("load: %w", domain.ErrCampNotFound), wantStatus: http.StatusNotFound, wantCode: "CAMP_NOT_FOUND"},
+		{name: "message revoked", mapError: messageHTTPError, err: domain.ErrSessionRevoked, wantStatus: http.StatusUnauthorized, wantCode: "SESSION_REVOKED"},
+		{name: "report state", mapError: reportHTTPError, err: domain.ErrCampInvalidTransition, wantStatus: http.StatusConflict, wantCode: "CAMP_NOT_ENDED"},
+		{name: "unexpected error remains internal", mapError: messageHTTPError, err: errors.New("database unavailable"), wantStatus: http.StatusInternalServerError, wantCode: "INTERNAL_SERVER_ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// arrange
+			e := echo.New()
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(httptest.NewRequest(http.MethodGet, "/test", nil), rec)
+
+			// act
+			ErrorHandler()(tt.mapError(tt.err), ctx)
+
+			// assert
+			if rec.Code != tt.wantStatus || !strings.Contains(rec.Body.String(), tt.wantCode) {
+				t.Fatalf("expected %d %s, got status=%d body=%s", tt.wantStatus, tt.wantCode, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}

--- a/backend/internal/infrastructure/web/message_handler.go
+++ b/backend/internal/infrastructure/web/message_handler.go
@@ -89,7 +89,8 @@ type BroadcastMessageRequest struct {
 // @Param        campId path string true "캠프 ID"
 // @Param        request body BroadcastMessageRequest true "메시지 내용"
 // @Success      201 {object} MessageResponse
-// @Failure      400 {object} ErrorResponse
+// @Failure      400 {object} ErrorResponse "BAD_REQUEST: 요청 본문 또는 campId가 없음"
+// @Failure      409 {object} ErrorResponse "CAMP_NOT_ACTIVE: ACTIVE 캠프에서만 공지를 보낼 수 있음"
 // @Router       /camps/{campId}/messages/broadcast [post]
 func (h *MessageHandler) SendBroadcast(c echo.Context) error {
 	session, ok := c.Get("adminSession").(*domain.AdminSession)
@@ -108,7 +109,7 @@ func (h *MessageHandler) SendBroadcast(c echo.Context) error {
 
 	announcement, err := h.announcement.SendAnnouncement(c.Request().Context(), campID, req.Content, session.AdminID())
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
+		return messageHTTPError(err)
 	}
 
 	return c.JSON(http.StatusCreated, MessageResponse{
@@ -137,7 +138,7 @@ func (h *MessageHandler) ListBroadcasts(c echo.Context) error {
 	if session, ok := c.Get("facilitatorSession").(*domain.FacilitatorSession); ok {
 		views, err := h.announcementQuery.ListNoticesForTrack(c.Request().Context(), campID, session.TrackID())
 		if err != nil {
-			return err
+			return messageHTTPError(err)
 		}
 		res = make([]MessageResponse, len(views))
 		for i, view := range views {
@@ -213,7 +214,7 @@ func (h *MessageHandler) ReadBroadcast(c echo.Context) error {
 
 	err := h.announcement.MarkNoticeRead(c.Request().Context(), token, announcementID)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
+		return messageHTTPError(err)
 	}
 
 	return c.NoContent(http.StatusNoContent)
@@ -255,7 +256,7 @@ func (h *MessageHandler) SendDirect(c echo.Context) error {
 
 	msg, err := h.message.SendDirect(c.Request().Context(), trackID, req.Content, senderRole)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
+		return messageHTTPError(err)
 	}
 
 	var tID *string
@@ -284,7 +285,7 @@ func (h *MessageHandler) SendDirect(c echo.Context) error {
 // @Param        background query bool false "true면 상대측이 보낸 미확인 메시지를 읽음 처리"
 // @Param        after query string false "RFC3339 UTC 이후 메시지만 반환"
 // @Success      200 {array} MessageResponse
-// @Failure      403 {object} ErrorResponse "세션 트랙과 요청 트랙 불일치"
+// @Failure      403 {object} ErrorResponse "TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치"
 // @Router       /tracks/{trackId}/messages [get]
 func (h *MessageHandler) ListDirectMessages(c echo.Context) error {
 	trackID := domain.TrackID(c.Param("trackId"))
@@ -305,7 +306,7 @@ func (h *MessageHandler) ListDirectMessages(c echo.Context) error {
 	}
 	msgs, err := h.message.ListDirectMessages(c.Request().Context(), trackID, viewerRole, after, background)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
+		return messageHTTPError(err)
 	}
 
 	return c.JSON(http.StatusOK, mapMessages(msgs))
@@ -323,7 +324,7 @@ type UnreadCountResponse struct {
 // @Produce      json
 // @Param        trackId path string true "트랙 ID"
 // @Success      200 {object} UnreadCountResponse
-// @Failure      403 {object} ErrorResponse "세션 트랙과 요청 트랙 불일치"
+// @Failure      403 {object} ErrorResponse "TRACK_SCOPE_FORBIDDEN: 세션 트랙과 요청 트랙이 불일치"
 // @Router       /tracks/{trackId}/messages/unread-count [get]
 func (h *MessageHandler) GetUnreadCount(c echo.Context) error {
 	trackID := domain.TrackID(c.Param("trackId"))
@@ -336,7 +337,7 @@ func (h *MessageHandler) GetUnreadCount(c echo.Context) error {
 	}
 	count, err := h.message.GetUnreadCount(c.Request().Context(), trackID, role)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_SERVER_ERROR", Message: err.Error()}).SetInternal(err)
+		return messageHTTPError(err)
 	}
 	return c.JSON(http.StatusOK, UnreadCountResponse{UnreadCount: count})
 }
@@ -347,9 +348,26 @@ func requireFacilitatorTrackScope(c echo.Context, trackID domain.TrackID) error 
 		return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
 	}
 	if session.TrackID() != trackID {
-		return domain.ErrTrackScopeForbidden
+		return messageHTTPError(domain.ErrTrackScopeForbidden)
 	}
 	return nil
+}
+
+func messageHTTPError(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrSessionRevoked):
+		return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: "SESSION_REVOKED", Message: "facilitator session is revoked"}).SetInternal(err)
+	case errors.Is(err, domain.ErrTrackScopeForbidden):
+		return echo.NewHTTPError(http.StatusForbidden, ErrorResponse{Code: "TRACK_SCOPE_FORBIDDEN", Message: "track session cannot access the requested track"}).SetInternal(err)
+	case errors.Is(err, domain.ErrTrackNotFound), errors.Is(err, domain.ErrTrackNotActive):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "TRACK_NOT_FOUND", Message: "track not found"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCornerNotInItinerary):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "CORNER_NOT_FOUND", Message: "track corner not found"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampInvalidTransition):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "CAMP_NOT_ACTIVE", Message: "camp is not active"}).SetInternal(err)
+	default:
+		return err
+	}
 }
 
 func parseBackground(value string) (bool, error) {

--- a/backend/internal/infrastructure/web/message_handler_test.go
+++ b/backend/internal/infrastructure/web/message_handler_test.go
@@ -129,8 +129,9 @@ func TestListDirectMessagesShoudRejectRequestWhenSessionTrackDiffers(t *testing.
 	err := NewMessageHandler(&messageUsecaseForHandler{}, nil, nil).ListDirectMessages(c)
 
 	// Assert
-	if err != domain.ErrTrackScopeForbidden {
-		t.Fatalf("expected ErrTrackScopeForbidden, got %v", err)
+	var httpErr *echo.HTTPError
+	if !errorsAsHTTPError(err, &httpErr) || httpErr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 HTTP error, got %v", err)
 	}
 }
 
@@ -148,8 +149,9 @@ func TestGetUnreadCountShoudRejectRequestWhenSessionTrackDiffers(t *testing.T) {
 	err := NewMessageHandler(&messageUsecaseForHandler{}, nil, nil).GetUnreadCount(c)
 
 	// Assert
-	if err != domain.ErrTrackScopeForbidden {
-		t.Fatalf("expected ErrTrackScopeForbidden, got %v", err)
+	var httpErr *echo.HTTPError
+	if !errorsAsHTTPError(err, &httpErr) || httpErr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 HTTP error, got %v", err)
 	}
 }
 
@@ -168,8 +170,9 @@ func TestSendDirectShoudRejectRequestWhenSessionTrackDiffers(t *testing.T) {
 	err := NewMessageHandler(&messageUsecaseForHandler{}, nil, nil).SendDirect(c)
 
 	// Assert
-	if err != domain.ErrTrackScopeForbidden {
-		t.Fatalf("expected ErrTrackScopeForbidden, got %v", err)
+	var httpErr *echo.HTTPError
+	if !errorsAsHTTPError(err, &httpErr) || httpErr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 HTTP error, got %v", err)
 	}
 }
 

--- a/backend/internal/infrastructure/web/report_handler.go
+++ b/backend/internal/infrastructure/web/report_handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -145,12 +146,13 @@ func mapReport(r *usecase.CampReport) CampReportResponse {
 // @Produce      json
 // @Param        campId path string true "캠프 ID"
 // @Success      200 {object} CampSummaryStatsResponse
+// @Failure      404 {object} ErrorResponse "CAMP_NOT_FOUND: 캠프가 없음"
 // @Router       /camps/{campId}/reports/live-summary [get]
 func (h *ReportHandler) LiveSummary(c echo.Context) error {
 	campID := domain.CampID(c.Param("campId"))
 	report, err := h.reportService.GetCampReport(c.Request().Context(), campID)
 	if err != nil {
-		return err
+		return reportHTTPError(err)
 	}
 
 	return c.JSON(http.StatusOK, mapSummary(report))
@@ -163,12 +165,13 @@ func (h *ReportHandler) LiveSummary(c echo.Context) error {
 // @Produce      json
 // @Param        campId path string true "캠프 ID"
 // @Success      200 {object} CampReportResponse
+// @Failure      404 {object} ErrorResponse "CAMP_NOT_FOUND: 캠프가 없음"
 // @Router       /camps/{campId}/reports/current [get]
 func (h *ReportHandler) GetCurrentReport(c echo.Context) error {
 	campID := domain.CampID(c.Param("campId"))
 	report, err := h.reportService.GetCampReport(c.Request().Context(), campID)
 	if err != nil {
-		return err
+		return reportHTTPError(err)
 	}
 
 	return c.JSON(http.StatusOK, mapReport(report))
@@ -181,12 +184,14 @@ func (h *ReportHandler) GetCurrentReport(c echo.Context) error {
 // @Produce      json
 // @Param        campId path string true "캠프 ID"
 // @Success      201 {object} CampReportResponse
+// @Failure      404 {object} ErrorResponse "CAMP_NOT_FOUND: 캠프가 없음"
+// @Failure      409 {object} ErrorResponse "CAMP_NOT_ENDED: 종료된 캠프에서만 최종 리포트를 생성할 수 있음"
 // @Router       /camps/{campId}/reports/generate [post]
 func (h *ReportHandler) GenerateReport(c echo.Context) error {
 	campID := domain.CampID(c.Param("campId"))
 	report, err := h.reportService.GenerateCampReport(c.Request().Context(), campID)
 	if err != nil {
-		return err
+		return reportHTTPError(err)
 	}
 
 	return c.JSON(http.StatusCreated, mapReport(report))
@@ -199,14 +204,26 @@ func (h *ReportHandler) GenerateReport(c echo.Context) error {
 // @Produce      json
 // @Param        campId path string true "캠프 ID"
 // @Success      200 {object} CampReportResponse
+// @Failure      404 {object} ErrorResponse "CAMP_NOT_FOUND: 캠프가 없음"
 // @Router       /camps/{campId}/reports/current/export [get]
 func (h *ReportHandler) ExportCurrentReport(c echo.Context) error {
 	campID := domain.CampID(c.Param("campId"))
 	report, err := h.reportService.GetCampReport(c.Request().Context(), campID)
 	if err != nil {
-		return err
+		return reportHTTPError(err)
 	}
 
 	// Just return JSON as per the updated spec
 	return c.JSON(http.StatusOK, mapReport(report))
+}
+
+func reportHTTPError(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrCampNotFound):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "CAMP_NOT_FOUND", Message: "camp not found"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampInvalidTransition):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "CAMP_NOT_ENDED", Message: "camp must be ended before report generation"}).SetInternal(err)
+	default:
+		return err
+	}
 }

--- a/backend/internal/infrastructure/web/track_handler.go
+++ b/backend/internal/infrastructure/web/track_handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"net/http"
 
 	"cornermon/backend/internal/domain"
@@ -93,6 +94,8 @@ type CreateTracksRequest struct {
 // @Produce      json
 // @Param        request body CreateTracksRequest true "생성 정보"
 // @Success      201 {array} TrackPinResponse
+// @Failure      404 {object} ErrorResponse "CORNER_NOT_FOUND: 대상 코너가 없음"
+// @Failure      409 {object} ErrorResponse "CAMP_NOT_AVAILABLE: 종료된 캠프에는 트랙을 생성할 수 없음"
 // @Router       /tracks [post]
 func (h *TrackHandler) CreateTracks(c echo.Context) error {
 	var req CreateTracksRequest
@@ -103,7 +106,7 @@ func (h *TrackHandler) CreateTracks(c echo.Context) error {
 	for i := 0; i < req.Count; i++ {
 		track, pin, err := h.svc.CreateTrack(c.Request().Context(), domain.CampID(req.CampID), domain.CornerID(req.CornerID))
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
+			return trackHTTPError(err)
 		}
 		res = append(res, TrackPinResponse{Track: mapDomainTrackToDTO(track), PIN: pin})
 	}
@@ -146,6 +149,8 @@ type BulkDeleteTracksRequest struct {
 // @Produce      json
 // @Param        request body BulkDeleteTracksRequest true "삭제할 트랙 ID 목록"
 // @Success      204 "성공적으로 삭제됨"
+// @Failure      404 {object} ErrorResponse "TRACK_NOT_FOUND: 대상 트랙이 없거나 이미 삭제됨"
+// @Failure      409 {object} ErrorResponse "TRACK_DELETE_BLOCKED: 진행 중인 방문이 있어 삭제할 수 없음"
 // @Router       /tracks/bulk-delete [delete]
 func (h *TrackHandler) BulkDeleteTracks(c echo.Context) error {
 	var req BulkDeleteTracksRequest
@@ -155,7 +160,7 @@ func (h *TrackHandler) BulkDeleteTracks(c echo.Context) error {
 	for _, id := range req.TrackIDs {
 		_, err := h.svc.DeleteTrack(c.Request().Context(), domain.TrackID(id))
 		if err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
+			return trackHTTPError(err)
 		}
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -190,7 +195,7 @@ func (h *TrackHandler) ReplaceTrack(c echo.Context) error {
 		domain.CornerID(req.NewCornerID),
 	)
 	if err != nil {
-		return err
+		return trackHTTPError(err)
 	}
 	return c.JSON(http.StatusOK, TrackPinResponse{Track: mapDomainTrackToDTO(track), PIN: pin})
 }
@@ -202,12 +207,13 @@ func (h *TrackHandler) ReplaceTrack(c echo.Context) error {
 // @Produce      json
 // @Param        id path string true "트랙 ID"
 // @Success      200 {object} TrackPinResponse
+// @Failure      404 {object} ErrorResponse "TRACK_NOT_FOUND: 대상 트랙이 없거나 활성 상태가 아님"
 // @Router       /tracks/{id}/regenerate-pin [post]
 func (h *TrackHandler) RegeneratePin(c echo.Context) error {
 	id := domain.TrackID(c.Param("id"))
 	track, plainPIN, err := h.svc.RegeneratePIN(c.Request().Context(), id)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, ErrorResponse{Code: "INTERNAL_ERROR", Message: err.Error()}).SetInternal(err)
+		return trackHTTPError(err)
 	}
 	return c.JSON(http.StatusOK, TrackPinResponse{Track: mapDomainTrackToDTO(track), PIN: plainPIN})
 }
@@ -227,7 +233,7 @@ func (h *TrackHandler) ExportTracks(c echo.Context) error {
 	}
 	tracks, pins, err := h.svc.ExportTrackPINs(c.Request().Context(), campID)
 	if err != nil {
-		return err
+		return trackHTTPError(err)
 	}
 	res := make([]TrackPinResponse, len(tracks))
 	for i, track := range tracks {
@@ -248,8 +254,23 @@ func (h *TrackHandler) ExportTracks(c echo.Context) error {
 func (h *TrackHandler) ExportTrackSingle(c echo.Context) error {
 	track, pin, err := h.svc.ExportTrackPIN(c.Request().Context(), domain.TrackID(c.Param("id")))
 	if err != nil {
-		return err
+		return trackHTTPError(err)
 	}
 	c.Response().Header().Set("Cache-Control", "no-store")
 	return c.JSON(http.StatusOK, TrackPinResponse{Track: mapDomainTrackToDTO(track), PIN: pin})
+}
+
+func trackHTTPError(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrCornerNotFound), errors.Is(err, domain.ErrCornerNotInItinerary):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "CORNER_NOT_FOUND", Message: "corner not found"}).SetInternal(err)
+	case errors.Is(err, domain.ErrTrackNotActive), errors.Is(err, domain.ErrTrackNotFound):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "TRACK_NOT_FOUND", Message: "track not found"}).SetInternal(err)
+	case errors.Is(err, domain.ErrTrackDeleteBlocked), errors.Is(err, domain.ErrTrackBusy), errors.Is(err, domain.ErrTrackCampMismatch):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "TRACK_CONFLICT", Message: "track cannot be changed in its current state"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampInvalidTransition):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "CAMP_NOT_AVAILABLE", Message: "camp is not available for track management"}).SetInternal(err)
+	default:
+		return err
+	}
 }

--- a/backend/internal/infrastructure/web/track_handler_error_test.go
+++ b/backend/internal/infrastructure/web/track_handler_error_test.go
@@ -1,0 +1,44 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"cornermon/backend/internal/domain"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestTrackHTTPErrorShouldMapExpectedDomainErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "missing track", err: domain.ErrTrackNotActive, wantStatus: http.StatusNotFound, wantCode: "TRACK_NOT_FOUND"},
+		{name: "wrapped target corner missing", err: fmt.Errorf("replace: %w", domain.ErrCornerNotFound), wantStatus: http.StatusNotFound, wantCode: "CORNER_NOT_FOUND"},
+		{name: "cross camp replacement", err: domain.ErrTrackCampMismatch, wantStatus: http.StatusConflict, wantCode: "TRACK_CONFLICT"},
+		{name: "ended camp", err: domain.ErrCampInvalidTransition, wantStatus: http.StatusConflict, wantCode: "CAMP_NOT_AVAILABLE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// arrange
+			e := echo.New()
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(httptest.NewRequest(http.MethodPut, "/tracks/track-1/replace", nil), rec)
+
+			// act
+			ErrorHandler()(trackHTTPError(tt.err), ctx)
+
+			// assert
+			if rec.Code != tt.wantStatus || !strings.Contains(rec.Body.String(), tt.wantCode) {
+				t.Fatalf("expected %d %s, got status=%d body=%s", tt.wantStatus, tt.wantCode, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}

--- a/backend/internal/infrastructure/web/visit_handler.go
+++ b/backend/internal/infrastructure/web/visit_handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -66,7 +67,9 @@ func mapVisitToDTO(v *domain.Visit) VisitSummaryResponse {
 // @Param        trackId path string true "트랙 ID"
 // @Param        request body VisitStartRequest true "입장 방식 및 페이로드"
 // @Success      201 {object} VisitSummaryResponse
-// @Failure      409 {object} ErrorResponse "TRACK_BUSY, DUPLICATE_VISIT 등"
+// @Failure      401 {object} ErrorResponse "SESSION_REVOKED: 진행자 세션이 취소됨"
+// @Failure      404 {object} ErrorResponse "BADGE_NOT_ASSIGNED: 배지가 존재하지 않거나 조에 배정되지 않음"
+// @Failure      409 {object} ErrorResponse "TRACK_BUSY, TRACK_NOT_ACTIVE, ITINERARY_CONFLICT, CAMP_NOT_ACTIVE: 현재 운영 상태에서 방문을 시작할 수 없음"
 // @Router       /tracks/{trackId}/visits/start [post]
 func (h *VisitHandler) StartVisit(c echo.Context) error {
 	authHeader := c.Request().Header.Get("Authorization")
@@ -74,7 +77,7 @@ func (h *VisitHandler) StartVisit(c echo.Context) error {
 
 	var req VisitStartRequest
 	if err := c.Bind(&req); err != nil {
-		return err
+		return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: "BAD_REQUEST", Message: "invalid request"}).SetInternal(err)
 	}
 
 	var visit *domain.Visit
@@ -87,7 +90,7 @@ func (h *VisitHandler) StartVisit(c echo.Context) error {
 	}
 
 	if err != nil {
-		return err
+		return visitHTTPError(err)
 	}
 
 	return c.JSON(http.StatusCreated, mapVisitToDTO(visit))
@@ -100,7 +103,8 @@ func (h *VisitHandler) StartVisit(c echo.Context) error {
 // @Produce      json
 // @Param        trackId path string true "트랙 ID"
 // @Success      200 {object} VisitSummaryResponse
-// @Failure      409 {object} ErrorResponse "TRACK_NOT_BUSY 등"
+// @Failure      401 {object} ErrorResponse "SESSION_REVOKED: 진행자 세션이 취소됨"
+// @Failure      409 {object} ErrorResponse "TRACK_NOT_BUSY, TRACK_NOT_ACTIVE, ITINERARY_CONFLICT: 현재 운영 상태에서 방문을 종료할 수 없음"
 // @Router       /tracks/{trackId}/visits/current/end [post]
 func (h *VisitHandler) EndCurrentVisit(c echo.Context) error {
 	authHeader := c.Request().Header.Get("Authorization")
@@ -108,7 +112,7 @@ func (h *VisitHandler) EndCurrentVisit(c echo.Context) error {
 
 	visit, err := h.visitUC.CompleteVisit(c.Request().Context(), token)
 	if err != nil {
-		return err
+		return visitHTTPError(err)
 	}
 
 	return c.JSON(http.StatusOK, mapVisitToDTO(visit))
@@ -121,7 +125,8 @@ func (h *VisitHandler) EndCurrentVisit(c echo.Context) error {
 // @Produce      json
 // @Param        trackId path string true "트랙 ID"
 // @Success      200 {object} VisitSummaryResponse
-// @Failure      404 "진행 중인 방문 없음"
+// @Failure      401 {object} ErrorResponse "SESSION_REVOKED: 진행자 세션이 취소됨"
+// @Failure      404 {object} ErrorResponse "VISIT_NOT_FOUND: 진행 중인 방문 없음"
 // @Router       /tracks/{trackId}/visits/current [get]
 func (h *VisitHandler) GetCurrentVisit(c echo.Context) error {
 	authHeader := c.Request().Header.Get("Authorization")
@@ -129,11 +134,32 @@ func (h *VisitHandler) GetCurrentVisit(c echo.Context) error {
 
 	visit, err := h.visitUC.GetCurrentVisit(c.Request().Context(), token)
 	if err != nil {
-		return err
+		return visitHTTPError(err)
 	}
 	if visit == nil {
 		return echo.ErrNotFound
 	}
 
 	return c.JSON(http.StatusOK, mapVisitToDTO(visit))
+}
+
+func visitHTTPError(err error) error {
+	switch {
+	case errors.Is(err, domain.ErrSessionRevoked):
+		return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: "SESSION_REVOKED", Message: "facilitator session is revoked"}).SetInternal(err)
+	case errors.Is(err, domain.ErrBadgeNotAssigned):
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: "BADGE_NOT_ASSIGNED", Message: "badge is not assigned to a group"}).SetInternal(err)
+	case errors.Is(err, domain.ErrTrackBusy):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "TRACK_BUSY", Message: "track already has a visit in progress"}).SetInternal(err)
+	case errors.Is(err, domain.ErrTrackNotBusy):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "TRACK_NOT_BUSY", Message: "track has no visit in progress"}).SetInternal(err)
+	case errors.Is(err, domain.ErrTrackNotActive):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "TRACK_NOT_ACTIVE", Message: "track is not active"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCornerNotInItinerary), errors.Is(err, domain.ErrGroupBusy), errors.Is(err, domain.ErrDuplicateVisit), errors.Is(err, domain.ErrVisitAlreadyCompleted):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "ITINERARY_CONFLICT", Message: "visit does not satisfy the group itinerary"}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampInvalidTransition):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: "CAMP_NOT_ACTIVE", Message: "camp is not active"}).SetInternal(err)
+	default:
+		return err
+	}
 }

--- a/backend/internal/infrastructure/web/visit_handler_test.go
+++ b/backend/internal/infrastructure/web/visit_handler_test.go
@@ -1,0 +1,45 @@
+package web
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"cornermon/backend/internal/domain"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestVisitHTTPErrorShouldMapExpectedDomainErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantCode   string
+	}{
+		{name: "revoked session", err: domain.ErrSessionRevoked, wantStatus: http.StatusUnauthorized, wantCode: "SESSION_REVOKED"},
+		{name: "wrapped busy track", err: fmt.Errorf("start visit: %w", domain.ErrTrackBusy), wantStatus: http.StatusConflict, wantCode: "TRACK_BUSY"},
+		{name: "unassigned badge", err: domain.ErrBadgeNotAssigned, wantStatus: http.StatusNotFound, wantCode: "BADGE_NOT_ASSIGNED"},
+		{name: "inactive camp", err: domain.ErrCampInvalidTransition, wantStatus: http.StatusConflict, wantCode: "CAMP_NOT_ACTIVE"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// arrange
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/tracks/track-1/visits/start", nil)
+			rec := httptest.NewRecorder()
+			ctx := e.NewContext(req, rec)
+
+			// act
+			ErrorHandler()(visitHTTPError(tt.err), ctx)
+
+			// assert
+			if rec.Code != tt.wantStatus || !strings.Contains(rec.Body.String(), tt.wantCode) {
+				t.Fatalf("expected %d %s, got status=%d body=%s", tt.wantStatus, tt.wantCode, rec.Code, rec.Body.String())
+			}
+		})
+	}
+}

--- a/backend/internal/usecase/track.go
+++ b/backend/internal/usecase/track.go
@@ -391,8 +391,11 @@ func (s *TrackService) ListTracksByCamp(ctx context.Context, campID domain.CampI
 
 func (s *TrackService) ExportTrackPIN(ctx context.Context, trackID domain.TrackID) (*domain.Track, string, error) {
 	track, err := s.tracks.Get(ctx, trackID)
-	if err != nil || track == nil || track.Status() != domain.TrackActive {
+	if err != nil {
 		return nil, "", err
+	}
+	if track == nil || track.Status() != domain.TrackActive {
+		return nil, "", domain.ErrTrackNotActive
 	}
 	if track.PINCiphertext() == "" || s.pinProtector == nil {
 		return nil, "", fmt.Errorf("track PIN must be regenerated before export")


### PR DESCRIPTION
## 변경 사항
- 각 웹 핸들러가 자신의 API 문맥에서 예상 domain/usecase 오류를 4xx ErrorResponse로 변환합니다.
- 인증·기기·방문·트랙·캠프·코너·리포트·메시지·그룹·배지 흐름의 500 오분류를 정리했습니다.
- ErrorResponse.code와 Swagger @Failure 설명을 추가하고 API 생성 산출물을 동기화했습니다.
- 래핑 sentinel error와 미분류 오류의 500 유지 경계를 테스트했습니다.

## 변경 이유
예상 가능한 인증·상태·권한 오류가 중앙 오류 처리기에 일반 error로 전달되어 500으로 응답되던 문제를 해결합니다. 상태 코드 결정은 전역 매퍼가 아니라 각 핸들러의 국지적 문맥에 남깁니다.

## 검증
- cd backend && make swag
- cd backend && go test ./...
- cd backend && go vet ./...
- git diff --check
- 생성 문서/계획 문서를 제외한 코드 additions: 499