### PR TITLE
fix: 방문 시작 후 진행자 세션이 강제 로그아웃되는 문제 수정

### DIFF
--- a/frontend/lib/facilitator/features/main_track/_main_track_body.dart
+++ b/frontend/lib/facilitator/features/main_track/_main_track_body.dart
@@ -173,9 +173,15 @@ class _BusyBodyState extends ConsumerState<_BusyBody> {
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final colors = isDark ? AppColors.dark : AppColors.light;
-    final groupAsync = ref.watch(
-      groupDetailProvider(GroupId(widget.visit.groupId!)),
-    );
+    // groupDetailProvider(GET /groups/{id})는 admin 전용 라우트라 트랙 토큰으로 호출하면
+    // 401을 유발해 세션이 강제 종료된다 — 이미 로그인 시 구독 중인 트랙 스코프 그룹 목록
+    // (GET /tracks/{trackId}/groups)에서 같은 조를 찾아 쓴다.
+    final groupAsync = ref
+        .watch(trackScopedGroupsProvider(widget.trackId))
+        .whenData(
+          (groups) =>
+              groups.firstWhere((g) => g.id == widget.visit.groupId),
+        );
 
     final targetSeconds = widget.targetMinutes != null
         ? widget.targetMinutes! * 60

--- a/frontend/lib/facilitator/features/main_track/main_track_screen.dart
+++ b/frontend/lib/facilitator/features/main_track/main_track_screen.dart
@@ -94,6 +94,7 @@ class _MainTrackScreenState extends ConsumerState<MainTrackScreen> {
             if (_visitJustCompleted != null)
               Positioned.fill(
                 child: VisitSummaryOverlay(
+                  trackId: trackId,
                   visit: _visitJustCompleted!,
                   onDismiss: () => setState(() => _visitJustCompleted = null),
                 ),

--- a/frontend/lib/facilitator/features/visit_summary/visit_summary_overlay.dart
+++ b/frontend/lib/facilitator/features/visit_summary/visit_summary_overlay.dart
@@ -13,11 +13,13 @@ import 'package:cornermon/shared/design_system/tokens/typography.dart';
 /// B5 — 방문 종료 확인 직후 소요시간/편차를 짧게 보여주고 자동으로 사라지는 오버레이.
 class VisitSummaryOverlay extends ConsumerStatefulWidget {
   const VisitSummaryOverlay({
+    required this.trackId,
     required this.visit,
     required this.onDismiss,
     super.key,
   });
 
+  final TrackId trackId;
   final VisitSummary visit;
   final VoidCallback onDismiss;
 
@@ -69,9 +71,15 @@ class _VisitSummaryOverlayState extends ConsumerState<VisitSummaryOverlay> {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final colors = isDark ? AppColors.dark : AppColors.light;
 
-    final groupAsync = ref.watch(
-      groupDetailProvider(GroupId(widget.visit.groupId!)),
-    );
+    // groupDetailProvider(GET /groups/{id})는 admin 전용 라우트라 트랙 토큰으로 호출하면
+    // 401을 유발해 세션이 강제 종료된다 — 이미 로그인 시 구독 중인 트랙 스코프 그룹 목록
+    // (GET /tracks/{trackId}/groups)에서 같은 조를 찾아 쓴다.
+    final groupAsync = ref
+        .watch(trackScopedGroupsProvider(widget.trackId))
+        .whenData(
+          (groups) =>
+              groups.firstWhere((g) => g.id == widget.visit.groupId),
+        );
     final duration = widget.visit.durationSeconds ?? 0;
     final deviation = widget.visit.deviationSeconds ?? 0;
     final deviationColor = deviation > 0

--- a/frontend/test/facilitator/features/main_track_test.dart
+++ b/frontend/test/facilitator/features/main_track_test.dart
@@ -104,7 +104,9 @@ void main() {
           onVisitEnded: onVisitEnded,
         ),
         overrides: [
-          groupDetailProvider(groupId).overrideWith((ref) => fakeGroup()),
+          trackScopedGroupsProvider(
+            trackId,
+          ).overrideWith((ref) => [fakeGroup()]),
           visitActionsProvider(trackId).overrideWith(() => fakeActions),
         ],
       );

--- a/frontend/test/facilitator/features/visit_summary_test.dart
+++ b/frontend/test/facilitator/features/visit_summary_test.dart
@@ -42,6 +42,8 @@ Future<void> _drainAutoDismissTimer(WidgetTester tester) =>
     tester.pump(const Duration(seconds: 3));
 
 void main() {
+  final trackId = TrackId('track-1');
+
   testWidgets('ShouldFormatDurationAsMinutesSeconds', (tester) async {
     // arrange
     final visit = _buildVisit(durationSeconds: 600, deviationSeconds: 0);
@@ -50,11 +52,11 @@ void main() {
     // act
     await tester.pumpWidget(
       buildTestable(
-        VisitSummaryOverlay(visit: visit, onDismiss: () {}),
-        overrides: [groupDetailProvider(GroupId(visit.groupId!)).overrideWith((ref) => group)],
+        VisitSummaryOverlay(trackId: trackId, visit: visit, onDismiss: () {}),
+        overrides: [trackScopedGroupsProvider(trackId).overrideWith((ref) => [group])],
       ),
     );
-    await tester.pump(); // groupDetailProvider(FutureOr) 1틱 대기
+    await tester.pump(); // trackScopedGroupsProvider(FutureOr) 1틱 대기
 
     // assert
     expect(find.text('10:00'), findsOneWidget);
@@ -70,8 +72,8 @@ void main() {
     // act
     await tester.pumpWidget(
       buildTestable(
-        VisitSummaryOverlay(visit: visit, onDismiss: () {}),
-        overrides: [groupDetailProvider(GroupId(visit.groupId!)).overrideWith((ref) => group)],
+        VisitSummaryOverlay(trackId: trackId, visit: visit, onDismiss: () {}),
+        overrides: [trackScopedGroupsProvider(trackId).overrideWith((ref) => [group])],
       ),
     );
     await tester.pump();
@@ -91,9 +93,9 @@ void main() {
     // act: 편차 0
     await tester.pumpWidget(
       buildTestable(
-        VisitSummaryOverlay(visit: zeroVisit, onDismiss: () {}),
+        VisitSummaryOverlay(trackId: trackId, visit: zeroVisit, onDismiss: () {}),
         overrides: [
-          groupDetailProvider(GroupId(zeroVisit.groupId!)).overrideWith((ref) => group),
+          trackScopedGroupsProvider(trackId).overrideWith((ref) => [group]),
         ],
       ),
     );
@@ -108,9 +110,9 @@ void main() {
     final negativeVisit = _buildVisit(deviationSeconds: -30);
     await tester.pumpWidget(
       buildTestable(
-        VisitSummaryOverlay(visit: negativeVisit, onDismiss: () {}),
+        VisitSummaryOverlay(trackId: trackId, visit: negativeVisit, onDismiss: () {}),
         overrides: [
-          groupDetailProvider(GroupId(negativeVisit.groupId!)).overrideWith((ref) => group),
+          trackScopedGroupsProvider(trackId).overrideWith((ref) => [group]),
         ],
       ),
     );
@@ -131,8 +133,8 @@ void main() {
     // act
     await tester.pumpWidget(
       buildTestable(
-        VisitSummaryOverlay(visit: visit, onDismiss: () => dismissCount++),
-        overrides: [groupDetailProvider(GroupId(visit.groupId!)).overrideWith((ref) => group)],
+        VisitSummaryOverlay(trackId: trackId, visit: visit, onDismiss: () => dismissCount++),
+        overrides: [trackScopedGroupsProvider(trackId).overrideWith((ref) => [group])],
       ),
     );
     await tester.pump();
@@ -153,8 +155,8 @@ void main() {
       // act
       await tester.pumpWidget(
         buildTestable(
-          VisitSummaryOverlay(visit: visit, onDismiss: () => dismissCount++),
-          overrides: [groupDetailProvider(GroupId(visit.groupId!)).overrideWith((ref) => group)],
+          VisitSummaryOverlay(trackId: trackId, visit: visit, onDismiss: () => dismissCount++),
+          overrides: [trackScopedGroupsProvider(trackId).overrideWith((ref) => [group])],
         ),
       );
       await tester.pump();


### PR DESCRIPTION
## Summary
- 방문 시작(QR/수동 무관) 직후 진행자 메인 트랙 화면과 방문 종료 오버레이가 `groupDetailProvider`(`GET /groups/{id}`, admin 전용 라우트)를 트랙 토큰으로 호출하고 있었음
- 백엔드가 `admin_sessions`에서 트랙 토큰 해시를 찾지 못해 401을 반환 → `AuthInterceptor`가 즉시 트랙 세션을 강제 종료 → 진행자가 아무 안내 없이 PIN 로그인 화면으로 튕겨나가는 버그였음
- 이미 로그인 시 구독 중인 트랙 스코프 그룹 목록(`GET /tracks/{trackId}/groups`, `trackScopedGroupsProvider`)에서 같은 조를 찾아 쓰도록 교체 — 두 엔드포인트 모두 `mapGroupToDTO`로 동일한 응답 형태를 쓰므로 백엔드 변경 불필요
- PR #125 브랜치(`worktree-agent-afc1d7d9b3d1ee68a`)에서 분기, 테스트를 위해 해당 브랜치로 우선 병합 요청

## Test plan
- [x] `dart analyze lib/ test/` — no issues
- [x] `flutter test test/facilitator/features/main_track_test.dart` — 6/7 통과 (나머지 1개는 base 브랜치에서도 동일하게 실패하는 기존 flaky 테스트, 이번 변경과 무관)
- [x] `flutter test test/facilitator/features/visit_summary_test.dart` — 5/5 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)