### PR TITLE
fix: 진행자 DM 수신 시 SSE 구독 유지

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ each part's developer guide — **read the relevant one before working there**:
 
 **New worktrees**: Always confirm with the user before creating a new worktree.
 
+**Test integrity**: Never delete, disable, skip, or weaken a failing test merely to make a
+test run pass. Fix the production code or the test's compatibility with the currently used
+library/version while preserving the scenario being verified. Removing a test requires an
+explicit user approval and a documented replacement or rationale.
+
 ---
 
 ## Monorepo Structure

--- a/frontend/lib/facilitator/app.dart
+++ b/frontend/lib/facilitator/app.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../shared/api/ids.dart';
 import '../shared/design_system/theme/facilitator_theme.dart';
-import 'features/main_track/track_event_coordinator.dart';
+import 'realtime/track_event_coordinator.dart';
 import 'router/facilitator_router.dart';
 import 'session/track_session_provider.dart';
 

--- a/frontend/lib/facilitator/app.dart
+++ b/frontend/lib/facilitator/app.dart
@@ -1,14 +1,26 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../shared/api/ids.dart';
 import '../shared/design_system/theme/facilitator_theme.dart';
+import 'features/main_track/track_event_coordinator.dart';
 import 'router/facilitator_router.dart';
+import 'session/track_session_provider.dart';
 
 class FacilitatorApp extends ConsumerWidget {
   const FacilitatorApp({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final trackSession = ref.watch(trackSessionProvider);
+    // SSE 재조회 처리는 특정 화면의 수명에 묶이지 않아야 한다. 대화·공지 등 /main의
+    // 하위 라우트로 이동해도 인증된 트랙 세션 동안 동일한 코디네이터를 유지한다.
+    if (trackSession is TrackSessionAuthenticated) {
+      ref.watch(
+        trackEventCoordinatorProvider(TrackId(trackSession.track.id!)),
+      );
+    }
+
     return MaterialApp.router(
       routerConfig: ref.watch(facilitatorRouterProvider),
       theme: FacilitatorTheme.lightTheme,

--- a/frontend/lib/facilitator/features/main_track/main_track_screen.dart
+++ b/frontend/lib/facilitator/features/main_track/main_track_screen.dart
@@ -13,7 +13,6 @@ import 'package:cornermon/facilitator/session/track_session_provider.dart';
 import '../visit_summary/visit_summary_overlay.dart';
 import '_main_track_body.dart';
 import '_main_track_header.dart';
-import 'track_event_coordinator.dart';
 
 /// B2. 진행자 메인 트랙 화면 — IDLE→BUSY→COMPLETED 핵심 루프(scenarios.md Feature 1).
 class MainTrackScreen extends ConsumerStatefulWidget {
@@ -36,11 +35,6 @@ class _MainTrackScreenState extends ConsumerState<MainTrackScreen> {
     }
 
     final trackId = TrackId(session.track.id!);
-
-    // 코디네이터는 watch만 해서 화면이 떠 있는 동안만 활성화한다 — @riverpod 기본값
-    // (autoDispose)이므로 화면이 unmount되면 코디네이터와 그 안의 trackEvents 구독도
-    // 함께 dispose된다(§04 plan). 반환값(void)은 쓰지 않는다.
-    ref.watch(trackEventCoordinatorProvider(trackId));
 
     final currentVisit = ref
         .watch(currentVisitProvider(trackId))

--- a/frontend/lib/facilitator/features/track_direct/track_direct_screen.dart
+++ b/frontend/lib/facilitator/features/track_direct/track_direct_screen.dart
@@ -26,7 +26,6 @@ class TrackDirectScreen extends ConsumerStatefulWidget {
 class _TrackDirectScreenState extends ConsumerState<TrackDirectScreen> {
   final _inputController = TextEditingController();
   final _messageListController = ScrollController();
-  bool _scrollToBottomAfterSend = false;
 
   @override
   void dispose() {
@@ -63,8 +62,10 @@ class _TrackDirectScreenState extends ConsumerState<TrackDirectScreen> {
         if (next.hasValue) {
           ref.invalidate(unreadDirectMessageCountProvider(trackId));
         }
-        if (_scrollToBottomAfterSend && next.hasValue && !next.isLoading) {
-          _scrollToBottomAfterSend = false;
+        // 관리자 발송으로 SSE가 도착했을 때도 목록은 재조회되지만, ListView의 기존
+        // 위치는 자동으로 바뀌지 않는다. 최신 메시지가 화면 밖에 남지 않도록 목록
+        // 갱신이 완료된 뒤 항상 마지막 메시지로 이동한다.
+        if (next.hasValue && !next.isLoading) {
           WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
         }
       },
@@ -114,13 +115,11 @@ class _TrackDirectScreenState extends ConsumerState<TrackDirectScreen> {
             _QuickReplyRow(
               trackId: trackId,
               colors: colors,
-              onSendSucceeded: () => _scrollToBottomAfterSend = true,
             ),
             _MessageInputRow(
               trackId: trackId,
               controller: _inputController,
               colors: colors,
-              onSendSucceeded: () => _scrollToBottomAfterSend = true,
             ),
           ],
         ),
@@ -180,12 +179,10 @@ class _QuickReplyRow extends ConsumerWidget {
   const _QuickReplyRow({
     required this.trackId,
     required this.colors,
-    required this.onSendSucceeded,
   });
 
   final TrackId trackId;
   final AppColors colors;
-  final VoidCallback onSendSucceeded;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -215,7 +212,6 @@ class _QuickReplyRow extends ConsumerWidget {
                   ref,
                   trackId,
                   label,
-                  onSendSucceeded: onSendSucceeded,
                 ),
               ),
             )
@@ -230,13 +226,11 @@ class _MessageInputRow extends ConsumerWidget {
     required this.trackId,
     required this.controller,
     required this.colors,
-    required this.onSendSucceeded,
   });
 
   final TrackId trackId;
   final TextEditingController controller;
   final AppColors colors;
-  final VoidCallback onSendSucceeded;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -249,7 +243,6 @@ class _MessageInputRow extends ConsumerWidget {
         ref,
         trackId,
         text,
-        onSendSucceeded: onSendSucceeded,
       );
     }
 
@@ -294,16 +287,13 @@ Future<void> _send(
   BuildContext context,
   WidgetRef ref,
   TrackId trackId,
-  String content, {
-  VoidCallback? onSendSucceeded,
-}
+  String content,
 ) async {
   try {
     await ref.read(trackDirectActionsProvider(trackId).notifier).send(content);
     // 화면의 ref로 invalidate한다 — action notifier는 위젯이 watch하지 않는 autoDispose라
     // 전송 직후 폐기되어 그 안에서 invalidate하면 유실될 수 있다.
     if (!context.mounted) return;
-    onSendSucceeded?.call();
     ref.invalidate(trackMessageListProvider(trackId, background: true));
   } catch (_) {
     if (!context.mounted) return;

--- a/frontend/lib/facilitator/features/track_direct/track_direct_screen.dart
+++ b/frontend/lib/facilitator/features/track_direct/track_direct_screen.dart
@@ -26,6 +26,7 @@ class TrackDirectScreen extends ConsumerStatefulWidget {
 class _TrackDirectScreenState extends ConsumerState<TrackDirectScreen> {
   final _inputController = TextEditingController();
   final _messageListController = ScrollController();
+  bool _scrollToBottomAfterListUpdate = false;
 
   @override
   void dispose() {
@@ -37,11 +38,26 @@ class _TrackDirectScreenState extends ConsumerState<TrackDirectScreen> {
   void _scrollToBottom() {
     if (!_messageListController.hasClients) return;
 
+    final maxScrollExtent = _messageListController.position.maxScrollExtent;
     _messageListController.animateTo(
-      _messageListController.position.maxScrollExtent,
+      maxScrollExtent,
       duration: const Duration(milliseconds: 250),
       curve: Curves.easeOut,
     );
+    // lazy ListView는 첫 레이아웃 뒤에도 콘텐츠 추정치를 보정할 수 있다. 다음 두 프레임에
+    // 마지막 위치를 다시 맞춰, 새 항목이 화면 밖에 남지 않게 한다.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!_messageListController.hasClients) return;
+      _messageListController.jumpTo(
+        _messageListController.position.maxScrollExtent,
+      );
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!_messageListController.hasClients) return;
+        _messageListController.jumpTo(
+          _messageListController.position.maxScrollExtent,
+        );
+      });
+    });
   }
 
   @override
@@ -56,20 +72,16 @@ class _TrackDirectScreenState extends ConsumerState<TrackDirectScreen> {
     }
     final trackId = TrackId(sessionState.track.id!);
 
-    ref.listen(
-      trackMessageListProvider(trackId, background: true),
-      (_, next) {
-        if (next.hasValue) {
-          ref.invalidate(unreadDirectMessageCountProvider(trackId));
-        }
-        // 관리자 발송으로 SSE가 도착했을 때도 목록은 재조회되지만, ListView의 기존
-        // 위치는 자동으로 바뀌지 않는다. 최신 메시지가 화면 밖에 남지 않도록 목록
-        // 갱신이 완료된 뒤 항상 마지막 메시지로 이동한다.
-        if (next.hasValue && !next.isLoading) {
-          WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
-        }
-      },
-    );
+    ref.listen(trackMessageListProvider(trackId, background: true), (_, next) {
+      if (next.hasValue) {
+        ref.invalidate(unreadDirectMessageCountProvider(trackId));
+      }
+      if (next.hasValue && !next.isLoading) {
+        // provider 알림은 ListView의 새 itemCount 레이아웃보다 먼저 온다. 이 플래그는
+        // data 분기에서 새 목록을 만든 뒤 post-frame 스크롤을 예약하는 데 쓴다.
+        _scrollToBottomAfterListUpdate = true;
+      }
+    });
     final messagesAsync = ref.watch(
       trackMessageListProvider(trackId, background: true),
     );
@@ -93,6 +105,14 @@ class _TrackDirectScreenState extends ConsumerState<TrackDirectScreen> {
                   final sorted = [...messages]
                     ..sort((a, b) => a.sentAt!.compareTo(b.sentAt!));
 
+                  if (_scrollToBottomAfterListUpdate) {
+                    _scrollToBottomAfterListUpdate = false;
+                    // ListView가 새 메시지를 포함해 레이아웃한 뒤 maxScrollExtent를 읽는다.
+                    WidgetsBinding.instance.addPostFrameCallback(
+                      (_) => _scrollToBottom(),
+                    );
+                  }
+
                   return ListView.builder(
                     key: const Key('direct-message-list'),
                     controller: _messageListController,
@@ -112,10 +132,7 @@ class _TrackDirectScreenState extends ConsumerState<TrackDirectScreen> {
               ),
             ),
             // 빈 스레드여도 입력창은 항상 노출 — 진행자가 먼저 말을 걸 수 있어야 한다.
-            _QuickReplyRow(
-              trackId: trackId,
-              colors: colors,
-            ),
+            _QuickReplyRow(trackId: trackId, colors: colors),
             _MessageInputRow(
               trackId: trackId,
               controller: _inputController,
@@ -176,10 +193,7 @@ class _MessageBubble extends StatelessWidget {
 }
 
 class _QuickReplyRow extends ConsumerWidget {
-  const _QuickReplyRow({
-    required this.trackId,
-    required this.colors,
-  });
+  const _QuickReplyRow({required this.trackId, required this.colors});
 
   final TrackId trackId;
   final AppColors colors;
@@ -207,12 +221,7 @@ class _QuickReplyRow extends ConsumerWidget {
                 ),
                 backgroundColor: colors.bgSurfaceRaised,
                 side: BorderSide(color: colors.border),
-                onPressed: () => _send(
-                  context,
-                  ref,
-                  trackId,
-                  label,
-                ),
+                onPressed: () => _send(context, ref, trackId, label),
               ),
             )
             .toList(),
@@ -238,12 +247,7 @@ class _MessageInputRow extends ConsumerWidget {
       final text = controller.text.trim();
       if (text.isEmpty) return;
       controller.clear();
-      await _send(
-        context,
-        ref,
-        trackId,
-        text,
-      );
+      await _send(context, ref, trackId, text);
     }
 
     return Padding(

--- a/frontend/lib/facilitator/realtime/track_event_coordinator.dart
+++ b/frontend/lib/facilitator/realtime/track_event_coordinator.dart
@@ -14,11 +14,16 @@ import 'package:cornermon/facilitator/session/track_session_provider.dart';
 
 part 'track_event_coordinator.g.dart';
 
-/// SSE 이벤트 분기는 위젯이 아니라 이 전용 Notifier에 둔다 — 위젯 build() 안에서 스트림
-/// 값에 반응해 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가
-/// 날 수 있다. ref.listen은 provider의 build() 안에서 쓰는 게 표준 패턴이고(콜백이 프레임
-/// 이후 비동기로 실행되어 "빌드 도중 변경" 제약이 없음), 화면(위젯)은 이 결과를 watch만 해서
-/// 생명주기(자동 dispose)만 공유한다(§04 plan).
+/// 인증된 트랙 세션의 SSE 수신·재조회 경계를 한 곳에서 관리한다.
+///
+/// 메시지·공지, 방문 상태, 세션 종료는 서로 다른 도메인 관심사지만, 현재는 모두 같은 트랙
+/// 세션의 단일 SSE 연결에서 도착하고 각 provider를 재조회시키는 얇은 어댑터다. 따라서 지금은
+/// 연결·재연결·세션 수명을 한 코디네이터에 둔다. 각 이벤트에 독자적인 정책 또는 화면별 구독
+/// 수명이 생길 때에만 메시지/방문/세션 코디네이터로 분리한다.
+///
+/// 이벤트 분기는 위젯이 아니라 이 Notifier에 둔다. 위젯 build() 안에서 스트림 값에 반응해
+/// 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가 날 수 있다.
+/// 화면은 이 결과만 watch하고, 앱 루트가 인증 세션 동안의 생명주기를 소유한다.
 @riverpod
 class TrackEventCoordinator extends _$TrackEventCoordinator {
   @override

--- a/frontend/lib/facilitator/realtime/track_event_coordinator.g.dart
+++ b/frontend/lib/facilitator/realtime/track_event_coordinator.g.dart
@@ -8,11 +8,16 @@ part of 'track_event_coordinator.dart';
 
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint, type=warning
-/// SSE 이벤트 분기는 위젯이 아니라 이 전용 Notifier에 둔다 — 위젯 build() 안에서 스트림
-/// 값에 반응해 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가
-/// 날 수 있다. ref.listen은 provider의 build() 안에서 쓰는 게 표준 패턴이고(콜백이 프레임
-/// 이후 비동기로 실행되어 "빌드 도중 변경" 제약이 없음), 화면(위젯)은 이 결과를 watch만 해서
-/// 생명주기(자동 dispose)만 공유한다(§04 plan).
+/// 인증된 트랙 세션의 SSE 수신·재조회 경계를 한 곳에서 관리한다.
+///
+/// 메시지·공지, 방문 상태, 세션 종료는 서로 다른 도메인 관심사지만, 현재는 모두 같은 트랙
+/// 세션의 단일 SSE 연결에서 도착하고 각 provider를 재조회시키는 얇은 어댑터다. 따라서 지금은
+/// 연결·재연결·세션 수명을 한 코디네이터에 둔다. 각 이벤트에 독자적인 정책 또는 화면별 구독
+/// 수명이 생길 때에만 메시지/방문/세션 코디네이터로 분리한다.
+///
+/// 이벤트 분기는 위젯이 아니라 이 Notifier에 둔다. 위젯 build() 안에서 스트림 값에 반응해
+/// 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가 날 수 있다.
+/// 화면은 이 결과만 watch하고, 앱 루트가 인증 세션 동안의 생명주기를 소유한다.
 
 @ProviderFor(TrackEventCoordinator)
 final trackEventCoordinatorProvider = TrackEventCoordinatorFamily._();

--- a/frontend/lib/shared/api/providers/corner_track_providers.dart
+++ b/frontend/lib/shared/api/providers/corner_track_providers.dart
@@ -36,7 +36,7 @@ Future<Corner> cornerDetail(Ref ref, CornerId id) async {
 /// TrackAuth로 자기 트랙이 속한 코너를 조회한다(GET /tracks/{trackId}/corner) — `cornerDetailProvider`와
 /// 달리 AdminAuth가 아니라 진행자 세션 토큰으로 호출되므로 크로스 트랙 관리자 정보(activeTracks 등)는 오지 않는다.
 /// 트랙 세션은 무만료라 로그인 스냅샷(`session.corner`)이 오래됐을 수 있으므로 화면 진입 시 한 번
-/// 조회하고, `corners_updated` SSE(track_event_coordinator.dart) 수신 시 다시 무효화해 최신
+/// 조회하고, `corners_updated` SSE(realtime/track_event_coordinator.dart) 수신 시 다시 무효화해 최신
 /// targetMinutes를 반영한다.
 @riverpod
 Future<Corner> trackCorner(Ref ref, TrackId trackId) async {

--- a/frontend/test/facilitator/features/track_direct_test.dart
+++ b/frontend/test/facilitator/features/track_direct_test.dart
@@ -169,65 +169,6 @@ void main() {
     );
   });
 
-  testWidgets('ShouldScrollToLatestMessageWhenAdministratorMessageArrives', (tester) async {
-    // arrange
-    final initialMessages = List.generate(
-      30,
-      (index) => _buildMessage(
-        id: 'message-$index',
-        content: '메시지 $index',
-        senderRole: MessageSenderRoleEnum.ADMIN,
-      ),
-    );
-    final messagesState = StateProvider<List<Message>>(
-      (ref) => initialMessages,
-    );
-    await tester.pumpWidget(
-      buildTestable(
-        const TrackDirectScreen(),
-        overrides: [
-          trackSessionProvider.overrideWith(
-            () => _FakeTrackSession(buildAuthenticatedState()),
-          ),
-          trackMessageListProvider(
-            trackId,
-            background: true,
-          ).overrideWith((ref) => ref.watch(messagesState)),
-        ],
-      ),
-    );
-    await tester.pumpAndSettle();
-    final scrollable = tester.state<ScrollableState>(
-      find.descendant(
-        of: find.byKey(const Key('direct-message-list')),
-        matching: find.byType(Scrollable),
-      ),
-    );
-    scrollable.position.jumpTo(0);
-
-    // act: SSE 재조회 결과에 관리자가 보낸 최신 메시지가 추가된다.
-    final container = ProviderScope.containerOf(
-      tester.element(find.byType(TrackDirectScreen)),
-      listen: false,
-    );
-    container.read(messagesState.notifier).state = [
-      ...initialMessages,
-      _buildMessage(
-        id: 'message-new',
-        content: '관리자 새 메시지',
-        senderRole: MessageSenderRoleEnum.ADMIN,
-      ),
-    ];
-    await tester.pumpAndSettle();
-
-    // assert
-    expect(find.text('관리자 새 메시지'), findsOneWidget);
-    expect(
-      scrollable.position.pixels,
-      closeTo(scrollable.position.maxScrollExtent, 0.1),
-    );
-  });
-
   testWidgets('ShouldSendQuickReplyContentWhenChipTapped', (tester) async {
     // arrange
     final fakeActions = _FakeTrackDirectActions();

--- a/frontend/test/facilitator/features/track_direct_test.dart
+++ b/frontend/test/facilitator/features/track_direct_test.dart
@@ -169,6 +169,65 @@ void main() {
     );
   });
 
+  testWidgets('ShouldScrollToLatestMessageWhenAdministratorMessageArrives', (tester) async {
+    // arrange
+    final initialMessages = List.generate(
+      30,
+      (index) => _buildMessage(
+        id: 'message-$index',
+        content: '메시지 $index',
+        senderRole: MessageSenderRoleEnum.ADMIN,
+      ),
+    );
+    final messagesState = StateProvider<List<Message>>(
+      (ref) => initialMessages,
+    );
+    await tester.pumpWidget(
+      buildTestable(
+        const TrackDirectScreen(),
+        overrides: [
+          trackSessionProvider.overrideWith(
+            () => _FakeTrackSession(buildAuthenticatedState()),
+          ),
+          trackMessageListProvider(
+            trackId,
+            background: true,
+          ).overrideWith((ref) => ref.watch(messagesState)),
+        ],
+      ),
+    );
+    await tester.pumpAndSettle();
+    final scrollable = tester.state<ScrollableState>(
+      find.descendant(
+        of: find.byKey(const Key('direct-message-list')),
+        matching: find.byType(Scrollable),
+      ),
+    );
+    scrollable.position.jumpTo(0);
+
+    // act: SSE 재조회 결과에 관리자가 보낸 최신 메시지가 추가된다.
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(TrackDirectScreen)),
+      listen: false,
+    );
+    container.read(messagesState.notifier).state = [
+      ...initialMessages,
+      _buildMessage(
+        id: 'message-new',
+        content: '관리자 새 메시지',
+        senderRole: MessageSenderRoleEnum.ADMIN,
+      ),
+    ];
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(find.text('관리자 새 메시지'), findsOneWidget);
+    expect(
+      scrollable.position.pixels,
+      closeTo(scrollable.position.maxScrollExtent, 0.1),
+    );
+  });
+
   testWidgets('ShouldSendQuickReplyContentWhenChipTapped', (tester) async {
     // arrange
     final fakeActions = _FakeTrackDirectActions();

--- a/frontend/test/facilitator/features/track_direct_test.dart
+++ b/frontend/test/facilitator/features/track_direct_test.dart
@@ -5,6 +5,8 @@ import 'package:cornermon/shared/api/domain_aliases.dart';
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/message_providers.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart' show Override;
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../test_utils/widget_test_helpers.dart';
@@ -54,10 +56,28 @@ Message _buildMessage({
   );
 }
 
+class _IncomingMessages extends Notifier<List<Message>> {
+  @override
+  List<Message> build() => List.generate(
+    30,
+    (index) => _buildMessage(
+      id: 'message-$index',
+      content: '메시지 $index',
+      senderRole: MessageSenderRoleEnum.ADMIN,
+    ),
+  );
+
+  void append(Message message) => state = [...state, message];
+}
+
+final _incomingMessagesProvider =
+    NotifierProvider<_IncomingMessages, List<Message>>(_IncomingMessages.new);
+
 void main() {
   final trackId = TrackId('track-1');
 
-  TrackSessionAuthenticated buildAuthenticatedState() => TrackSessionAuthenticated(
+  TrackSessionAuthenticated buildAuthenticatedState() =>
+      TrackSessionAuthenticated(
         trackToken: 'test-token',
         track: Track(
           (b) => b
@@ -73,18 +93,25 @@ void main() {
         ),
       );
 
+  List<Override> directScreenOverrides(List<Override> overrides) => [
+    ...overrides,
+    unreadDirectMessageCountProvider(trackId).overrideWith((ref) async => 0),
+  ];
+
   testWidgets('ShouldShowEmptyStateWhenThreadHasNoMessagesYet', (tester) async {
     // arrange & act
     await tester.pumpWidget(
       buildTestable(
         const TrackDirectScreen(),
-        overrides: [
-          trackSessionProvider.overrideWith(() => _FakeTrackSession(buildAuthenticatedState())),
+        overrides: directScreenOverrides([
+          trackSessionProvider.overrideWith(
+            () => _FakeTrackSession(buildAuthenticatedState()),
+          ),
           trackMessageListProvider(
             trackId,
             background: true,
           ).overrideWith((ref) async => <Message>[]),
-        ],
+        ]),
       ),
     );
     await tester.pump();
@@ -94,20 +121,24 @@ void main() {
     expect(find.byType(TextField), findsOneWidget);
   });
 
-  testWidgets('ShouldAllowFacilitatorToSendFirstMessageOnEmptyThread', (tester) async {
+  testWidgets('ShouldAllowFacilitatorToSendFirstMessageOnEmptyThread', (
+    tester,
+  ) async {
     // arrange
     final fakeActions = _FakeTrackDirectActions();
     await tester.pumpWidget(
       buildTestable(
         const TrackDirectScreen(),
-        overrides: [
-          trackSessionProvider.overrideWith(() => _FakeTrackSession(buildAuthenticatedState())),
+        overrides: directScreenOverrides([
+          trackSessionProvider.overrideWith(
+            () => _FakeTrackSession(buildAuthenticatedState()),
+          ),
           trackMessageListProvider(
             trackId,
             background: true,
           ).overrideWith((ref) async => <Message>[]),
           trackDirectActionsProvider(trackId).overrideWith(() => fakeActions),
-        ],
+        ]),
       ),
     );
     await tester.pump();
@@ -135,7 +166,7 @@ void main() {
     await tester.pumpWidget(
       buildTestable(
         const TrackDirectScreen(),
-        overrides: [
+        overrides: directScreenOverrides([
           trackSessionProvider.overrideWith(
             () => _FakeTrackSession(buildAuthenticatedState()),
           ),
@@ -144,7 +175,7 @@ void main() {
             background: true,
           ).overrideWith((ref) async => messages),
           trackDirectActionsProvider(trackId).overrideWith(() => fakeActions),
-        ],
+        ]),
       ),
     );
     await tester.pumpAndSettle();
@@ -169,20 +200,80 @@ void main() {
     );
   });
 
+  testWidgets(
+    'ShouldShowLatestDirectMessageWhenMessageListRefreshesWhileScreenIsOpen',
+    (tester) async {
+      // arrange
+      await tester.pumpWidget(
+        buildTestable(
+          const TrackDirectScreen(),
+          overrides: directScreenOverrides([
+            trackSessionProvider.overrideWith(
+              () => _FakeTrackSession(buildAuthenticatedState()),
+            ),
+            trackMessageListProvider(
+              trackId,
+              background: true,
+            ).overrideWith((ref) => ref.watch(_incomingMessagesProvider)),
+          ]),
+        ),
+      );
+      await tester.pumpAndSettle();
+      final scrollable = tester.state<ScrollableState>(
+        find.descendant(
+          of: find.byKey(const Key('direct-message-list')),
+          matching: find.byType(Scrollable),
+        ),
+      );
+      scrollable.position.jumpTo(0);
+      final container = tester.container();
+      container
+          .read(_incomingMessagesProvider.notifier)
+          .append(
+            _buildMessage(
+              id: 'message-new',
+              content: '관리자 새 메시지',
+              senderRole: MessageSenderRoleEnum.ADMIN,
+            ),
+          );
+
+      // act: SSE 수신·provider 무효화는 TrackEventCoordinator 단위 테스트에서 검증한다.
+      // 이 화면은 갱신된 목록이 전달됐을 때 최신 메시지를 보이도록 하는 책임만 검증한다.
+      await tester.pumpAndSettle();
+
+      // assert
+      expect(
+        container
+            .read(trackMessageListProvider(trackId, background: true))
+            .requireValue
+            .last
+            .content,
+        '관리자 새 메시지',
+      );
+      expect(find.text('관리자 새 메시지'), findsOneWidget);
+      expect(
+        scrollable.position.pixels,
+        closeTo(scrollable.position.maxScrollExtent, 0.1),
+      );
+    },
+  );
+
   testWidgets('ShouldSendQuickReplyContentWhenChipTapped', (tester) async {
     // arrange
     final fakeActions = _FakeTrackDirectActions();
     await tester.pumpWidget(
       buildTestable(
         const TrackDirectScreen(),
-        overrides: [
-          trackSessionProvider.overrideWith(() => _FakeTrackSession(buildAuthenticatedState())),
+        overrides: directScreenOverrides([
+          trackSessionProvider.overrideWith(
+            () => _FakeTrackSession(buildAuthenticatedState()),
+          ),
           trackMessageListProvider(
             trackId,
             background: true,
           ).overrideWith((ref) async => <Message>[]),
           trackDirectActionsProvider(trackId).overrideWith(() => fakeActions),
-        ],
+        ]),
       ),
     );
     await tester.pump();
@@ -195,7 +286,9 @@ void main() {
     expect(fakeActions.sentContents, ['인원부족']);
   });
 
-  testWidgets('ShouldOrderMessagesOldestFirstAndDistinguishSenderRole', (tester) async {
+  testWidgets('ShouldOrderMessagesOldestFirstAndDistinguishSenderRole', (
+    tester,
+  ) async {
     // arrange: 저장 순서를 일부러 뒤섞어 정렬 로직을 검증한다.
     final newer = _buildMessage(
       id: 'm-2',
@@ -214,13 +307,15 @@ void main() {
     await tester.pumpWidget(
       buildTestable(
         const TrackDirectScreen(),
-        overrides: [
-          trackSessionProvider.overrideWith(() => _FakeTrackSession(buildAuthenticatedState())),
+        overrides: directScreenOverrides([
+          trackSessionProvider.overrideWith(
+            () => _FakeTrackSession(buildAuthenticatedState()),
+          ),
           trackMessageListProvider(
             trackId,
             background: true,
           ).overrideWith((ref) async => [newer, older]),
-        ],
+        ]),
       ),
     );
     await tester.pump();
@@ -233,18 +328,22 @@ void main() {
 
   testWidgets('ShouldShowSnackBarWhenSendFails', (tester) async {
     // arrange
-    final fakeActions = _FakeTrackDirectActions(errorToThrow: Exception('network error'));
+    final fakeActions = _FakeTrackDirectActions(
+      errorToThrow: Exception('network error'),
+    );
     await tester.pumpWidget(
       buildTestable(
         const TrackDirectScreen(),
-        overrides: [
-          trackSessionProvider.overrideWith(() => _FakeTrackSession(buildAuthenticatedState())),
+        overrides: directScreenOverrides([
+          trackSessionProvider.overrideWith(
+            () => _FakeTrackSession(buildAuthenticatedState()),
+          ),
           trackMessageListProvider(
             trackId,
             background: true,
           ).overrideWith((ref) async => <Message>[]),
           trackDirectActionsProvider(trackId).overrideWith(() => fakeActions),
-        ],
+        ]),
       ),
     );
     await tester.pump();

--- a/frontend/test/facilitator/features/track_event_coordinator_test.dart
+++ b/frontend/test/facilitator/features/track_event_coordinator_test.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:cornermon/facilitator/features/main_track/track_event_coordinator.dart';
+import 'package:cornermon/facilitator/realtime/track_event_coordinator.dart';
 import 'package:cornermon/facilitator/session/device_trust_provider.dart';
 import 'package:cornermon/facilitator/session/track_session_provider.dart';
 import 'package:cornermon/shared/api/domain_aliases.dart';

--- a/frontend/test/shared/api/sse/sse_client_test.dart
+++ b/frontend/test/shared/api/sse/sse_client_test.dart
@@ -71,10 +71,7 @@ void main() {
       // arrange / act / assert
       expect(
         () => SseClient(
-          SseTransport(
-            Dio(),
-            receiveTimeout: const Duration(seconds: 40),
-          ),
+          SseTransport(Dio(), receiveTimeout: const Duration(seconds: 40)),
           heartbeatTimeout: const Duration(seconds: 40),
         ),
         throwsArgumentError,
@@ -83,7 +80,8 @@ void main() {
 
     test('ShouldParseDataLineIntoSseNotification', () async {
       // arrange — data: 라인 자체가 완전한 SSENotification JSON이다(00_overview.md §2.3).
-      const frame = 'event: track_updated\ndata: {"event":"track_updated","scope":{"kind":"track","trackId":"t1"}}\n\n';
+      const frame =
+          'event: track_updated\ndata: {"event":"track_updated","scope":{"kind":"track","trackId":"t1"}}\n\n';
       final dio = _buildFakeDio(() => Stream.value(_bytes(frame)));
       final sseClient = _buildSseClient(dio);
 
@@ -97,10 +95,28 @@ void main() {
       expect(events.single.scope?.trackId, 't1');
     });
 
+    test('ShouldParseMessagesChangedNotificationForTrackScope', () async {
+      // arrange
+      const frame =
+          'event: messages_changed\ndata: {"event":"messages_changed","scope":{"kind":"track","trackId":"t1"}}\n\n';
+      final dio = _buildFakeDio(() => Stream.value(_bytes(frame)));
+      final sseClient = _buildSseClient(dio);
+
+      // act
+      final events = await sseClient.connect('/events/track/t1').toList();
+
+      // assert
+      expect(events, hasLength(1));
+      expect(events.single.event, SSENotificationEventEnum.messagesChanged);
+      expect(events.single.scope?.kind, SSEScopeKindEnum.track);
+      expect(events.single.scope?.trackId, 't1');
+    });
+
     test('ShouldIgnoreHeartbeatCommentLines', () async {
       // arrange
       const heartbeat = ': heartbeat\n\n';
-      const realFrame = 'event: camp_updated\ndata: {"event":"camp_updated","scope":{"kind":"camp"}}\n\n';
+      const realFrame =
+          'event: camp_updated\ndata: {"event":"camp_updated","scope":{"kind":"camp"}}\n\n';
       final dio = _buildFakeDio(
         () => Stream.fromIterable([
           _bytes(heartbeat),
@@ -142,7 +158,8 @@ void main() {
     test('ShouldSkipMalformedFrameWithoutBreakingSubsequentFrames', () async {
       // arrange — data가 JSON으로 파싱 불가능한 깨진 프레임 뒤에 정상 프레임을 이어붙인다.
       const malformedFrame = 'event: track_updated\ndata: {not-valid-json}\n\n';
-      const validFrame = 'event: groups_updated\ndata: {"event":"groups_updated","scope":{"kind":"camp"}}\n\n';
+      const validFrame =
+          'event: groups_updated\ndata: {"event":"groups_updated","scope":{"kind":"camp"}}\n\n';
       final dio = _buildFakeDio(
         () => Stream.value(_bytes('$malformedFrame$validFrame')),
       );
@@ -157,27 +174,30 @@ void main() {
       expect(events.single.scope?.kind, SSEScopeKindEnum.camp);
     });
 
-    test('ShouldCallOnConnectedOnceWhenHttpResponseArrivesRegardlessOfDataArrival', () async {
-      // arrange — 데이터를 전혀 안 보내는 스트림이라도 HTTP 응답 자체는 성공한다.
-      final neverEmitting = StreamController<Uint8List>();
-      addTearDown(neverEmitting.close);
-      final dio = _buildFakeDio(() => neverEmitting.stream);
-      final sseClient = _buildSseClient(
-        dio,
-        heartbeatTimeout: const Duration(seconds: 5),
-      );
-      var connectedCount = 0;
+    test(
+      'ShouldCallOnConnectedOnceWhenHttpResponseArrivesRegardlessOfDataArrival',
+      () async {
+        // arrange — 데이터를 전혀 안 보내는 스트림이라도 HTTP 응답 자체는 성공한다.
+        final neverEmitting = StreamController<Uint8List>();
+        addTearDown(neverEmitting.close);
+        final dio = _buildFakeDio(() => neverEmitting.stream);
+        final sseClient = _buildSseClient(
+          dio,
+          heartbeatTimeout: const Duration(seconds: 5),
+        );
+        var connectedCount = 0;
 
-      // act
-      final sub = sseClient
-          .connect('/events/track/t1', onConnected: () => connectedCount++)
-          .listen((_) {});
-      addTearDown(sub.cancel);
-      await Future<void>.delayed(const Duration(milliseconds: 50));
+        // act
+        final sub = sseClient
+            .connect('/events/track/t1', onConnected: () => connectedCount++)
+            .listen((_) {});
+        addTearDown(sub.cancel);
+        await Future<void>.delayed(const Duration(milliseconds: 50));
 
-      // assert — 도메인 알림이 하나도 없어도 onConnected는 이미 1회 호출돼 있어야 한다.
-      expect(connectedCount, 1);
-    });
+        // assert — 도메인 알림이 하나도 없어도 onConnected는 이미 1회 호출돼 있어야 한다.
+        expect(connectedCount, 1);
+      },
+    );
 
     test('ShouldCallOnDisconnectedOnceWhenHeartbeatTimeoutElapses', () async {
       // arrange
@@ -206,7 +226,8 @@ void main() {
 
     test('ShouldCallOnDisconnectedOnceWhenStreamEndsNormally', () async {
       // arrange
-      const frame = 'event: track_updated\ndata: {"event":"track_updated","scope":{"kind":"track","trackId":"t1"}}\n\n';
+      const frame =
+          'event: track_updated\ndata: {"event":"track_updated","scope":{"kind":"track","trackId":"t1"}}\n\n';
       final dio = _buildFakeDio(() => Stream.value(_bytes(frame)));
       final sseClient = _buildSseClient(dio);
       var connectedCount = 0;


### PR DESCRIPTION
## 변경 사항
- 진행자 앱 루트에서 인증된 트랙 세션 동안 SSE 코디네이터를 유지합니다.
- 다이렉트 대화 등 /main 하위 라우트에서도 messages_changed 수신 후 목록과 미확인 수를 재조회합니다.
- 목록 갱신 뒤 최신 메시지가 화면 밖에 남지 않도록 마지막 메시지로 이동합니다.

## 원인
SSE 코디네이터가 MainTrackScreen 수명에만 묶여 있었습니다. 서버 로그상 이벤트는 대상 트랙 구독자에게 전달됐지만, 대화 화면에서는 진행자 메시지 목록 재조회 요청이 이어지지 않았습니다.

## 검증
- Docker: cornermon-flutter:3.44.7 (Dart 3.12.2)
- flutter test test/facilitator/features/track_direct_test.dart test/facilitator/features/track_event_coordinator_test.dart 통과 (16 tests)
- git diff --check 통과

Closes #188