### PR TITLE
fix: 캠프 리포트 집계 로직 및 진행 중 사이드바 리포트 메뉴 숨김

### DIFF
--- a/backend/internal/infrastructure/postgres/report_querier.go
+++ b/backend/internal/infrastructure/postgres/report_querier.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"sort"
+	"time"
 
 	"cornermon/backend/internal/domain"
 	"cornermon/backend/internal/errs"
@@ -13,11 +14,12 @@ import (
 )
 
 type pgReportQuerier struct {
-	pool *pgxpool.Pool
+	pool  *pgxpool.Pool
+	nowFn func() time.Time
 }
 
 func NewReportQuerier(pool *pgxpool.Pool) *pgReportQuerier {
-	return &pgReportQuerier{pool: pool}
+	return &pgReportQuerier{pool: pool, nowFn: func() time.Time { return time.Now().UTC() }}
 }
 
 func (r *pgReportQuerier) queries(ctx context.Context) *db.Queries {
@@ -29,6 +31,11 @@ func (r *pgReportQuerier) queries(ctx context.Context) *db.Queries {
 
 func (r *pgReportQuerier) QueryCampReport(ctx context.Context, campID domain.CampID) (*usecase.CampReport, error) {
 	q := r.queries(ctx)
+
+	dbCamp, err := q.GetCamp(ctx, string(campID))
+	if err != nil {
+		return nil, errs.Wrap(ctx, err)
+	}
 
 	dbGroups, err := q.ListGroupsByCamp(ctx, string(campID))
 	if err != nil {
@@ -45,10 +52,10 @@ func (r *pgReportQuerier) QueryCampReport(ctx context.Context, campID domain.Cam
 		return nil, errs.Wrap(ctx, err)
 	}
 
-	return calculateCampReport(campID, dbGroups, dbCorners, dbVisits)
+	return calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, r.nowFn())
 }
 
-func calculateCampReport(campID domain.CampID, dbGroups []db.Group, dbCorners []db.Corner, dbVisits []db.ListVisitsByCampRow) (*usecase.CampReport, error) {
+func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Group, dbCorners []db.Corner, dbVisits []db.ListVisitsByCampRow, now time.Time) (*usecase.CampReport, error) {
 	totalGroups := len(dbGroups)
 	finishedGroupsCount := 0
 
@@ -91,12 +98,16 @@ func calculateCampReport(campID domain.CampID, dbGroups []db.Group, dbCorners []
 	completedVisitsCount := 0
 	manualVisitsCount := 0
 
+	var campDeviationSum float64
+	campDeviationCount := 0
+
 	for i, gr := range groupReports {
 		gID := string(gr.GroupID)
 		completedVisits := groupCompletedVisits[gID]
 		groupReports[i].CompletedCount = len(completedVisits)
 
 		details := make([]usecase.VisitDetail, 0, len(completedVisits))
+		totalDuration := 0
 		for _, cv := range completedVisits {
 			completedVisitsCount++
 			if cv.InputMethod == "MANUAL" {
@@ -113,9 +124,37 @@ func calculateCampReport(campID domain.CampID, dbGroups []db.Group, dbCorners []
 					DurationSec:  duration,
 					DeviationSec: deviation,
 				})
+				totalDuration += duration
+				campDeviationSum += float64(deviation)
+				campDeviationCount++
 			}
 		}
 		groupReports[i].VisitDetails = details
+		groupReports[i].TotalDurationSec = totalDuration
+	}
+
+	avgDeviationSec := 0.0
+	if campDeviationCount > 0 {
+		avgDeviationSec = campDeviationSum / float64(campDeviationCount)
+	}
+
+	programDurationSec := 0
+	var firstVisitStart time.Time
+	hasFirstVisit := false
+	for _, v := range dbVisits {
+		if v.StartedAt.Valid && (!hasFirstVisit || v.StartedAt.Time.Before(firstVisitStart)) {
+			firstVisitStart = v.StartedAt.Time
+			hasFirstVisit = true
+		}
+	}
+	if hasFirstVisit {
+		endRef := now
+		if dbCamp.EndedAt.Valid {
+			endRef = dbCamp.EndedAt.Time
+		}
+		if endRef.After(firstVisitStart) {
+			programDurationSec = int(endRef.Sub(firstVisitStart).Seconds())
+		}
 	}
 
 	cornerReports := make([]usecase.CornerReport, 0, len(dbCorners))
@@ -176,14 +215,16 @@ func calculateCampReport(campID domain.CampID, dbGroups []db.Group, dbCorners []
 	}
 
 	report := &usecase.CampReport{
-		CampID:          campID,
-		TotalGroups:     totalGroups,
-		FinishedGroups:  finishedGroupsCount,
-		TotalVisits:     totalVisits,
-		CompletedVisits: completedVisitsCount,
-		ManualVisits:    manualVisitsCount,
-		CornerReports:   cornerReports,
-		GroupReports:    groupReports,
+		CampID:             campID,
+		TotalGroups:        totalGroups,
+		FinishedGroups:     finishedGroupsCount,
+		TotalVisits:        totalVisits,
+		CompletedVisits:    completedVisitsCount,
+		ManualVisits:       manualVisitsCount,
+		ProgramDurationSec: programDurationSec,
+		AvgDeviationSec:    avgDeviationSec,
+		CornerReports:      cornerReports,
+		GroupReports:       groupReports,
 	}
 
 	return report, nil

--- a/backend/internal/infrastructure/postgres/report_querier_test.go
+++ b/backend/internal/infrastructure/postgres/report_querier_test.go
@@ -36,6 +36,7 @@ func TestCalculateCampReport(t *testing.T) {
 		}
 
 		now := time.Now()
+		dbCamp := db.Camp{ID: "camp-1", EndedAt: pgtype.Timestamptz{Time: now, Valid: true}}
 		dbVisits := []db.ListVisitsByCampRow{
 			{
 				ID:            "visit-1",
@@ -76,7 +77,7 @@ func TestCalculateCampReport(t *testing.T) {
 		}
 
 		// Act
-		report, err := calculateCampReport(campID, dbGroups, dbCorners, dbVisits)
+		report, err := calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, now)
 
 		// Assert
 		if err != nil {
@@ -101,6 +102,28 @@ func TestCalculateCampReport(t *testing.T) {
 		}
 		if report.ManualVisits != 1 {
 			t.Errorf("expected ManualVisits 1, got %d", report.ManualVisits)
+		}
+
+		// visit-1 deviation 0, visit-2 (20min dur - 15min target) = +300, visit-3 (8min dur - 10min target) = -120
+		// avg = (0 + 300 - 120) / 3 = 60
+		if report.AvgDeviationSec != 60 {
+			t.Errorf("expected AvgDeviationSec 60, got %f", report.AvgDeviationSec)
+		}
+
+		// earliest visit start is visit-2 at now-20min, camp ended at `now` -> 20min = 1200s
+		if report.ProgramDurationSec != 1200 {
+			t.Errorf("expected ProgramDurationSec 1200, got %d", report.ProgramDurationSec)
+		}
+
+		var g1Report usecase.GroupReport
+		for _, gr := range report.GroupReports {
+			if gr.GroupID == "group-1" {
+				g1Report = gr
+			}
+		}
+		// group-1: visit-1 duration 600s + visit-2 duration 1080s = 1680s
+		if g1Report.TotalDurationSec != 1680 {
+			t.Errorf("expected group-1 TotalDurationSec 1680, got %d", g1Report.TotalDurationSec)
 		}
 
 		var c1Report usecase.CornerReport
@@ -140,6 +163,7 @@ func TestCalculateCampReport(t *testing.T) {
 		}
 
 		now := time.Now()
+		dbCamp := db.Camp{ID: "camp-2", EndedAt: pgtype.Timestamptz{Time: now, Valid: true}}
 		dbVisits := []db.ListVisitsByCampRow{
 			{
 				ID: "visit-4", GroupID: "group-3", CornerID: "corner-3", TrackID: "track-3",
@@ -165,7 +189,7 @@ func TestCalculateCampReport(t *testing.T) {
 		}
 
 		// Act
-		report, err := calculateCampReport(campID, dbGroups, dbCorners, dbVisits)
+		report, err := calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, now)
 
 		// Assert
 		if err != nil {

--- a/backend/internal/infrastructure/web/report_handler.go
+++ b/backend/internal/infrastructure/web/report_handler.go
@@ -105,12 +105,14 @@ func mapSummary(r *usecase.CampReport) CampSummaryStatsResponse {
 	}
 
 	return CampSummaryStatsResponse{
-		TotalGroups:         r.TotalGroups,
-		FinishedGroupCount:  r.FinishedGroups,
-		CompletionRate:      completionRate,
-		TotalVisits:         r.TotalVisits,
-		VisitCompletionRate: visitCompletionRate,
-		ManualVisitRatio:    manualVisitRatio,
+		TotalGroups:            r.TotalGroups,
+		FinishedGroupCount:     r.FinishedGroups,
+		CompletionRate:         completionRate,
+		TotalVisits:            r.TotalVisits,
+		VisitCompletionRate:    visitCompletionRate,
+		ProgramDurationSeconds: r.ProgramDurationSec,
+		AvgDeviationSeconds:    float32(r.AvgDeviationSec),
+		ManualVisitRatio:       manualVisitRatio,
 	}
 }
 
@@ -131,9 +133,10 @@ func mapReport(r *usecase.CampReport) CampReportResponse {
 	}
 	for _, gr := range r.GroupReports {
 		res.GroupStats = append(res.GroupStats, GroupStatsResponse{
-			GroupID:        string(gr.GroupID),
-			GroupName:      gr.GroupName,
-			CompletedCount: gr.CompletedCount,
+			GroupID:              string(gr.GroupID),
+			GroupName:            gr.GroupName,
+			CompletedCount:       gr.CompletedCount,
+			TotalDurationSeconds: gr.TotalDurationSec,
 		})
 	}
 	return res

--- a/backend/internal/infrastructure/web/report_handler_test.go
+++ b/backend/internal/infrastructure/web/report_handler_test.go
@@ -69,6 +69,36 @@ func TestMapReportShouldMapOverDeviationRatioWhenCornerReportsProvided(t *testin
 	}
 }
 
+func TestMapReportShouldMapCampAndGroupAggregatesWhenReportProvided(t *testing.T) {
+	// Arrange
+	report := &usecase.CampReport{
+		CampID:             "camp-1",
+		ProgramDurationSec: 1200,
+		AvgDeviationSec:    60,
+		GroupReports: []usecase.GroupReport{
+			{GroupID: "group-1", GroupName: "조 1", CompletedCount: 2, TotalDurationSec: 1680},
+		},
+	}
+
+	// Act
+	res := mapReport(report)
+	summary := mapSummary(report)
+
+	// Assert
+	if summary.ProgramDurationSeconds != 1200 {
+		t.Errorf("expected ProgramDurationSeconds 1200, got %d", summary.ProgramDurationSeconds)
+	}
+	if summary.AvgDeviationSeconds != 60 {
+		t.Errorf("expected AvgDeviationSeconds 60, got %f", summary.AvgDeviationSeconds)
+	}
+	if len(res.GroupStats) != 1 {
+		t.Fatalf("expected 1 group stat, got %d", len(res.GroupStats))
+	}
+	if got := res.GroupStats[0].TotalDurationSeconds; got != 1680 {
+		t.Errorf("expected group-1 TotalDurationSeconds 1680, got %d", got)
+	}
+}
+
 func TestGetCurrentReportShoudKeepCampScopeWhenRequestsRunConcurrently(t *testing.T) {
 	// Arrange
 	camps := &campRepositoryStub{camps: map[domain.CampID]*domain.Camp{

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -273,14 +273,16 @@ type ReportQuerier interface {
 
 // CampReport는 캠프 전체 결과 집계 DTO입니다.
 type CampReport struct {
-	CampID          domain.CampID
-	TotalGroups     int
-	FinishedGroups  int
-	TotalVisits     int
-	CompletedVisits int
-	ManualVisits    int
-	CornerReports   []CornerReport
-	GroupReports    []GroupReport
+	CampID             domain.CampID
+	TotalGroups        int
+	FinishedGroups     int
+	TotalVisits        int
+	CompletedVisits    int
+	ManualVisits       int
+	ProgramDurationSec int     // 첫 방문 started_at ~ 캠프 종료 선언 시각(진행 중이면 현재 시각)
+	AvgDeviationSec    float64 // 모든 COMPLETED 방문의 (실제 소요시간 - 목표시간) 평균
+	CornerReports      []CornerReport
+	GroupReports       []GroupReport
 }
 
 // CornerReport는 코너별 분석 집계 DTO입니다.
@@ -297,11 +299,12 @@ type CornerReport struct {
 
 // GroupReport는 조별 분석 집계 DTO입니다.
 type GroupReport struct {
-	GroupID        domain.GroupID
-	GroupName      string
-	IsFinished     bool
-	CompletedCount int
-	VisitDetails   []VisitDetail
+	GroupID          domain.GroupID
+	GroupName        string
+	IsFinished       bool
+	CompletedCount   int
+	TotalDurationSec int // 완료한 모든 방문의 소요시간 합
+	VisitDetails     []VisitDetail
 }
 
 // VisitDetail은 조의 코너별 방문 상세 정보 DTO입니다.

--- a/frontend/lib/admin/widgets/sidebar/admin_sidebar.dart
+++ b/frontend/lib/admin/widgets/sidebar/admin_sidebar.dart
@@ -33,7 +33,6 @@ class AdminSidebar extends ConsumerWidget {
         ('조 현황', Icons.groups_outlined, '/groups'),
         ('기기 관리', Icons.devices_outlined, '/devices'),
         ('메시지', Icons.message_outlined, '/messages/broadcast'),
-        ('리포트', Icons.assessment_outlined, '/report'),
         ('감사 로그', Icons.history_outlined, '/audit-log'),
         ('설정', Icons.settings_outlined, '/settings'),
       ],


### PR DESCRIPTION
## Summary
- `CampSummaryStatsResponse.avgDeviationSeconds`/`programDurationSeconds`, `GroupStatsResponse.totalDurationSeconds`가 응답 DTO에는 선언되어 있었지만 `usecase.CampReport`/`GroupReport`에 대응 필드가 없어 항상 0으로 내려가던 버그를 수정. `docs/domain/analytics-model.md` §1.1/§1.4 정의에 따라 캠프 전체 평균편차, 프로그램 총 소요시간, 조별 총 활동시간 집계 로직을 추가.
- 코너학습(캠프 ACTIVE) 진행 중에는 대시보드에 이미 간단 리포트가 노출되므로, 사이드바 `SidebarMode.operating` 메뉴에서 '리포트' 항목 제거 (캠프 종료 후 `reportOnly` 모드에는 유지).

## Test plan
- [ ] `cd backend && go test ./...` (로컬 환경에 Go 툴체인이 없어 이 세션에서는 실행하지 못함 — PR 전 직접 실행 필요)
- [x] `dart analyze` on 변경된 프론트 파일: 이상 없음
- [x] `report_querier_test.go`/`report_handler_test.go`에 신규 필드 assertion 추가 (평균편차, 프로그램 총 소요시간, 조별 총 활동시간)

🤖 Generated with [Claude Code](https://claude.com/claude-code)