### PR TITLE
feat: 모바일 내보내기 저장 위치 선택 제공

### DIFF
--- a/frontend/docs/artifacts/plan/20260722_issue_193_export_save_location_plan_.md
+++ b/frontend/docs/artifacts/plan/20260722_issue_193_export_save_location_plan_.md
@@ -39,6 +39,7 @@
 - [x] 저장 취소(null)는 error state와 오류 SnackBar를 만들지 않는다.
 - [x] 공유 선택은 기존 `Printing.sharePdf`/`SharePlus` 시트를 계속 사용한다.
 - [x] 저장/공유 선택 메뉴는 화면 하단 바텀시트가 아니라 트리거 버튼 바로 아래에서 연다.
+- [x] 선택 메뉴는 design-system.md의 raised surface·12px 모서리·테두리, 44pt 이상 터치 영역과 본문 강조/캡션 타이포 위계를 따른다.
 - [x] 기존 이미지 `cornermon-flutter:3.44.7`로 관련 테스트와 정적 분석을 실행하며 새 이미지를 pull하지 않는다.
 - [x] `flutter analyze lib` 통과, #193 관련 controller·widget 테스트 32건 통과.
 - [ ] 전체 `flutter test`는 #193 범위 밖 기존 실패 5건으로 통과하지 못함(변경하지 않음).

--- a/frontend/docs/artifacts/plan/20260722_issue_193_export_save_location_plan_.md
+++ b/frontend/docs/artifacts/plan/20260722_issue_193_export_save_location_plan_.md
@@ -1,0 +1,43 @@
+# Issue #193 모바일 내보내기 저장 위치 선택 계획
+
+## 1. 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-1: PDF 기기에 저장 | 사용자가 PDF 저장 위치를 선택하고, 취소하면 조용히 복귀한다. | **프로덕션 핵심 로직** |
+| **P0** | UC-2: 전체 PIN XLSX 기기에 저장 | 사용자가 XLSX 저장 위치를 선택하고, 올바른 이름·MIME으로 저장한다. | **프로덕션 핵심 로직** |
+| **P0** | UC-3: 다른 앱으로 공유 | 기존 플랫폼 공유 시트를 파일 형식별로 그대로 연다. | **프로덕션 핵심 로직** |
+| P1 | UC-4: 저장/공유 오류 피드백 | 저장 취소와 오류를 구별해 각 화면의 기존 SnackBar 규칙을 보존한다. | 테스트/검증용 |
+
+## 2. 설계와 책임
+
+- `lib/shared/export/export_file.dart` **(신규)**: `file_saver` 네이티브 파일 선택기를 Provider 포트로 감싼다. `saveAs`의 nullable path를 결과값으로 변환하여 취소를 성공/오류와 분리하고, PDF/XLSX의 확장자와 MIME type을 한 곳에서 보장한다.
+- 기능별 controller는 API 조회와 PDF/XLSX 바이트 생성을 책임진다. `exportAndSave`는 공통 저장 포트만 의존하고, `exportAndShare`는 기존 `Printing`/`SharePlus` 포트만 의존한다.
+- 위젯은 공통 `ExportActionButton`으로 `기기에 저장`과 `다른 앱으로 공유`를 명시적으로 노출하고, controller 결과의 취소/성공/오류를 화면별 기존 SnackBar 규칙에 맞춰 표시한다.
+
+## 3. 구현 단계
+
+### Phase A: 공유 저장 경계 (예상 30분)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| A-1 | `ExportFile`, 저장 Provider와 PDF/XLSX factory 추가 | `/home/lsjtop10/projects/cornermon/.worktrees/issue-193/frontend/lib/shared/export/export_file.dart` **(신규)** |
+| A-2 | `file_saver` 의존성 추가 | `/home/lsjtop10/projects/cornermon/.worktrees/issue-193/frontend/pubspec.yaml` **(기존 파일 확장)** |
+
+### Phase B: 기능별 controller와 UI (예상 90분)
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| B-1 | PDF·XLSX 저장 action 추가 | `/home/lsjtop10/projects/cornermon/.worktrees/issue-193/frontend/lib/admin/features/**` **(기존 파일 확장)** |
+| B-2 | 저장/공유 선택 UI 연결 | `/home/lsjtop10/projects/cornermon/.worktrees/issue-193/frontend/lib/shared/export/export_action_menu.dart` 및 각 화면 **(기존 파일 확장)** |
+| B-3 | 저장 성공·취소·실패 및 공유 회귀 테스트 | `/home/lsjtop10/projects/cornermon/.worktrees/issue-193/frontend/test/admin/features/**` **(기존 파일 확장)** |
+
+## 4. 검증 체크리스트
+
+- [x] feature controller가 file_saver 구체 구현이 아니라 shared Provider 포트만 사용한다.
+- [x] PDF는 `pdf`, `MimeType.pdf`, XLSX는 `xlsx`, `MimeType.microsoftExcel`을 전달한다.
+- [x] 저장 취소(null)는 error state와 오류 SnackBar를 만들지 않는다.
+- [x] 공유 선택은 기존 `Printing.sharePdf`/`SharePlus` 시트를 계속 사용한다.
+- [x] 기존 이미지 `cornermon-flutter:3.44.7`로 관련 테스트와 정적 분석을 실행하며 새 이미지를 pull하지 않는다.
+- [x] `flutter analyze lib` 통과, #193 관련 controller·widget 테스트 32건 통과.
+- [ ] 전체 `flutter test`는 #193 범위 밖 기존 실패 5건으로 통과하지 못함(변경하지 않음).

--- a/frontend/docs/artifacts/plan/20260722_issue_193_export_save_location_plan_.md
+++ b/frontend/docs/artifacts/plan/20260722_issue_193_export_save_location_plan_.md
@@ -13,7 +13,7 @@
 
 - `lib/shared/export/export_file.dart` **(신규)**: `file_saver` 네이티브 파일 선택기를 Provider 포트로 감싼다. `saveAs`의 nullable path를 결과값으로 변환하여 취소를 성공/오류와 분리하고, PDF/XLSX의 확장자와 MIME type을 한 곳에서 보장한다.
 - 기능별 controller는 API 조회와 PDF/XLSX 바이트 생성을 책임진다. `exportAndSave`는 공통 저장 포트만 의존하고, `exportAndShare`는 기존 `Printing`/`SharePlus` 포트만 의존한다.
-- 위젯은 공통 `ExportActionButton`으로 `기기에 저장`과 `다른 앱으로 공유`를 명시적으로 노출하고, controller 결과의 취소/성공/오류를 화면별 기존 SnackBar 규칙에 맞춰 표시한다.
+- 위젯은 공통 `ExportActionButton`으로 `기기에 저장`과 `다른 앱으로 공유`를 명시적으로 노출한다. 선택 메뉴는 트리거 버튼 바로 아래에 앵커링하고, controller 결과의 취소/성공/오류를 화면별 기존 SnackBar 규칙에 맞춰 표시한다.
 
 ## 3. 구현 단계
 
@@ -38,6 +38,7 @@
 - [x] PDF는 `pdf`, `MimeType.pdf`, XLSX는 `xlsx`, `MimeType.microsoftExcel`을 전달한다.
 - [x] 저장 취소(null)는 error state와 오류 SnackBar를 만들지 않는다.
 - [x] 공유 선택은 기존 `Printing.sharePdf`/`SharePlus` 시트를 계속 사용한다.
+- [x] 저장/공유 선택 메뉴는 화면 하단 바텀시트가 아니라 트리거 버튼 바로 아래에서 연다.
 - [x] 기존 이미지 `cornermon-flutter:3.44.7`로 관련 테스트와 정적 분석을 실행하며 새 이미지를 pull하지 않는다.
 - [x] `flutter analyze lib` 통과, #193 관련 controller·widget 테스트 32건 통과.
 - [ ] 전체 `flutter test`는 #193 범위 밖 기존 실패 5건으로 통과하지 못함(변경하지 않음).

--- a/frontend/lib/admin/features/badge_precreate/badge_controllers.dart
+++ b/frontend/lib/admin/features/badge_precreate/badge_controllers.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:cornermon/admin/features/badge_precreate/badge_sticker_pdf.dart';
 import 'package:cornermon/shared/api/providers/badge_providers.dart';
+import 'package:cornermon/shared/export/export_file.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:printing/printing.dart';
 
@@ -50,5 +51,27 @@ class BadgeExportController extends AsyncNotifier<bool> {
       return true;
     });
     return state.value ?? false;
+  }
+
+  /// 미배정 배지 PDF를 기기 저장 위치 선택기에 저장한다.
+  ///
+  /// null은 내보낼 미배정 배지가 없는 경우이고, cancelled는 사용자가 선택기를
+  /// 닫은 정상 흐름이다.
+  Future<ExportSaveResult?> exportAndSave() async {
+    state = const AsyncLoading();
+    ExportSaveResult? result;
+    state = await AsyncValue.guard(() async {
+      final badges = await ref.read(exportUnassignedBadgesProvider.future);
+      if (badges.isEmpty) return false;
+      final bytes = await buildBadgeStickerPdf(badges);
+      result = await ref.read(saveExportFileProvider)(
+        ExportFile.pdf(
+          name: 'cornermon-badges-${DateTime.now().millisecondsSinceEpoch}',
+          bytes: bytes,
+        ),
+      );
+      return true;
+    });
+    return state.hasError ? null : result;
   }
 }

--- a/frontend/lib/admin/features/badge_precreate/badge_precreate_screen.dart
+++ b/frontend/lib/admin/features/badge_precreate/badge_precreate_screen.dart
@@ -6,6 +6,8 @@ import 'package:cornermon/shared/api/providers/group_providers.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/empty_state.dart';
 import 'package:cornermon/shared/design_system/widgets/app_tag.dart';
+import 'package:cornermon/shared/export/export_action_menu.dart';
+import 'package:cornermon/shared/export/export_file.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -61,12 +63,16 @@ class _BadgePrecreateScreenState extends ConsumerState<BadgePrecreateScreen> {
     }
   }
 
-  Future<void> _export() async {
+  Future<void> _export(ExportAction action) async {
     setState(() => _busy = true);
     try {
-      final shared = await ref
-          .read(badgeExportControllerProvider.notifier)
-          .exportAndShare();
+      final controller = ref.read(badgeExportControllerProvider.notifier);
+      final saveResult = action == ExportAction.saveToDevice
+          ? await controller.exportAndSave()
+          : null;
+      final shared = action == ExportAction.shareWithApp
+          ? await controller.exportAndShare()
+          : saveResult != null;
       final result = ref.read(badgeExportControllerProvider);
       if (result.hasError) {
         throw result.error!;
@@ -78,6 +84,21 @@ class _BadgePrecreateScreenState extends ConsumerState<BadgePrecreateScreen> {
           ).showSnackBar(const SnackBar(content: Text('내보낼 미배정 배지가 없습니다')));
         }
         return;
+      }
+      if (action == ExportAction.saveToDevice &&
+          saveResult == ExportSaveResult.cancelled) {
+        return;
+      }
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              action == ExportAction.saveToDevice
+                  ? 'PDF를 저장했습니다'
+                  : 'PDF를 내보냈습니다',
+            ),
+          ),
+        );
       }
     } catch (error) {
       if (mounted) {
@@ -148,12 +169,11 @@ class _BadgePrecreateScreenState extends ConsumerState<BadgePrecreateScreen> {
                           : null,
                       onPressed: _count == null || _busy ? null : _generate,
                     ),
-                    AppButton(
-                      variant: AppButtonVariant.secondary,
-                      size: AppButtonSize.compact,
+                    ExportActionButton(
                       icon: Icons.ios_share,
                       label: '스티커 PDF로 내보내기',
-                      onPressed: _busy ? null : _export,
+                      busy: _busy,
+                      onSelected: _export,
                     ),
                   ],
                 ),

--- a/frontend/lib/admin/features/dashboard/dashboard_screen.dart
+++ b/frontend/lib/admin/features/dashboard/dashboard_screen.dart
@@ -13,6 +13,8 @@ import 'package:cornermon/shared/design_system/widgets/confirm_modal.dart';
 import 'package:cornermon/shared/design_system/widgets/empty_state.dart';
 import 'package:cornermon/shared/design_system/widgets/connection_banner.dart';
 import 'package:cornermon/shared/design_system/widgets/pill_tab_bar.dart';
+import 'package:cornermon/shared/export/export_action_menu.dart';
+import 'package:cornermon/shared/export/export_file.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -241,42 +243,51 @@ class DashboardScreen extends ConsumerWidget {
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 12),
-            child: AppButton(
+            child: ExportActionButton(
               key: dashboardPinExportButtonKey,
-              variant: AppButtonVariant.secondary,
-              size: AppButtonSize.compact,
               icon: Icons.download_outlined,
               label: '전체 PIN 내보내기',
-              onPressed: exportState.isLoading
-                  ? null
-                  : () async {
-                      final buttonBox =
-                          dashboardPinExportButtonKey.currentContext
-                                  ?.findRenderObject()
-                              as RenderBox?;
-                      final sharePositionOrigin =
-                          buttonBox != null && buttonBox.hasSize
-                          ? buttonBox.localToGlobal(Offset.zero) &
-                                buttonBox.size
-                          : null;
-                      await ref
-                          .read(trackPinExportControllerProvider.notifier)
-                          .exportAndShare(
-                            id,
-                            sharePositionOrigin: sharePositionOrigin,
-                          );
-                      if (!context.mounted) return;
-                      final result = ref.read(trackPinExportControllerProvider);
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text(
-                            result.hasError
-                                ? 'PIN 엑셀 내보내기 실패: ${result.error}'
-                                : 'PIN 엑셀을 내보냈습니다',
-                          ),
-                        ),
-                      );
-                    },
+              busy: exportState.isLoading,
+              onSelected: (action) async {
+                final buttonBox =
+                    dashboardPinExportButtonKey.currentContext
+                            ?.findRenderObject()
+                        as RenderBox?;
+                final sharePositionOrigin =
+                    buttonBox != null && buttonBox.hasSize
+                    ? buttonBox.localToGlobal(Offset.zero) & buttonBox.size
+                    : null;
+                final controller = ref.read(
+                  trackPinExportControllerProvider.notifier,
+                );
+                final saveResult = action == ExportAction.saveToDevice
+                    ? await controller.exportAndSave(id)
+                    : null;
+                if (action == ExportAction.shareWithApp) {
+                  await controller.exportAndShare(
+                    id,
+                    sharePositionOrigin: sharePositionOrigin,
+                  );
+                }
+                if (!context.mounted) return;
+                final result = ref.read(trackPinExportControllerProvider);
+                if (action == ExportAction.saveToDevice &&
+                    saveResult == ExportSaveResult.cancelled &&
+                    !result.hasError) {
+                  return;
+                }
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(
+                      result.hasError
+                          ? 'PIN 엑셀 내보내기 실패: ${result.error}'
+                          : action == ExportAction.saveToDevice
+                          ? 'PIN 엑셀을 저장했습니다'
+                          : 'PIN 엑셀을 내보냈습니다',
+                    ),
+                  ),
+                );
+              },
             ),
           ),
         ],

--- a/frontend/lib/admin/features/report/report_export_button.dart
+++ b/frontend/lib/admin/features/report/report_export_button.dart
@@ -3,7 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:cornermon/shared/api/domain_aliases.dart' as api;
 import 'package:cornermon/shared/api/ids.dart';
-import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon/shared/export/export_action_menu.dart';
+import 'package:cornermon/shared/export/export_file.dart';
 import 'report_export_controller.dart';
 
 /// 탭 우측 고정 PDF 내보내기 버튼. `campId`는 `selectedCampIdProvider`를 다시 watch하지
@@ -17,17 +18,30 @@ class ReportExportButton extends ConsumerWidget {
     final exportState = ref.watch(reportExportControllerProvider);
     final busy = exportState.isLoading;
 
-    Future<void> onPressed() async {
+    Future<void> onSelected(ExportAction action) async {
       final campId = CampId(report.campId ?? '');
-      await ref
-          .read(reportExportControllerProvider.notifier)
-          .exportAndShare(campId);
+      final controller = ref.read(reportExportControllerProvider.notifier);
+      final saveResult = action == ExportAction.saveToDevice
+          ? await controller.exportAndSave(campId)
+          : null;
+      if (action == ExportAction.shareWithApp) {
+        await controller.exportAndShare(campId);
+      }
       if (!context.mounted) return;
       final result = ref.read(reportExportControllerProvider);
+      if (action == ExportAction.saveToDevice &&
+          saveResult == ExportSaveResult.cancelled &&
+          !result.hasError) {
+        return;
+      }
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            result.hasError ? 'PDF 내보내기 실패: ${result.error}' : 'PDF를 내보냈습니다',
+            result.hasError
+                ? 'PDF 내보내기 실패: ${result.error}'
+                : action == ExportAction.saveToDevice
+                ? 'PDF를 저장했습니다'
+                : 'PDF를 내보냈습니다',
           ),
         ),
       );
@@ -36,12 +50,11 @@ class ReportExportButton extends ConsumerWidget {
     return Stack(
       alignment: Alignment.center,
       children: [
-        AppButton(
-          variant: AppButtonVariant.secondary,
-          size: AppButtonSize.compact,
+        ExportActionButton(
           icon: Icons.ios_share,
           label: 'PDF로 내보내기',
-          onPressed: busy ? null : onPressed,
+          busy: busy,
+          onSelected: onSelected,
         ),
         if (busy)
           const SizedBox(

--- a/frontend/lib/admin/features/report/report_export_controller.dart
+++ b/frontend/lib/admin/features/report/report_export_controller.dart
@@ -6,6 +6,7 @@ import 'package:printing/printing.dart';
 
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/report_providers.dart';
+import 'package:cornermon/shared/export/export_file.dart';
 import 'report_pdf.dart';
 
 typedef SharePdf =
@@ -38,5 +39,23 @@ class ReportExportController extends AsyncNotifier<void> {
             'cornermon-report-${campId.value}-${DateTime.now().millisecondsSinceEpoch}.pdf',
       );
     });
+  }
+
+  /// PDF를 생성한 뒤 사용자가 선택한 기기 위치에 저장한다.
+  Future<ExportSaveResult?> exportAndSave(CampId campId) async {
+    state = const AsyncLoading();
+    ExportSaveResult? result;
+    state = await AsyncValue.guard(() async {
+      final report = await ref.read(exportReportProvider(campId).future);
+      final bytes = await buildReportPdf(report);
+      result = await ref.read(saveExportFileProvider)(
+        ExportFile.pdf(
+          name:
+              'cornermon-report-${campId.value}-${DateTime.now().millisecondsSinceEpoch}',
+          bytes: bytes,
+        ),
+      );
+    });
+    return result;
   }
 }

--- a/frontend/lib/admin/features/track_bulk_manage/track_pin_export_controller.dart
+++ b/frontend/lib/admin/features/track_bulk_manage/track_pin_export_controller.dart
@@ -5,6 +5,7 @@ import 'dart:ui';
 import 'package:cornermon/admin/features/track_bulk_manage/track_excel_export.dart';
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/corner_track_providers.dart';
+import 'package:cornermon/shared/export/export_file.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_plus/share_plus.dart';
 
@@ -57,5 +58,28 @@ class TrackPinExportController extends AsyncNotifier<void> {
     } finally {
       subscription.close();
     }
+  }
+
+  /// 전체 PIN XLSX를 생성한 뒤 사용자가 선택한 기기 위치에 저장한다.
+  Future<ExportSaveResult?> exportAndSave(CampId campId) async {
+    state = const AsyncLoading();
+    final request = exportAllTrackPinsProvider(campId);
+    final subscription = ref.listen(request, (_, _) {});
+    ExportSaveResult? result;
+    try {
+      final response = await ref.read(request.future);
+      final bytes = Uint8List.fromList(
+        buildTrackPinWorkbookBytes(response.tracks ?? const []),
+      );
+      result = await ref.read(saveExportFileProvider)(
+        ExportFile.xlsx(name: 'track-pins', bytes: bytes),
+      );
+      state = const AsyncData(null);
+    } catch (error, stackTrace) {
+      state = AsyncError(error, stackTrace);
+    } finally {
+      subscription.close();
+    }
+    return result;
   }
 }

--- a/frontend/lib/admin/widgets/track_row_actions.dart
+++ b/frontend/lib/admin/widgets/track_row_actions.dart
@@ -44,43 +44,47 @@ Future<void> showTrackPinDialog(
           icon: const Icon(Icons.copy),
           label: const Text('복사'),
         ),
-        TextButton.icon(
-          onPressed: () async {
-            final action = await showExportActionMenu(dialogContext);
-            if (action == null || !context.mounted) return;
-            try {
-              final file = ExportFile.pdf(
-                name: 'track-${track.trackNo ?? 'pin'}-pin',
-                bytes: await buildTrackPinPdf(
-                  trackNo: '${track.trackNo ?? '-'}',
-                  pin: result.pin ?? '-',
-                ),
-              );
-              if (action == ExportAction.saveToDevice) {
-                final saveResult = await ref.read(saveExportFileProvider)(file);
-                if (saveResult == ExportSaveResult.cancelled ||
-                    !context.mounted) {
+        Builder(
+          builder: (buttonContext) => TextButton.icon(
+            onPressed: () async {
+              final action = await showExportActionMenu(buttonContext);
+              if (action == null || !context.mounted) return;
+              try {
+                final file = ExportFile.pdf(
+                  name: 'track-${track.trackNo ?? 'pin'}-pin',
+                  bytes: await buildTrackPinPdf(
+                    trackNo: '${track.trackNo ?? '-'}',
+                    pin: result.pin ?? '-',
+                  ),
+                );
+                if (action == ExportAction.saveToDevice) {
+                  final saveResult = await ref.read(saveExportFileProvider)(
+                    file,
+                  );
+                  if (saveResult == ExportSaveResult.cancelled ||
+                      !context.mounted) {
+                    return;
+                  }
+                  ScaffoldMessenger.of(
+                    context,
+                  ).showSnackBar(const SnackBar(content: Text('PDF를 저장했습니다')));
                   return;
                 }
-                ScaffoldMessenger.of(
-                  context,
-                ).showSnackBar(const SnackBar(content: Text('PDF를 저장했습니다')));
-                return;
+                await Printing.sharePdf(
+                  bytes: file.bytes,
+                  filename: file.filename,
+                );
+              } catch (error) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('PDF 내보내기 실패: $error')),
+                  );
+                }
               }
-              await Printing.sharePdf(
-                bytes: file.bytes,
-                filename: file.filename,
-              );
-            } catch (error) {
-              if (context.mounted) {
-                ScaffoldMessenger.of(
-                  context,
-                ).showSnackBar(SnackBar(content: Text('PDF 내보내기 실패: $error')));
-              }
-            }
-          },
-          icon: const Icon(Icons.picture_as_pdf_outlined),
-          label: const Text('PDF 내보내기'),
+            },
+            icon: const Icon(Icons.picture_as_pdf_outlined),
+            label: const Text('PDF 내보내기'),
+          ),
         ),
         TextButton(
           onPressed: () => Navigator.pop(dialogContext),

--- a/frontend/lib/admin/widgets/track_row_actions.dart
+++ b/frontend/lib/admin/widgets/track_row_actions.dart
@@ -4,6 +4,8 @@ import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/corner_track_providers.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/confirm_modal.dart';
+import 'package:cornermon/shared/export/export_action_menu.dart';
+import 'package:cornermon/shared/export/export_file.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -44,14 +46,38 @@ Future<void> showTrackPinDialog(
         ),
         TextButton.icon(
           onPressed: () async {
-            final bytes = await buildTrackPinPdf(
-              trackNo: '${track.trackNo ?? '-'}',
-              pin: result.pin ?? '-',
-            );
-            await Printing.sharePdf(
-              bytes: bytes,
-              filename: 'track-${track.trackNo ?? 'pin'}-pin.pdf',
-            );
+            final action = await showExportActionMenu(dialogContext);
+            if (action == null || !context.mounted) return;
+            try {
+              final file = ExportFile.pdf(
+                name: 'track-${track.trackNo ?? 'pin'}-pin',
+                bytes: await buildTrackPinPdf(
+                  trackNo: '${track.trackNo ?? '-'}',
+                  pin: result.pin ?? '-',
+                ),
+              );
+              if (action == ExportAction.saveToDevice) {
+                final saveResult = await ref.read(saveExportFileProvider)(file);
+                if (saveResult == ExportSaveResult.cancelled ||
+                    !context.mounted) {
+                  return;
+                }
+                ScaffoldMessenger.of(
+                  context,
+                ).showSnackBar(const SnackBar(content: Text('PDF를 저장했습니다')));
+                return;
+              }
+              await Printing.sharePdf(
+                bytes: file.bytes,
+                filename: file.filename,
+              );
+            } catch (error) {
+              if (context.mounted) {
+                ScaffoldMessenger.of(
+                  context,
+                ).showSnackBar(SnackBar(content: Text('PDF 내보내기 실패: $error')));
+              }
+            }
           },
           icon: const Icon(Icons.picture_as_pdf_outlined),
           label: const Text('PDF 내보내기'),

--- a/frontend/lib/shared/export/export_action_menu.dart
+++ b/frontend/lib/shared/export/export_action_menu.dart
@@ -1,0 +1,60 @@
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:flutter/material.dart';
+
+enum ExportAction { saveToDevice, shareWithApp }
+
+/// 내보내기 방식을 명시적으로 선택하게 하는 공통 UI.
+class ExportActionButton extends StatelessWidget {
+  const ExportActionButton({
+    required this.label,
+    required this.icon,
+    required this.onSelected,
+    this.busy = false,
+    super.key,
+  });
+
+  final String label;
+  final IconData icon;
+  final ValueChanged<ExportAction> onSelected;
+  final bool busy;
+
+  @override
+  Widget build(BuildContext context) => AppButton(
+    variant: AppButtonVariant.secondary,
+    size: AppButtonSize.compact,
+    icon: icon,
+    label: label,
+    onPressed: busy
+        ? null
+        : () async {
+            final action = await showExportActionMenu(context);
+            if (action != null) onSelected(action);
+          },
+  );
+}
+
+Future<ExportAction?> showExportActionMenu(BuildContext context) =>
+    showModalBottomSheet<ExportAction>(
+      context: context,
+      builder: (sheetContext) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.save_alt_outlined),
+              title: const Text('기기에 저장'),
+              subtitle: const Text('저장 위치를 선택합니다'),
+              onTap: () =>
+                  Navigator.pop(sheetContext, ExportAction.saveToDevice),
+            ),
+            ListTile(
+              leading: const Icon(Icons.share_outlined),
+              title: const Text('다른 앱으로 공유'),
+              subtitle: const Text('시스템 공유 시트를 엽니다'),
+              onTap: () =>
+                  Navigator.pop(sheetContext, ExportAction.shareWithApp),
+            ),
+          ],
+        ),
+      ),
+    );

--- a/frontend/lib/shared/export/export_action_menu.dart
+++ b/frontend/lib/shared/export/export_action_menu.dart
@@ -4,6 +4,10 @@ import 'package:flutter/material.dart';
 enum ExportAction { saveToDevice, shareWithApp }
 
 /// 내보내기 방식을 명시적으로 선택하게 하는 공통 UI.
+///
+/// 선택 메뉴는 트리거 바로 아래에 표시한다. 이후 시스템 저장 선택기와 공유
+/// 시트는 각 플랫폼이 정한 위치에 표시되지만, 앱 안의 첫 선택은 항상 버튼
+/// 근처에서 시작하게 한다.
 class ExportActionButton extends StatelessWidget {
   const ExportActionButton({
     required this.label,
@@ -19,42 +23,88 @@ class ExportActionButton extends StatelessWidget {
   final bool busy;
 
   @override
-  Widget build(BuildContext context) => AppButton(
-    variant: AppButtonVariant.secondary,
-    size: AppButtonSize.compact,
-    icon: icon,
-    label: label,
-    onPressed: busy
-        ? null
-        : () async {
-            final action = await showExportActionMenu(context);
-            if (action != null) onSelected(action);
-          },
+  Widget build(BuildContext context) => Builder(
+    builder: (buttonContext) => AppButton(
+      variant: AppButtonVariant.secondary,
+      size: AppButtonSize.compact,
+      icon: icon,
+      label: label,
+      onPressed: busy
+          ? null
+          : () async {
+              final action = await showExportActionMenu(buttonContext);
+              if (action != null) onSelected(action);
+            },
+    ),
   );
 }
 
-Future<ExportAction?> showExportActionMenu(BuildContext context) =>
-    showModalBottomSheet<ExportAction>(
-      context: context,
-      builder: (sheetContext) => SafeArea(
+/// [context]의 render box를 기준으로 메뉴를 열어 앱 내 선택 동선을 고정한다.
+Future<ExportAction?> showExportActionMenu(BuildContext context) {
+  final anchor = context.findRenderObject()! as RenderBox;
+  final overlay =
+      Navigator.of(context).overlay!.context.findRenderObject()! as RenderBox;
+  final anchorRect = Rect.fromPoints(
+    anchor.localToGlobal(Offset.zero, ancestor: overlay),
+    anchor.localToGlobal(
+      anchor.size.bottomRight(Offset.zero),
+      ancestor: overlay,
+    ),
+  );
+
+  return showMenu<ExportAction>(
+    context: context,
+    position: RelativeRect.fromRect(
+      Rect.fromLTWH(anchorRect.left, anchorRect.bottom, anchorRect.width, 0),
+      Offset.zero & overlay.size,
+    ),
+    items: const [
+      PopupMenuItem(
+        value: ExportAction.saveToDevice,
+        child: _ExportActionMenuItem(
+          icon: Icons.save_alt_outlined,
+          title: '기기에 저장',
+          subtitle: '저장 위치를 선택합니다',
+        ),
+      ),
+      PopupMenuItem(
+        value: ExportAction.shareWithApp,
+        child: _ExportActionMenuItem(
+          icon: Icons.share_outlined,
+          title: '다른 앱으로 공유',
+          subtitle: '시스템 공유 시트를 엽니다',
+        ),
+      ),
+    ],
+  );
+}
+
+class _ExportActionMenuItem extends StatelessWidget {
+  const _ExportActionMenuItem({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) => Row(
+    children: [
+      Icon(icon),
+      const SizedBox(width: 12),
+      Expanded(
         child: Column(
           mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            ListTile(
-              leading: const Icon(Icons.save_alt_outlined),
-              title: const Text('기기에 저장'),
-              subtitle: const Text('저장 위치를 선택합니다'),
-              onTap: () =>
-                  Navigator.pop(sheetContext, ExportAction.saveToDevice),
-            ),
-            ListTile(
-              leading: const Icon(Icons.share_outlined),
-              title: const Text('다른 앱으로 공유'),
-              subtitle: const Text('시스템 공유 시트를 엽니다'),
-              onTap: () =>
-                  Navigator.pop(sheetContext, ExportAction.shareWithApp),
-            ),
+            Text(title),
+            Text(subtitle, style: Theme.of(context).textTheme.bodySmall),
           ],
         ),
       ),
-    );
+    ],
+  );
+}

--- a/frontend/lib/shared/export/export_action_menu.dart
+++ b/frontend/lib/shared/export/export_action_menu.dart
@@ -1,4 +1,6 @@
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:flutter/material.dart';
 
 enum ExportAction { saveToDevice, shareWithApp }
@@ -44,6 +46,8 @@ Future<ExportAction?> showExportActionMenu(BuildContext context) {
   final anchor = context.findRenderObject()! as RenderBox;
   final overlay =
       Navigator.of(context).overlay!.context.findRenderObject()! as RenderBox;
+  final isDark = Theme.of(context).brightness == Brightness.dark;
+  final colors = isDark ? AppColors.dark : AppColors.light;
   final anchorRect = Rect.fromPoints(
     anchor.localToGlobal(Offset.zero, ancestor: overlay),
     anchor.localToGlobal(
@@ -58,9 +62,23 @@ Future<ExportAction?> showExportActionMenu(BuildContext context) {
       Rect.fromLTWH(anchorRect.left, anchorRect.bottom, anchorRect.width, 0),
       Offset.zero & overlay.size,
     ),
+    color: colors.bgSurfaceRaised,
+    surfaceTintColor: Colors.transparent,
+    elevation: isDark ? 0 : 4,
+    shadowColor: isDark
+        ? Colors.transparent
+        : Colors.black.withValues(alpha: .16),
+    shape: RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(12),
+      side: BorderSide(color: colors.border),
+    ),
+    menuPadding: const EdgeInsets.symmetric(vertical: 4),
+    constraints: const BoxConstraints.tightFor(width: 264),
     items: const [
       PopupMenuItem(
         value: ExportAction.saveToDevice,
+        height: 68,
+        padding: EdgeInsets.zero,
         child: _ExportActionMenuItem(
           icon: Icons.save_alt_outlined,
           title: '기기에 저장',
@@ -69,6 +87,8 @@ Future<ExportAction?> showExportActionMenu(BuildContext context) {
       ),
       PopupMenuItem(
         value: ExportAction.shareWithApp,
+        height: 68,
+        padding: EdgeInsets.zero,
         child: _ExportActionMenuItem(
           icon: Icons.share_outlined,
           title: '다른 앱으로 공유',
@@ -91,20 +111,38 @@ class _ExportActionMenuItem extends StatelessWidget {
   final String subtitle;
 
   @override
-  Widget build(BuildContext context) => Row(
-    children: [
-      Icon(icon),
-      const SizedBox(width: 12),
-      Expanded(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(title),
-            Text(subtitle, style: Theme.of(context).textTheme.bodySmall),
-          ],
-        ),
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final colors = isDark ? AppColors.dark : AppColors.light;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+      child: Row(
+        children: [
+          Icon(icon, size: 20, color: colors.textSecondary),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: AppTypography.bodyEmphasis.copyWith(
+                    color: colors.textPrimary,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  subtitle,
+                  style: AppTypography.caption.copyWith(
+                    color: colors.textSecondary,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
       ),
-    ],
-  );
+    );
+  }
 }

--- a/frontend/lib/shared/export/export_file.dart
+++ b/frontend/lib/shared/export/export_file.dart
@@ -1,0 +1,57 @@
+import 'dart:typed_data';
+
+import 'package:file_saver/file_saver.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+enum ExportSaveResult { saved, cancelled }
+
+/// 플랫폼 저장 위치 선택기에 넘길 완성된 내보내기 파일이다.
+///
+/// [name]에는 확장자를 포함하지 않는다. 확장자와 MIME type은 별도 필드로 전달한다.
+class ExportFile {
+  const ExportFile({
+    required this.name,
+    required this.bytes,
+    required this.fileExtension,
+    required this.mimeType,
+  });
+
+  factory ExportFile.pdf({required String name, required Uint8List bytes}) =>
+      ExportFile(
+        name: name,
+        bytes: bytes,
+        fileExtension: 'pdf',
+        mimeType: MimeType.pdf,
+      );
+
+  factory ExportFile.xlsx({required String name, required Uint8List bytes}) =>
+      ExportFile(
+        name: name,
+        bytes: bytes,
+        fileExtension: 'xlsx',
+        mimeType: MimeType.microsoftExcel,
+      );
+
+  final String name;
+  final Uint8List bytes;
+  final String fileExtension;
+  final MimeType mimeType;
+
+  String get filename => '$name.$fileExtension';
+}
+
+typedef SaveExportFile = Future<ExportSaveResult> Function(ExportFile file);
+
+/// 네이티브 구현을 Provider 경계로 감싼다. null은 사용자가 파일 선택기를 취소한
+/// 정상 흐름이므로 error가 아닌 [ExportSaveResult.cancelled]로 변환한다.
+final saveExportFileProvider = Provider<SaveExportFile>((ref) {
+  return (file) async {
+    final path = await FileSaver.instance.saveAs(
+      name: file.name,
+      bytes: file.bytes,
+      fileExtension: file.fileExtension,
+      mimeType: file.mimeType,
+    );
+    return path == null ? ExportSaveResult.cancelled : ExportSaveResult.saved;
+  };
+});

--- a/frontend/linux/flutter/generated_plugin_registrant.cc
+++ b/frontend/linux/flutter/generated_plugin_registrant.cc
@@ -6,11 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_saver/file_saver_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <printing/printing_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_saver_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSaverPlugin");
+  file_saver_plugin_register_with_registrar(file_saver_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);

--- a/frontend/linux/flutter/generated_plugins.cmake
+++ b/frontend/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_saver
   flutter_secure_storage_linux
   printing
   url_launcher_linux

--- a/frontend/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/frontend/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import connectivity_plus
 import device_info_plus
+import file_saver
 import flutter_secure_storage_darwin
 import mobile_scanner
 import printing
@@ -15,6 +16,7 @@ import share_plus
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
+  FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
   PrintingPlugin.register(with: registry.registrar(forPlugin: "PrintingPlugin"))

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -328,6 +328,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
+  file_saver:
+    dependency: "direct main"
+    description:
+      name: file_saver
+      sha256: "68c9a085d9bb4546e0a31d1e583a48d7c17a6987d538788ea064f0043b1fc02d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0"
   fixnum:
     dependency: transitive
     description:
@@ -1179,4 +1187,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.2 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.41.0"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   pdf: ^3.11.1
   printing: ^5.13.4
   share_plus: ^12.0.1
+  file_saver: ^0.4.0
   cornermon_api_gen:
     path: lib/shared/api/gen
   device_info_plus: ^12.4.0

--- a/frontend/test/admin/features/badge_precreate/badge_controllers_test.dart
+++ b/frontend/test/admin/features/badge_precreate/badge_controllers_test.dart
@@ -1,5 +1,6 @@
 import 'package:cornermon/admin/features/badge_precreate/badge_controllers.dart';
 import 'package:cornermon/shared/api/providers/badge_providers.dart';
+import 'package:cornermon/shared/export/export_file.dart';
 import 'package:cornermon_api_gen/cornermon_api_gen.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -90,5 +91,36 @@ void main() {
     expect(shared, isTrue);
     expect(shareCalls, 1);
     expect(sharedFilename, startsWith('cornermon-badges-'));
+  });
+
+  test('ShoudNotSetErrorWhenBadgePdfSaveIsCancelled', () async {
+    // arrange
+    final container = ProviderContainer(
+      overrides: [
+        exportUnassignedBadgesProvider.overrideWith(
+          (_) async => [
+            BadgeResponse(
+              (b) => b
+                ..id = 'badge-1'
+                ..shortId = 'B-0001'
+                ..qrPayload = 'payload',
+            ),
+          ],
+        ),
+        saveExportFileProvider.overrideWithValue(
+          (_) async => ExportSaveResult.cancelled,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // act
+    final result = await container
+        .read(badgeExportControllerProvider.notifier)
+        .exportAndSave();
+
+    // assert
+    expect(result, ExportSaveResult.cancelled);
+    expect(container.read(badgeExportControllerProvider).hasError, isFalse);
   });
 }

--- a/frontend/test/admin/features/dashboard/dashboard_screen_test.dart
+++ b/frontend/test/admin/features/dashboard/dashboard_screen_test.dart
@@ -524,6 +524,8 @@ void main() {
       // act
       await tester.tap(find.text('전체 PIN 내보내기'));
       await tester.pumpAndSettle();
+      await tester.tap(find.text('다른 앱으로 공유'));
+      await tester.pumpAndSettle();
 
       // assert
       expect(shared, isTrue);
@@ -546,6 +548,8 @@ void main() {
       // act
       await tester.tap(find.text('전체 PIN 내보내기'));
       await tester.pumpAndSettle();
+      await tester.tap(find.text('다른 앱으로 공유'));
+      await tester.pumpAndSettle();
 
       // assert
       expect(find.textContaining('PIN 엑셀 내보내기 실패:'), findsOneWidget);
@@ -563,6 +567,8 @@ void main() {
 
       // act
       await tester.tap(find.text('전체 PIN 내보내기'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('다른 앱으로 공유'));
       await tester.pumpAndSettle();
 
       // assert

--- a/frontend/test/admin/features/report/report_export_button_test.dart
+++ b/frontend/test/admin/features/report/report_export_button_test.dart
@@ -11,43 +11,40 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets(
-    'ShoudDisableButtonAndShowSpinnerWhileExportIsInProgress',
-    (tester) async {
-      // arrange — exportReport가 completer로 대기하는 동안 상태를 관찰한다.
-      final completer = Completer<CampReportResponse>();
-      final report = CampReportResponse((b) => b..campId = 'camp-1');
-      await tester.pumpWidget(
-        ProviderScope(
-          overrides: [
-            exportReportProvider(
-              CampId('camp-1'),
-            ).overrideWith((ref) => completer.future),
-            reportPdfShareProvider.overrideWithValue(({
-              required bytes,
-              required filename,
-            }) async => true),
-          ],
-          child: MaterialApp(
-            home: Scaffold(body: ReportExportButton(report: report)),
+  testWidgets('ShoudDisableButtonAndShowSpinnerWhileExportIsInProgress', (
+    tester,
+  ) async {
+    // arrange — exportReport가 completer로 대기하는 동안 상태를 관찰한다.
+    final completer = Completer<CampReportResponse>();
+    final report = CampReportResponse((b) => b..campId = 'camp-1');
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          exportReportProvider(
+            CampId('camp-1'),
+          ).overrideWith((ref) => completer.future),
+          reportPdfShareProvider.overrideWithValue(
+            ({required bytes, required filename}) async => true,
           ),
+        ],
+        child: MaterialApp(
+          home: Scaffold(body: ReportExportButton(report: report)),
         ),
-      );
+      ),
+    );
 
-      // act — 버튼 탭.
-      await tester.tap(find.byType(AppButton));
-      await tester.pump();
+    // act — 버튼 탭.
+    await tester.tap(find.byType(AppButton));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('다른 앱으로 공유'));
+    await tester.pump();
 
-      // assert — 대기 중엔 버튼이 비활성화되고 스피너가 겹쳐 보인다.
-      expect(
-        tester.widget<AppButton>(find.byType(AppButton)).onPressed,
-        isNull,
-      );
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    // assert — 대기 중엔 버튼이 비활성화되고 스피너가 겹쳐 보인다.
+    expect(tester.widget<AppButton>(find.byType(AppButton)).onPressed, isNull);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
-      // cleanup
-      completer.complete(report);
-      await tester.pumpAndSettle();
-    },
-  );
+    // cleanup
+    completer.complete(report);
+    await tester.pumpAndSettle();
+  });
 }

--- a/frontend/test/admin/features/report/report_export_controller_test.dart
+++ b/frontend/test/admin/features/report/report_export_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:cornermon/admin/features/report/report_export_controller.dart';
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/report_providers.dart';
+import 'package:cornermon/shared/export/export_file.dart';
 import 'package:cornermon_api_gen/cornermon_api_gen.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -67,5 +68,56 @@ void main() {
     // assert
     expect(shareCalls, 0);
     expect(container.read(reportExportControllerProvider).hasError, isTrue);
+  });
+
+  test('ShoudSavePdfWithPdfMetadataWhenExportAndSaveSucceeds', () async {
+    // arrange
+    final campId = CampId('camp-1');
+    ExportFile? savedFile;
+    final container = ProviderContainer(
+      overrides: [
+        exportReportProvider(campId).overrideWith((ref) async => _report()),
+        saveExportFileProvider.overrideWithValue((file) async {
+          savedFile = file;
+          return ExportSaveResult.saved;
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // act
+    final result = await container
+        .read(reportExportControllerProvider.notifier)
+        .exportAndSave(campId);
+
+    // assert
+    expect(result, ExportSaveResult.saved);
+    expect(savedFile!.filename, startsWith('cornermon-report-camp-1-'));
+    expect(savedFile!.fileExtension, 'pdf');
+    expect(savedFile!.mimeType.name, 'PDF');
+    expect(container.read(reportExportControllerProvider).hasError, isFalse);
+  });
+
+  test('ShoudNotSetErrorWhenSaveIsCancelled', () async {
+    // arrange
+    final campId = CampId('camp-1');
+    final container = ProviderContainer(
+      overrides: [
+        exportReportProvider(campId).overrideWith((ref) async => _report()),
+        saveExportFileProvider.overrideWithValue(
+          (_) async => ExportSaveResult.cancelled,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // act
+    final result = await container
+        .read(reportExportControllerProvider.notifier)
+        .exportAndSave(campId);
+
+    // assert
+    expect(result, ExportSaveResult.cancelled);
+    expect(container.read(reportExportControllerProvider).hasError, isFalse);
   });
 }

--- a/frontend/test/admin/features/track_bulk_manage/track_pin_export_controller_test.dart
+++ b/frontend/test/admin/features/track_bulk_manage/track_pin_export_controller_test.dart
@@ -1,0 +1,63 @@
+import 'package:cornermon/admin/features/track_bulk_manage/track_pin_export_controller.dart';
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/providers/corner_track_providers.dart';
+import 'package:cornermon/shared/export/export_file.dart';
+import 'package:cornermon_api_gen/cornermon_api_gen.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('ShoudSaveWorkbookWithXlsxMetadataWhenExportAndSaveSucceeds', () async {
+    // arrange
+    final campId = CampId('camp-1');
+    ExportFile? savedFile;
+    final container = ProviderContainer(
+      overrides: [
+        exportAllTrackPinsProvider(campId).overrideWith(
+          (_) async => ExportTracksResponse((b) => b..tracks.replace([])),
+        ),
+        saveExportFileProvider.overrideWithValue((file) async {
+          savedFile = file;
+          return ExportSaveResult.saved;
+        }),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // act
+    final result = await container
+        .read(trackPinExportControllerProvider.notifier)
+        .exportAndSave(campId);
+
+    // assert
+    expect(result, ExportSaveResult.saved);
+    expect(savedFile!.filename, 'track-pins.xlsx');
+    expect(savedFile!.mimeType.name, 'Microsoft Excel');
+    expect(container.read(trackPinExportControllerProvider).hasError, isFalse);
+  });
+
+  test('ShoudNotSetErrorWhenWorkbookSaveIsCancelled', () async {
+    // arrange
+    final campId = CampId('camp-1');
+    final container = ProviderContainer(
+      overrides: [
+        exportAllTrackPinsProvider(campId).overrideWith(
+          (_) async => ExportTracksResponse((b) => b..tracks.replace([])),
+        ),
+        saveExportFileProvider.overrideWithValue(
+          (_) async => ExportSaveResult.cancelled,
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    // act
+    final result = await container
+        .read(trackPinExportControllerProvider.notifier)
+        .exportAndSave(campId);
+
+    // assert
+    expect(result, ExportSaveResult.cancelled);
+    expect(container.read(trackPinExportControllerProvider).hasError, isFalse);
+  });
+}

--- a/frontend/test/shared/export/export_action_menu_test.dart
+++ b/frontend/test/shared/export/export_action_menu_test.dart
@@ -29,9 +29,11 @@ void main() {
     expect(find.text('다른 앱으로 공유'), findsOneWidget);
     expect(
       tester.getRect(find.text('기기에 저장')).top,
-      greaterThanOrEqualTo(
-        tester.getRect(find.text('PDF로 내보내기')).bottom,
-      ),
+      greaterThanOrEqualTo(tester.getRect(find.text('PDF로 내보내기')).bottom),
+    );
+    expect(
+      tester.getSize(find.byType(PopupMenuItem<ExportAction>).first).height,
+      greaterThanOrEqualTo(44),
     );
 
     // act

--- a/frontend/test/shared/export/export_action_menu_test.dart
+++ b/frontend/test/shared/export/export_action_menu_test.dart
@@ -1,0 +1,63 @@
+import 'package:cornermon/shared/export/export_action_menu.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('ShoudOfferSaveAndShareWhenExportButtonIsPressed', (
+    tester,
+  ) async {
+    // arrange
+    ExportAction? selected;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ExportActionButton(
+            label: 'PDF로 내보내기',
+            icon: Icons.ios_share,
+            onSelected: (action) => selected = action,
+          ),
+        ),
+      ),
+    );
+
+    // act
+    await tester.tap(find.text('PDF로 내보내기'));
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(find.text('기기에 저장'), findsOneWidget);
+    expect(find.text('다른 앱으로 공유'), findsOneWidget);
+
+    // act
+    await tester.tap(find.text('기기에 저장'));
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(selected, ExportAction.saveToDevice);
+  });
+
+  testWidgets('ShoudNotSelectActionWhenExportMenuIsDismissed', (tester) async {
+    // arrange
+    ExportAction? selected;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ExportActionButton(
+            label: 'PDF로 내보내기',
+            icon: Icons.ios_share,
+            onSelected: (action) => selected = action,
+          ),
+        ),
+      ),
+    );
+
+    // act
+    await tester.tap(find.text('PDF로 내보내기'));
+    await tester.pumpAndSettle();
+    await tester.tapAt(const Offset(8, 8));
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(selected, isNull);
+  });
+}

--- a/frontend/test/shared/export/export_action_menu_test.dart
+++ b/frontend/test/shared/export/export_action_menu_test.dart
@@ -27,6 +27,12 @@ void main() {
     // assert
     expect(find.text('기기에 저장'), findsOneWidget);
     expect(find.text('다른 앱으로 공유'), findsOneWidget);
+    expect(
+      tester.getRect(find.text('기기에 저장')).top,
+      greaterThanOrEqualTo(
+        tester.getRect(find.text('PDF로 내보내기')).bottom,
+      ),
+    );
 
     // act
     await tester.tap(find.text('기기에 저장'));

--- a/frontend/windows/flutter/generated_plugin_registrant.cc
+++ b/frontend/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
+#include <file_saver/file_saver_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <printing/printing_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
@@ -15,6 +16,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   ConnectivityPlusWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
+  FileSaverPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSaverPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   PrintingPluginRegisterWithRegistrar(

--- a/frontend/windows/flutter/generated_plugins.cmake
+++ b/frontend/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   connectivity_plus
+  file_saver
   flutter_secure_storage_windows
   printing
   share_plus


### PR DESCRIPTION
## 변경 사항
- PDF와 전체 PIN XLSX 내보내기에 기기에 저장과 다른 앱으로 공유 선택을 추가했습니다.
- Android/iPadOS 저장 위치 선택기는 file_saver.saveAs로 연결하고, PDF/XLSX 확장자와 MIME type을 공통 경계에서 보장합니다.
- 저장 취소는 오류 SnackBar 없이 종료하고, 기존 Printing/SharePlus 공유 시트는 유지했습니다.
- controller/widget 테스트를 추가하고 기존 대시보드·리포트 버튼 테스트를 새 선택 흐름에 맞췄습니다.

## 검증
- flutter analyze lib 통과 (로컬 cornermon-flutter:3.44.7 Docker 이미지)
- #193 관련 controller/widget 테스트 32건 통과
- 전체 flutter test는 이 변경과 무관한 기존 테스트 5건 실패
- Android APK 빌드는 소스 오류 전 Maven Central의 kotlin-reflect-2.2.0.jar 다운로드 연결 재설정으로 중단됨

Closes #193