### PR TITLE
fix: PIN 로그인 에러 코드를 백엔드 최신 스펙에 맞춰 갱신

### DIFF
--- a/frontend/lib/facilitator/features/pin_login/pin_login_error_provider.dart
+++ b/frontend/lib/facilitator/features/pin_login/pin_login_error_provider.dart
@@ -20,19 +20,19 @@ class PinInvalid extends PinLoginUiError {
   final int? retryAfterSeconds;
 }
 
-/// 429 PIN_LOCKED — 2분 단계, 카운트다운만 표시하고 액션 링크는 없다(도움요청 제거 결정, 2026-07-10).
+/// 429 DEVICE_LOCKED — 2분 단계, 카운트다운만 표시하고 액션 링크는 없다(도움요청 제거 결정, 2026-07-10).
 class PinLocked extends PinLoginUiError {
   const PinLocked({required this.retryAfterSeconds});
 
   final int retryAfterSeconds;
 }
 
-/// 403 DEVICE_NOT_TRUSTED.
+/// 403 DEVICE_NOT_APPROVED.
 class DeviceNotTrustedYet extends PinLoginUiError {
   const DeviceNotTrustedYet();
 }
 
-/// 403 CAMP_NOT_ACTIVE.
+/// 403 CAMP_NOT_AVAILABLE.
 class CampNotActiveYet extends PinLoginUiError {
   const CampNotActiveYet();
 }
@@ -59,7 +59,7 @@ class PinLoginError extends _$PinLoginError {
   bool _isDeviceNotTrusted(DioException e) =>
       e.response?.statusCode == 403 &&
       e.response?.data is Map &&
-      (e.response?.data as Map)['code'] == 'DEVICE_NOT_TRUSTED';
+      (e.response?.data as Map)['code'] == 'DEVICE_NOT_APPROVED';
 
   PinLoginUiError _mapError(DioException e) {
     final statusCode = e.response?.statusCode;
@@ -74,13 +74,13 @@ class PinLoginError extends _$PinLoginError {
     if (statusCode == 400 && code == 'INVALID_PIN') {
       return PinInvalid(retryAfterSeconds: retryAfterSeconds);
     }
-    if (statusCode == 403 && code == 'DEVICE_NOT_TRUSTED') {
+    if (statusCode == 403 && code == 'DEVICE_NOT_APPROVED') {
       return const DeviceNotTrustedYet();
     }
-    if (statusCode == 403 && code == 'CAMP_NOT_ACTIVE') {
+    if (statusCode == 403 && code == 'CAMP_NOT_AVAILABLE') {
       return const CampNotActiveYet();
     }
-    if (statusCode == 429 && code == 'PIN_LOCKED') {
+    if (statusCode == 429 && code == 'DEVICE_LOCKED') {
       return PinLocked(retryAfterSeconds: retryAfterSeconds ?? 0);
     }
     // 인식되지 않은 코드는 "PIN이 일치하지 않습니다"로 안전하게 대체한다(fail-safe degrade).

--- a/frontend/lib/facilitator/features/pin_login/pin_login_screen.dart
+++ b/frontend/lib/facilitator/features/pin_login/pin_login_screen.dart
@@ -74,7 +74,7 @@ class PinLoginScreen extends ConsumerWidget {
   }
 }
 
-/// PinOtpInput + 상태별 안내 텍스트. PIN_LOCKED 카운트다운은 서버가 내려준
+/// PinOtpInput + 상태별 안내 텍스트. DEVICE_LOCKED 카운트다운은 서버가 내려준
 /// retryAfterSeconds에서 시작해 로컬 타이머로 0까지 줄이고, 0이 되면 입력을 다시 활성화한다.
 class _PinLoginBody extends StatefulWidget {
   const _PinLoginBody({required this.error, required this.onSubmitted});

--- a/frontend/test/facilitator/features/pin_login_test.dart
+++ b/frontend/test/facilitator/features/pin_login_test.dart
@@ -130,7 +130,7 @@ void main() {
     final container = _buildContainer(
       _loginError(
         statusCode: 429,
-        code: 'PIN_LOCKED',
+        code: 'DEVICE_LOCKED',
         details: {'retryAfterSeconds': 120},
       ),
     );
@@ -148,7 +148,7 @@ void main() {
   test('ShouldMapDeviceNotTrustedErrorCode', () async {
     // arrange
     final container = _buildContainer(
-      _loginError(statusCode: 403, code: 'DEVICE_NOT_TRUSTED'),
+      _loginError(statusCode: 403, code: 'DEVICE_NOT_APPROVED'),
     );
     addTearDown(container.dispose);
 
@@ -165,7 +165,7 @@ void main() {
       // arrange
       final deviceTrust = _RecordingDeviceTrust();
       final container = _buildContainer(
-        _loginError(statusCode: 403, code: 'DEVICE_NOT_TRUSTED'),
+        _loginError(statusCode: 403, code: 'DEVICE_NOT_APPROVED'),
         deviceTrust: deviceTrust,
       );
       addTearDown(container.dispose);
@@ -181,7 +181,7 @@ void main() {
   test('ShouldMapCampNotActiveErrorCode', () async {
     // arrange
     final container = _buildContainer(
-      _loginError(statusCode: 403, code: 'CAMP_NOT_ACTIVE'),
+      _loginError(statusCode: 403, code: 'CAMP_NOT_AVAILABLE'),
     );
     addTearDown(container.dispose);
 


### PR DESCRIPTION
## Summary
- 백엔드 커밋 `f72f16c`(핸들러별 도메인 오류를 4xx로 로컬 매핑)에서 `POST /auth/track/login`의 에러 코드가 `DEVICE_NOT_TRUSTED`→`DEVICE_NOT_APPROVED`, `CAMP_NOT_ACTIVE`→`CAMP_NOT_AVAILABLE`, `PIN_LOCKED`→`DEVICE_LOCKED`로 이름이 바뀌었으나 프론트(`pin_login_error_provider.dart`)는 옛 코드 문자열을 그대로 매칭하고 있었음
- 매칭 실패 시 fallback(`PinInvalid`)으로 떨어지는 구조라, 기기 미승인·캠프 미시작·PIN 잠금 등 모든 케이스가 "PIN이 일치하지 않습니다"로 뭉뚱그려 표시되는 문제였음
- 코드 문자열만 최신 스펙에 맞춰 갱신 (동작/분기 로직 자체는 변경 없음)
- 401 `SESSION_REVOKED`는 `auth_interceptor.dart`/`TrackSessionTokenSource.onUnauthorized`가 코드 문자열과 무관하게 모든 401에 대해 이미 강제 로그아웃 + 기기 신뢰 상태 복구를 수행하므로 별도 수정 불필요함을 확인함

## Test plan
- [x] `flutter test test/facilitator/features/pin_login_test.dart` (9 tests) 통과
- [x] `dart analyze` 이상 없음