### PR TITLE
fix: admin 화면의 원시 서버 에러 노출 제거

### DIFF
--- a/frontend/lib/admin/features/end_camp/end_camp_confirm_dialog.dart
+++ b/frontend/lib/admin/features/end_camp/end_camp_confirm_dialog.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -10,6 +11,27 @@ import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+
+/// POST end-camp 실패를 사용자 문구로 변환한다(camp_handler.go EndCamp 참고).
+/// 인식 못한 코드(네트워크 오류, 5xx 등)는 원문을 로그로만 남기고 일반 문구로 대체한다.
+String _describeEndError(Object error, StackTrace stackTrace) {
+  if (error is DioException) {
+    debugPrint(
+      '[end_camp] failed: type=${error.type} '
+      'statusCode=${error.response?.statusCode} '
+      'body=${error.response?.data}\n$stackTrace',
+    );
+    final code = (error.response?.data is Map)
+        ? (error.response?.data as Map)['code'] as String?
+        : null;
+    if (code == 'CAMP_STATE_CONFLICT') {
+      return '종료할 수 없는 캠프 상태이거나 정리 중인 방문이 있습니다.';
+    }
+  } else {
+    debugPrint('[end_camp] failed: $error\n$stackTrace');
+  }
+  return '종료 처리에 실패했습니다. 잠시 후 다시 시도해주세요.';
+}
 
 class EndCampConfirmDialog extends ConsumerStatefulWidget {
   const EndCampConfirmDialog({required this.campId, super.key});
@@ -50,8 +72,8 @@ class _EndCampConfirmDialogState extends ConsumerState<EndCampConfirmDialog> {
           });
         }
       }
-    } catch (error) {
-      if (mounted) setState(() => _error = error.toString());
+    } catch (error, stackTrace) {
+      if (mounted) setState(() => _error = _describeEndError(error, stackTrace));
     } finally {
       if (mounted) setState(() => _submitting = false);
     }

--- a/frontend/lib/admin/features/settings/update_camp_controller.dart
+++ b/frontend/lib/admin/features/settings/update_camp_controller.dart
@@ -3,7 +3,35 @@ import 'dart:async';
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/camp_providers.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// PATCH camp 실패를 사용자 문구로 변환한다(camp_handler.go UpdateCampSettings 참고).
+/// 인식 못한 코드(네트워크 오류, 5xx 등)는 원문을 로그로만 남기고 일반 문구로 대체한다.
+String describeUpdateCampError(Object error, StackTrace stackTrace) {
+  if (error is DioException) {
+    debugPrint(
+      '[update_camp] failed: type=${error.type} '
+      'statusCode=${error.response?.statusCode} '
+      'body=${error.response?.data}\n$stackTrace',
+    );
+    final code = (error.response?.data is Map)
+        ? (error.response?.data as Map)['code'] as String?
+        : null;
+    switch (code) {
+      case 'CAMP_INVALID_SETTINGS':
+        return '입력한 설정 값이 유효하지 않습니다.';
+      case 'CAMP_NOT_FOUND':
+        return '대상 캠프를 찾을 수 없습니다.';
+      case 'CAMP_SETTINGS_LOCKED':
+        return '종료된 캠프는 설정을 수정할 수 없습니다.';
+    }
+  } else {
+    debugPrint('[update_camp] failed: $error\n$stackTrace');
+  }
+  return '저장에 실패했습니다. 잠시 후 다시 시도해주세요.';
+}
 
 /// A15 설정의 두 섹션(캠프 정보, 병목 판정 기준)이 공유하는 저장 액션 컨트롤러.
 ///

--- a/frontend/lib/admin/features/settings/widgets/bottleneck_threshold_section.dart
+++ b/frontend/lib/admin/features/settings/widgets/bottleneck_threshold_section.dart
@@ -84,8 +84,9 @@ class _BottleneckThresholdSectionState
           context,
         ).showSnackBar(const SnackBar(content: Text('병목 판정 기준이 저장되었습니다.')));
       }
-    } catch (error) {
-      if (mounted) setState(() => _error = error.toString());
+    } catch (error, stackTrace) {
+      final message = describeUpdateCampError(error, stackTrace);
+      if (mounted) setState(() => _error = message);
     } finally {
       if (mounted) setState(() => _saving = false);
     }

--- a/frontend/lib/admin/features/settings/widgets/camp_info_section.dart
+++ b/frontend/lib/admin/features/settings/widgets/camp_info_section.dart
@@ -77,8 +77,9 @@ class _CampInfoSectionState extends ConsumerState<CampInfoSection> {
           context,
         ).showSnackBar(const SnackBar(content: Text('캠프 정보가 저장되었습니다.')));
       }
-    } catch (error) {
-      if (mounted) setState(() => _error = error.toString());
+    } catch (error, stackTrace) {
+      final message = describeUpdateCampError(error, stackTrace);
+      if (mounted) setState(() => _error = message);
     } finally {
       if (mounted) setState(() => _saving = false);
     }

--- a/frontend/lib/admin/features/start_camp/start_camp_button.dart
+++ b/frontend/lib/admin/features/start_camp/start_camp_button.dart
@@ -1,4 +1,5 @@
 import 'package:cornermon/admin/features/start_camp/start_camp_controller.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -21,6 +22,27 @@ class StartCampButton extends ConsumerWidget {
       builder: (_) => const StartCampConfirmDialog(),
     ),
   );
+}
+
+/// POST start-camp 실패를 사용자 문구로 변환한다(camp_handler.go StartCamp 참고).
+/// 인식 못한 코드(네트워크 오류, 5xx 등)는 원문을 로그로만 남기고 일반 문구로 대체한다.
+String _describeStartError(Object error, StackTrace stackTrace) {
+  if (error is DioException) {
+    debugPrint(
+      '[start_camp] failed: type=${error.type} '
+      'statusCode=${error.response?.statusCode} '
+      'body=${error.response?.data}\n$stackTrace',
+    );
+    final code = (error.response?.data is Map)
+        ? (error.response?.data as Map)['code'] as String?
+        : null;
+    if (code == 'CAMP_STATE_CONFLICT') {
+      return '이미 시작되었거나 시작할 수 없는 캠프 상태입니다.';
+    }
+  } else {
+    debugPrint('[start_camp] failed: $error\n$stackTrace');
+  }
+  return '시작 확정에 실패했습니다. 잠시 후 다시 시도해주세요.';
 }
 
 class StartCampConfirmDialog extends ConsumerStatefulWidget {
@@ -46,8 +68,8 @@ class _StartCampConfirmDialogState
       final result = ref.read(startCampControllerProvider);
       if (result.hasError) throw result.error!;
       if (mounted) Navigator.pop(context);
-    } catch (error) {
-      if (mounted) setState(() => _error = error.toString());
+    } catch (error, stackTrace) {
+      if (mounted) setState(() => _error = _describeStartError(error, stackTrace));
     } finally {
       if (mounted) setState(() => _submitting = false);
     }

--- a/frontend/test/admin/features/settings/camp_info_section_test.dart
+++ b/frontend/test/admin/features/settings/camp_info_section_test.dart
@@ -2,6 +2,7 @@ import 'package:cornermon/admin/features/settings/widgets/camp_info_section.dart
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/camp_providers.dart';
 import 'package:cornermon_api_gen/cornermon_api_gen.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -63,7 +64,7 @@ void main() {
   });
 
   testWidgets(
-    'ShoudShowInlineErrorAndKeepPreviousValueWhenSaveFails',
+    'ShoudShowFriendlyMessageAndKeepPreviousValueWhenSaveFails',
     (tester) async {
       // arrange
       final camp = _camp();
@@ -75,7 +76,16 @@ void main() {
               name: '테스트 캠프',
               startAt: camp.startAt,
               endAt: camp.endAt,
-            ).overrideWith((_) async => throw Exception('이름이 중복됩니다')),
+            ).overrideWith(
+              (_) async => throw DioException(
+                requestOptions: RequestOptions(path: '/camps/camp-1'),
+                response: Response(
+                  requestOptions: RequestOptions(path: '/camps/camp-1'),
+                  statusCode: 409,
+                  data: {'code': 'CAMP_SETTINGS_LOCKED', 'message': 'x'},
+                ),
+              ),
+            ),
           ],
           child: MaterialApp(home: Scaffold(body: CampInfoSection(camp: camp))),
         ),
@@ -85,8 +95,9 @@ void main() {
       await tester.tap(find.text('저장'));
       await tester.pumpAndSettle();
 
-      // assert
-      expect(find.textContaining('이름이 중복됩니다'), findsOneWidget);
+      // assert — 서버 원문(ErrorResponse.code/message)이 아닌 가공된 안내 문구만 노출한다
+      expect(find.textContaining('종료된 캠프는 설정을 수정할 수 없습니다'), findsOneWidget);
+      expect(find.textContaining('CAMP_SETTINGS_LOCKED'), findsNothing);
       expect(find.text('테스트 캠프'), findsOneWidget);
     },
   );

--- a/frontend/test/admin/features/start_camp/start_camp_button_test.dart
+++ b/frontend/test/admin/features/start_camp/start_camp_button_test.dart
@@ -7,6 +7,7 @@ import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/camp_providers.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon_api_gen/cornermon_api_gen.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -133,7 +134,7 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets('ShoudKeepDialogOpenAndShowServerMessageWhenStartFails', (
+  testWidgets('ShoudKeepDialogOpenAndShowFriendlyMessageWhenStartFails', (
     tester,
   ) async {
     // arrange
@@ -142,9 +143,16 @@ void main() {
       ProviderScope(
         overrides: [
           selectedCampIdProvider.overrideWith(() => _SelectedCampId(campId)),
-          startCampProvider(
-            campId,
-          ).overrideWith((ref) async => throw Exception('조건 미충족')),
+          startCampProvider(campId).overrideWith(
+            (ref) async => throw DioException(
+              requestOptions: RequestOptions(path: '/camps/camp-1/start'),
+              response: Response(
+                requestOptions: RequestOptions(path: '/camps/camp-1/start'),
+                statusCode: 409,
+                data: {'code': 'CAMP_STATE_CONFLICT', 'message': 'x'},
+              ),
+            ),
+          ),
         ],
         child: const MaterialApp(home: Scaffold(body: StartCampButton())),
       ),
@@ -158,8 +166,12 @@ void main() {
       await tester.pump(const Duration(seconds: 1));
     }
 
-    // assert
+    // assert — 서버 원문(ErrorResponse.code/message)이 아닌 가공된 안내 문구만 노출한다
     expect(find.text('코너학습을 시작할까요?'), findsOneWidget);
-    expect(find.textContaining('조건 미충족'), findsOneWidget);
+    expect(
+      find.textContaining('이미 시작되었거나 시작할 수 없는 캠프 상태입니다'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('CAMP_STATE_CONFLICT'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary
- `camp_info_section.dart`, `bottleneck_threshold_section.dart`, `start_camp_button.dart`, `end_camp_confirm_dialog.dart` 네 곳이 `catch (error) { _error = error.toString(); }`로 DioException 원문(`DioException [DioExceptionType.badResponse]: ...`)을 그대로 화면에 노출하고 있었음
- `ErrorResponse.code`로 구분 가능한 알려진 실패(예: `CAMP_SETTINGS_LOCKED`, `CAMP_STATE_CONFLICT`)는 사용자 친화 문구로 변환하고, 그 외(네트워크 오류·5xx 등 인식 못한 코드)는 일반 안내 문구로 대체. 원본 예외는 `debugPrint`로만 로깅
- `camp_info_section`/`bottleneck_threshold_section`은 같은 `PATCH /camps/{id}` 호출을 공유하므로 `update_camp_controller.dart`에 `describeUpdateCampError` 헬퍼를 두고 재사용
- `device_pending_screen.dart`의 기존 패턴(코드/statusCode 구분 + debugPrint)을 따름

## Test plan
- [x] `camp_info_section_test.dart` — 원문 노출 대신 가공된 문구만 보이는지 검증하도록 갱신
- [x] `start_camp_button_test.dart` — 동일하게 갱신
- [x] `flutter test`로 위 3개 위젯 테스트 전체 통과 (10 tests)
- [x] `dart analyze` 이상 없음