### PR TITLE
fix: 관리자 다이렉트 메시지 전송 후 자동 스크롤

### DIFF
--- a/frontend/lib/admin/features/track_direct/_chat_thread_pane.dart
+++ b/frontend/lib/admin/features/track_direct/_chat_thread_pane.dart
@@ -31,10 +31,13 @@ class ChatThreadPane extends ConsumerStatefulWidget {
 
 class _ChatThreadPaneState extends ConsumerState<ChatThreadPane> {
   final _input = TextEditingController();
+  final _messageListController = ScrollController();
+  bool _scrollToBottomAfterSend = false;
 
   @override
   void dispose() {
     _input.dispose();
+    _messageListController.dispose();
     super.dispose();
   }
 
@@ -59,11 +62,22 @@ class _ChatThreadPaneState extends ConsumerState<ChatThreadPane> {
     );
   }
 
+  void _scrollToBottom() {
+    if (!_messageListController.hasClients) return;
+
+    _messageListController.animateTo(
+      _messageListController.position.maxScrollExtent,
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOut,
+    );
+  }
+
   Future<void> _send() async {
     final text = _input.text.trim();
     if (text.isEmpty) return;
     _input.clear();
     await ref.read(sendDirectMessageProvider(widget.trackId, text).future);
+    _scrollToBottomAfterSend = true;
     ref.invalidate(trackMessageListProvider(widget.trackId, background: false));
     ref.invalidate(trackDirectSummariesProvider(widget.campId));
   }
@@ -83,6 +97,10 @@ class _ChatThreadPaneState extends ConsumerState<ChatThreadPane> {
       if (next.hasValue) {
         ref.invalidate(trackDirectSummariesProvider(widget.campId));
       }
+      if (_scrollToBottomAfterSend && next.hasValue && !next.isLoading) {
+        _scrollToBottomAfterSend = false;
+        WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
+      }
     });
 
     return Column(
@@ -96,6 +114,8 @@ class _ChatThreadPaneState extends ConsumerState<ChatThreadPane> {
                 return const EmptyState(message: '아직 나눈 대화가 없습니다');
               }
               return ListView.builder(
+                key: const Key('admin-direct-message-list'),
+                controller: _messageListController,
                 padding: const EdgeInsets.all(AppSpacing.space4),
                 itemCount: items.length,
                 itemBuilder: (context, index) =>

--- a/frontend/test/admin/features/track_direct/track_direct_screen_test.dart
+++ b/frontend/test/admin/features/track_direct/track_direct_screen_test.dart
@@ -194,5 +194,63 @@ void main() {
         expect(find.byType(TextField), findsNothing);
       },
     );
+
+    testWidgets('ShouldScrollToLatestMessageWhenSendSucceeds', (tester) async {
+      // arrange
+      final trackId = TrackId('t1');
+      final messages = List.generate(
+        30,
+        (index) => _msg(
+          MessageResponseSenderRoleEnum.TRACK,
+          '메시지 $index',
+          DateTime(2026, 1, 1, 0, index),
+        ),
+      );
+      await _pump(
+        tester,
+        campId: campId,
+        tracks: [_track(trackId.value, 1, 'c1')],
+        extraOverrides: [
+          trackMessageListProvider(
+            trackId,
+            background: true,
+          ).overrideWith((ref) async => messages),
+          trackMessageListProvider(
+            trackId,
+            background: false,
+          ).overrideWith((ref) async => messages),
+          sendDirectMessageProvider(
+            trackId,
+            '확인했습니다',
+          ).overrideWith(
+            (ref) async => _msg(
+              MessageResponseSenderRoleEnum.ADMIN,
+              '확인했습니다',
+              DateTime(2026, 1, 1),
+            ),
+          ),
+        ],
+      );
+      await tester.tap(find.text('코너 1 · 1번 트랙'));
+      await tester.pumpAndSettle();
+      final scrollable = tester.state<ScrollableState>(
+        find.descendant(
+          of: find.byKey(const Key('admin-direct-message-list')),
+          matching: find.byType(Scrollable),
+        ),
+      );
+      scrollable.position.jumpTo(0);
+
+      // act
+      await tester.enterText(find.byType(TextField), '확인했습니다');
+      await tester.tap(find.byIcon(Icons.send_rounded));
+      await tester.pumpAndSettle();
+
+      // assert
+      expect(
+        scrollable.position.pixels,
+        closeTo(scrollable.position.maxScrollExtent, 0.1),
+      );
+    });
   });
 }


### PR DESCRIPTION
## 변경 사항
- 관리자가 다이렉트 메시지 전송에 성공하면 목록 갱신 완료 후 최신 메시지까지 자동 스크롤합니다.
- 진행자 화면과 동일하게 post-frame 콜백에서 스크롤 컨트롤러를 사용합니다.
- 전송 성공 시 최하단 도달을 검증하는 관리자 위젯 테스트를 추가했습니다.

## 변경 이유
관리자 화면은 메시지 전송 후 목록 위치가 유지되어 최신 발신 메시지를 바로 확인할 수 없었습니다.

## 검증
- Docker: Flutter 3.44.7 / Dart 3.12.2
- flutter test test/admin/features/track_direct/track_direct_screen_test.dart 통과 (5 tests)
- dart analyze lib/admin/features/track_direct test/admin/features/track_direct 통과
- git diff --check 통과