### PR TITLE
fix : 대시보드 완주율 100% 초과 표시 버그 수정

### DIFF
--- a/frontend/lib/admin/features/dashboard/dashboard_screen.dart
+++ b/frontend/lib/admin/features/dashboard/dashboard_screen.dart
@@ -405,7 +405,7 @@ class _SummaryBar extends StatelessWidget {
     error: (_, _) => const Text('요약을 불러오지 못했습니다'),
     data: (item) {
       final tiles = [
-        ('완주율', '${((item.completionRate ?? 0) * 100).round()}%'),
+        ('완주율', '${(item.completionRate ?? 0).round()}%'),
         (
           '미완주 조',
           '${(item.totalGroups ?? 0) - (item.finishedGroupCount ?? 0)}',

--- a/frontend/lib/admin/features/report/widgets/summary_tab.dart
+++ b/frontend/lib/admin/features/report/widgets/summary_tab.dart
@@ -14,9 +14,9 @@ import 'bottleneck_top3.dart';
 /// 완주율 — analytics-model.md §1.1 "전체 완주율"과 대응). `visitCompletionRate`는 별개로
 /// `CompletedVisits / TotalVisits * 100`(방문 단위)이라 이 카드가 요구하는 값이 아니다.
 /// `manualVisitRatio`도 동일하게 이미 0~100 퍼센트다. **`CornerStatsResponse.overDeviationRatio`
-/// (0~1 비율)와 스케일이 다르므로 혼동해서 다시 ×100 하지 않는다** — 이미 병합된
-/// `dashboard_screen.dart`의 `_SummaryBar`가 `completionRate`에 ×100을 한 번 더 하고 있는데,
-/// 이는 A1 범위의 기존 이슈이며 이 작업(A12)의 범위가 아니라 여기서 고치지 않는다.
+/// (0~1 비율)와 스케일이 다르므로 혼동해서 다시 ×100 하지 않는다** — `dashboard_screen.dart`의
+/// `_SummaryBar`가 `completionRate`에 ×100을 한 번 더 하던 버그(완주율이 100%를 넘게
+/// 표시되던 원인, 이슈 #201)는 수정 완료.
 /// `completionRate`가 없을 때만 `finishedGroupCount/totalGroups`를 직접 계산해 퍼센트로
 /// 변환한 값으로 폴백한다(둘 다 없으면 0%).
 class ReportSummaryTab extends StatelessWidget {

--- a/frontend/test/admin/features/dashboard/dashboard_screen_test.dart
+++ b/frontend/test/admin/features/dashboard/dashboard_screen_test.dart
@@ -62,7 +62,7 @@ CornerResponse _corner(
 
 CampSummaryStatsResponse _summary() => CampSummaryStatsResponse(
   (b) => b
-    ..completionRate = 0.7
+    ..completionRate = 70
     ..totalGroups = 10
     ..finishedGroupCount = 3
     ..programDurationSeconds = 3600,
@@ -265,6 +265,20 @@ void main() {
   });
 
   group('Dashboard screen', () {
+    testWidgets('ShoudRenderCompletionRateWithoutDoublingPercent', (
+      tester,
+    ) async {
+      // arrange: 백엔드 completionRate는 이미 0~100 스케일의 퍼센트 값이다
+      await _pumpDashboard(
+        tester,
+        campId: CampId('camp-1'),
+        corners: [_corner('corner-1', '코너 1', CornerResponseStatusEnum.BUSY)],
+      );
+
+      // act / assert: ×100을 다시 하지 않고 그대로 반올림해 표시해야 한다 (이슈 #201)
+      expect(find.text('70%'), findsOneWidget);
+    });
+
     testWidgets('ShoudRenderBottleneckBorderWhenCornerIsBottleneck', (
       tester,
     ) async {


### PR DESCRIPTION
## Summary
- 백엔드 `mapSummary()`(`backend/internal/infrastructure/web/report_handler.go`)가 반환하는 `completionRate`는 이미 0~100 스케일의 퍼센트 값(`FinishedGroups/TotalGroups*100`)인데, `frontend/lib/admin/features/dashboard/dashboard_screen.dart`의 `_SummaryBar`가 여기에 `×100`을 한 번 더 하고 있어 완주 조가 하나라도 있으면 완주율이 100%를 훨씬 넘게(최대 10000%) 표시되던 버그를 수정했다.
- `FinishedGroups`는 항상 `TotalGroups`의 부분집합으로 계산되어 백엔드 산출값 자체는 수학적으로 100을 넘을 수 없음을 확인했다(`backend/internal/infrastructure/postgres/report_querier.go:calculateCampReport`). 즉 원인은 전적으로 프론트엔드 표시 로직에 있었고, 백엔드는 수정하지 않았다.
- 같은 값을 참조하는 `summary_tab.dart`의 기존 주석("dashboard_screen.dart의 ×100 중복 버그, 이 작업 범위 아님")이 이번 수정으로 해소되었음을 반영해 갱신했다.

## Test plan
- [x] `flutter test test/admin/features/dashboard/dashboard_screen_test.dart` — 신규 회귀 테스트(`ShoudRenderCompletionRateWithoutDoublingPercent`) 포함 전체 통과
- [x] `flutter test test/admin/features/report/` — 관련 리포트 화면 테스트 전체 통과
- [x] `dart analyze` on changed files — 이슈 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)