### PR TITLE
feat: 운영 관리자 본인 탈퇴 허용 + 관리자 본인/목록 조회 API

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -18,6 +18,38 @@ const docTemplate = `{
     "basePath": "{{.BasePath}}",
     "paths": {
         "/admins": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 전체 관리자 목록을 반환합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "관리자 목록 조회",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AdminResponse"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -68,6 +100,37 @@ const docTemplate = `{
                 }
             }
         },
+        "/admins/me": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "로그인한 관리자 본인의 id/username/role을 반환합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "내 관리자 정보 조회",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admins/{id}": {
             "delete": {
                 "security": [
@@ -75,7 +138,7 @@ const docTemplate = `{
                         "AdminAuth": []
                     }
                 ],
-                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 자기 자신은 삭제할 수 없으므로 마지막 SYSTEM_ADMIN 삭제 요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.",
+                "description": "SYSTEM_ADMIN은 다른 관리자를 삭제할 수 있습니다. CORNER_OPERATOR는 본인 계정만 탈퇴할 수 있습니다. SYSTEM_ADMIN은 자기 자신을 삭제할 수 없으므로(마지막 SYSTEM_ADMIN 보호) 그 요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.",
                 "tags": [
                     "A. Auth \u0026 Device Trust"
                 ],

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -11,6 +11,38 @@
     "basePath": "/api/v1",
     "paths": {
         "/admins": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 전체 관리자 목록을 반환합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "관리자 목록 조회",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/AdminResponse"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            },
             "post": {
                 "security": [
                     {
@@ -61,6 +93,37 @@
                 }
             }
         },
+        "/admins/me": {
+            "get": {
+                "security": [
+                    {
+                        "AdminAuth": []
+                    }
+                ],
+                "description": "로그인한 관리자 본인의 id/username/role을 반환합니다.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "내 관리자 정보 조회",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/AdminResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/admins/{id}": {
             "delete": {
                 "security": [
@@ -68,7 +131,7 @@
                         "AdminAuth": []
                     }
                 ],
-                "description": "SYSTEM_ADMIN만 호출할 수 있습니다. 자기 자신은 삭제할 수 없으므로 마지막 SYSTEM_ADMIN 삭제 요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.",
+                "description": "SYSTEM_ADMIN은 다른 관리자를 삭제할 수 있습니다. CORNER_OPERATOR는 본인 계정만 탈퇴할 수 있습니다. SYSTEM_ADMIN은 자기 자신을 삭제할 수 없으므로(마지막 SYSTEM_ADMIN 보호) 그 요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.",
                 "tags": [
                     "A. Auth \u0026 Device Trust"
                 ],

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -926,6 +926,26 @@ info:
   version: 1.0.0
 paths:
   /admins:
+    get:
+      description: SYSTEM_ADMIN만 호출할 수 있습니다. 전체 관리자 목록을 반환합니다.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/AdminResponse'
+            type: array
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: 관리자 목록 조회
+      tags:
+      - A. Auth & Device Trust
     post:
       consumes:
       - application/json
@@ -960,8 +980,9 @@ paths:
       - A. Auth & Device Trust
   /admins/{id}:
     delete:
-      description: SYSTEM_ADMIN만 호출할 수 있습니다. 자기 자신은 삭제할 수 없으므로 마지막 SYSTEM_ADMIN 삭제
-        요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.
+      description: SYSTEM_ADMIN은 다른 관리자를 삭제할 수 있습니다. CORNER_OPERATOR는 본인 계정만 탈퇴할 수
+        있습니다. SYSTEM_ADMIN은 자기 자신을 삭제할 수 없으므로(마지막 SYSTEM_ADMIN 보호) 그 요청은 성립하지 않습니다.
+        삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.
       parameters:
       - description: 관리자 ID
         in: path
@@ -1020,6 +1041,25 @@ paths:
       security:
       - AdminAuth: []
       summary: 관리자 비밀번호 변경
+      tags:
+      - A. Auth & Device Trust
+  /admins/me:
+    get:
+      description: 로그인한 관리자 본인의 id/username/role을 반환합니다.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/AdminResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      security:
+      - AdminAuth: []
+      summary: 내 관리자 정보 조회
       tags:
       - A. Auth & Device Trust
   /api/v1/camps/{campId}/events/admin:

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -245,6 +245,9 @@ SELECT COUNT(*) FROM admins;
 -- name: CountAdminsByRole :one
 SELECT COUNT(*) FROM admins WHERE role = $1;
 
+-- name: ListAdmins :many
+SELECT * FROM admins ORDER BY username;
+
 -- name: GetAdminSession :one
 SELECT * FROM admin_sessions WHERE id = $1;
 

--- a/backend/internal/domain/admin.go
+++ b/backend/internal/domain/admin.go
@@ -20,6 +20,8 @@ type Admin struct {
 
 func (a *Admin) IsSystemAdmin() bool { return a.role == AdminRoleSystemAdmin }
 
+func (a *Admin) IsCornerOperator() bool { return a.role == AdminRoleCornerOperator }
+
 type AdminSession struct {
 	id              AdminSessionID
 	adminID         AdminID

--- a/backend/internal/infrastructure/postgres/admin_repo.go
+++ b/backend/internal/infrastructure/postgres/admin_repo.go
@@ -78,3 +78,15 @@ func (r *pgAdminRepository) CountByRole(ctx context.Context, role domain.AdminRo
 	count, err := r.queries(ctx).CountAdminsByRole(ctx, string(role))
 	return int(count), err
 }
+
+func (r *pgAdminRepository) List(ctx context.Context) ([]*domain.Admin, error) {
+	rows, err := r.queries(ctx).ListAdmins(ctx)
+	if err != nil {
+		return nil, errs.Wrap(ctx, err)
+	}
+	admins := make([]*domain.Admin, 0, len(rows))
+	for _, row := range rows {
+		admins = append(admins, mapAdmin(row))
+	}
+	return admins, nil
+}

--- a/backend/internal/infrastructure/postgres/db/querier.go
+++ b/backend/internal/infrastructure/postgres/db/querier.go
@@ -41,6 +41,7 @@ type Querier interface {
 	ListActiveFacilitatorSessionsByTrack(ctx context.Context, trackID string) ([]FacilitatorSession, error)
 	ListActiveTracksByCamp(ctx context.Context, campID string) ([]Track, error)
 	ListAdminSessionsByAdmin(ctx context.Context, adminID string) ([]AdminSession, error)
+	ListAdmins(ctx context.Context) ([]Admin, error)
 	ListAllBadges(ctx context.Context) ([]Badge, error)
 	ListAnnouncementReceiptViews(ctx context.Context, announcementID string) ([]ListAnnouncementReceiptViewsRow, error)
 	ListAnnouncementReceiptsByAnnouncement(ctx context.Context, announcementID string) ([]AnnouncementReceipt, error)

--- a/backend/internal/infrastructure/postgres/db/query.sql.go
+++ b/backend/internal/infrastructure/postgres/db/query.sql.go
@@ -660,6 +660,35 @@ func (q *Queries) ListAdminSessionsByAdmin(ctx context.Context, adminID string) 
 	return items, nil
 }
 
+const listAdmins = `-- name: ListAdmins :many
+SELECT id, username, password_hash, role FROM admins ORDER BY username
+`
+
+func (q *Queries) ListAdmins(ctx context.Context) ([]Admin, error) {
+	rows, err := q.db.Query(ctx, listAdmins)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []Admin
+	for rows.Next() {
+		var i Admin
+		if err := rows.Scan(
+			&i.ID,
+			&i.Username,
+			&i.PasswordHash,
+			&i.Role,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAllBadges = `-- name: ListAllBadges :many
 SELECT id, short_id, qr_payload, status, assigned_group_id FROM badges
 `

--- a/backend/internal/infrastructure/web/admin_management_handler.go
+++ b/backend/internal/infrastructure/web/admin_management_handler.go
@@ -14,6 +14,8 @@ type AdminManagementUsecase interface {
 	CreateAdmin(ctx context.Context, actorAdminID domain.AdminID, username, password string, role domain.AdminRole) (*domain.Admin, error)
 	ChangeAdminPassword(ctx context.Context, actorAdminID, targetAdminID domain.AdminID, newPassword string) error
 	DeleteAdmin(ctx context.Context, actorAdminID, targetAdminID domain.AdminID) error
+	GetAdmin(ctx context.Context, actorAdminID domain.AdminID) (*domain.Admin, error)
+	ListAdmins(ctx context.Context, actorAdminID domain.AdminID) ([]*domain.Admin, error)
 }
 
 type AdminManagementHandler struct{ admins AdminManagementUsecase }
@@ -90,7 +92,7 @@ func (h *AdminManagementHandler) ChangeAdminPassword(c echo.Context) error {
 }
 
 // @Summary      관리자 삭제
-// @Description  SYSTEM_ADMIN만 호출할 수 있습니다. 자기 자신은 삭제할 수 없으므로 마지막 SYSTEM_ADMIN 삭제 요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.
+// @Description  SYSTEM_ADMIN은 다른 관리자를 삭제할 수 있습니다. CORNER_OPERATOR는 본인 계정만 탈퇴할 수 있습니다. SYSTEM_ADMIN은 자기 자신을 삭제할 수 없으므로(마지막 SYSTEM_ADMIN 보호) 그 요청은 성립하지 않습니다. 삭제 시 admin_sessions는 DB foreign key cascade로 함께 제거됩니다.
 // @Tags         A. Auth & Device Trust
 // @Security     AdminAuth
 // @Param        id path string true "관리자 ID"
@@ -106,6 +108,50 @@ func (h *AdminManagementHandler) DeleteAdmin(c echo.Context) error {
 		return adminManagementError(err)
 	}
 	return c.NoContent(http.StatusNoContent)
+}
+
+// @Summary      내 관리자 정보 조회
+// @Description  로그인한 관리자 본인의 id/username/role을 반환합니다.
+// @Tags         A. Auth & Device Trust
+// @Security     AdminAuth
+// @Produce      json
+// @Success      200 {object} AdminResponse
+// @Failure      404 {object} ErrorResponse
+// @Router       /admins/me [get]
+func (h *AdminManagementHandler) GetMyAdmin(c echo.Context) error {
+	actor, ok := c.Get("adminSession").(*domain.AdminSession)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: CodeUnauthorized, Message: "unauthorized"})
+	}
+	admin, err := h.admins.GetAdmin(c.Request().Context(), actor.AdminID())
+	if err != nil {
+		return adminManagementError(err)
+	}
+	return c.JSON(http.StatusOK, AdminResponse{ID: string(admin.ID()), Username: admin.Username(), Role: string(admin.Role())})
+}
+
+// @Summary      관리자 목록 조회
+// @Description  SYSTEM_ADMIN만 호출할 수 있습니다. 전체 관리자 목록을 반환합니다.
+// @Tags         A. Auth & Device Trust
+// @Security     AdminAuth
+// @Produce      json
+// @Success      200 {array} AdminResponse
+// @Failure      403 {object} ErrorResponse
+// @Router       /admins [get]
+func (h *AdminManagementHandler) ListAdmins(c echo.Context) error {
+	actor, ok := c.Get("adminSession").(*domain.AdminSession)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: CodeUnauthorized, Message: "unauthorized"})
+	}
+	admins, err := h.admins.ListAdmins(c.Request().Context(), actor.AdminID())
+	if err != nil {
+		return adminManagementError(err)
+	}
+	res := make([]AdminResponse, 0, len(admins))
+	for _, admin := range admins {
+		res = append(res, AdminResponse{ID: string(admin.ID()), Username: admin.Username(), Role: string(admin.Role())})
+	}
+	return c.JSON(http.StatusOK, res)
 }
 
 func adminManagementError(err error) error {

--- a/backend/internal/infrastructure/web/admin_management_handler_test.go
+++ b/backend/internal/infrastructure/web/admin_management_handler_test.go
@@ -23,6 +23,20 @@ func (s adminManagementUsecaseStub) ChangeAdminPassword(context.Context, domain.
 func (s adminManagementUsecaseStub) DeleteAdmin(context.Context, domain.AdminID, domain.AdminID) error {
 	return s.err
 }
+func (s adminManagementUsecaseStub) GetAdmin(context.Context, domain.AdminID) (*domain.Admin, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return domain.NewAdminFromProps(domain.AdminProps{ID: "actor", Username: "actor", Role: domain.AdminRoleCornerOperator}), nil
+}
+func (s adminManagementUsecaseStub) ListAdmins(context.Context, domain.AdminID) ([]*domain.Admin, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return []*domain.Admin{
+		domain.NewAdminFromProps(domain.AdminProps{ID: "actor", Username: "actor", Role: domain.AdminRoleSystemAdmin}),
+	}, nil
+}
 
 func TestAdminManagementHandlerShouldMapDomainErrorsToHTTPStatus(t *testing.T) {
 	for _, tc := range []struct {
@@ -57,5 +71,45 @@ func TestAdminManagementHandlerShouldMapDomainErrorsToHTTPStatus(t *testing.T) {
 				t.Fatalf("expected status %d, got status=%d err=%v", tc.want, rec.Code, err)
 			}
 		})
+	}
+}
+
+func TestAdminManagementHandlerGetMyAdminShouldReturnSelf(t *testing.T) {
+	// Arrange
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/admins/me", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("adminSession", domain.NewAdminSessionFromProps(domain.AdminSessionProps{AdminID: "actor"}))
+	handler := NewAdminManagementHandler(adminManagementUsecaseStub{})
+
+	// Act
+	err := handler.GetMyAdmin(c)
+
+	// Assert
+	if err != nil || rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got status=%d err=%v", rec.Code, err)
+	}
+}
+
+func TestAdminManagementHandlerListAdminsShouldReturnForbiddenForCornerOperator(t *testing.T) {
+	// Arrange
+	e := echo.New()
+	e.HTTPErrorHandler = ErrorHandler()
+	req := httptest.NewRequest(http.MethodGet, "/admins", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("adminSession", domain.NewAdminSessionFromProps(domain.AdminSessionProps{AdminID: "actor"}))
+	handler := NewAdminManagementHandler(adminManagementUsecaseStub{err: domain.ErrAdminForbidden})
+
+	// Act
+	err := handler.ListAdmins(c)
+	if err != nil {
+		e.HTTPErrorHandler(err, c)
+	}
+
+	// Assert
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got status=%d err=%v", rec.Code, err)
 	}
 }

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -47,6 +47,8 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 	admin.GET("/auth/admin/sessions", h.Auth.ListAdminSessions)
 	admin.POST("/auth/admin/sessions/:id/revoke", h.Auth.RevokeAdminSession)
 	if h.AdminManagement != nil {
+		admin.GET("/admins/me", h.AdminManagement.GetMyAdmin)
+		admin.GET("/admins", h.AdminManagement.ListAdmins)
 		admin.POST("/admins", h.AdminManagement.CreateAdmin)
 		admin.PATCH("/admins/:id/password", h.AdminManagement.ChangeAdminPassword)
 		admin.DELETE("/admins/:id", h.AdminManagement.DeleteAdmin)

--- a/backend/internal/usecase/admin_management_test.go
+++ b/backend/internal/usecase/admin_management_test.go
@@ -135,6 +135,81 @@ func TestAdminAuthService_AdminManagement(t *testing.T) {
 			t.Fatalf("expected self-delete forbidden, got %v", err)
 		}
 	})
+
+	t.Run("ShouldAllowCornerOperatorToDeleteSelf", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["operator"] = domain.NewAdminFromProps(domain.AdminProps{ID: "operator", Role: domain.AdminRoleCornerOperator})
+
+		// Act
+		err := newAdminManagementService(admins).DeleteAdmin(context.Background(), "operator", "operator")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected corner operator self-withdrawal to succeed, got %v", err)
+		}
+		if _, ok := admins.Admins["operator"]; ok {
+			t.Fatal("expected operator to be removed after self-withdrawal")
+		}
+	})
+
+	t.Run("ShouldReturnForbiddenWhenCornerOperatorDeletesAnother", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["operator"] = domain.NewAdminFromProps(domain.AdminProps{ID: "operator", Role: domain.AdminRoleCornerOperator})
+		admins.Admins["other"] = domain.NewAdminFromProps(domain.AdminProps{ID: "other", Role: domain.AdminRoleCornerOperator})
+
+		// Act
+		err := newAdminManagementService(admins).DeleteAdmin(context.Background(), "operator", "other")
+
+		// Assert
+		if !errors.Is(err, domain.ErrAdminForbidden) {
+			t.Fatalf("expected forbidden, got %v", err)
+		}
+	})
+
+	t.Run("ShouldReturnSelfAdminWhenGetAdminCalled", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["operator"] = domain.NewAdminFromProps(domain.AdminProps{ID: "operator", Username: "operator", Role: domain.AdminRoleCornerOperator})
+
+		// Act
+		admin, err := newAdminManagementService(admins).GetAdmin(context.Background(), "operator")
+
+		// Assert
+		if err != nil || admin.Username() != "operator" {
+			t.Fatalf("expected self admin info, got admin=%+v err=%v", admin, err)
+		}
+	})
+
+	t.Run("ShouldListAllAdminsWhenActorIsSystemAdmin", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["system"] = domain.NewAdminFromProps(domain.AdminProps{ID: "system", Role: domain.AdminRoleSystemAdmin})
+		admins.Admins["operator"] = domain.NewAdminFromProps(domain.AdminProps{ID: "operator", Role: domain.AdminRoleCornerOperator})
+
+		// Act
+		list, err := newAdminManagementService(admins).ListAdmins(context.Background(), "system")
+
+		// Assert
+		if err != nil || len(list) != 2 {
+			t.Fatalf("expected 2 admins listed, got list=%+v err=%v", list, err)
+		}
+	})
+
+	t.Run("ShouldReturnForbiddenWhenCornerOperatorListsAdmins", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		admins.Admins["operator"] = domain.NewAdminFromProps(domain.AdminProps{ID: "operator", Role: domain.AdminRoleCornerOperator})
+
+		// Act
+		_, err := newAdminManagementService(admins).ListAdmins(context.Background(), "operator")
+
+		// Assert
+		if !errors.Is(err, domain.ErrAdminForbidden) {
+			t.Fatalf("expected forbidden, got %v", err)
+		}
+	})
 }
 
 func TestBootstrapAdmin(t *testing.T) {

--- a/backend/internal/usecase/auth_admin.go
+++ b/backend/internal/usecase/auth_admin.go
@@ -240,18 +240,33 @@ func (s *AdminAuthService) DeleteAdmin(
 	targetAdminID domain.AdminID,
 ) error {
 
-	if _, err := s.authorizeSystemAdmin(ctx, actorAdminID); err != nil {
-		return err // D-2 allowed: already wrapped or handled
+	actor, err := s.admins.Get(ctx, actorAdminID)
+	if err != nil {
+		return withErrorContext("auth_admin.delete_admin", "repository.get_actor", err, map[string]any{"actor_admin_id": string(actorAdminID)})
 	}
-	if actorAdminID == targetAdminID {
+	if actor == nil {
+		return withErrorContext("auth_admin.delete_admin", "validate_actor", domain.ErrAdminNotFound, map[string]any{"actor_admin_id": string(actorAdminID), "admin_found": false})
+	}
+
+	isSelf := actorAdminID == targetAdminID
+	// 운영 관리자(CORNER_OPERATOR)는 본인 계정을 탈퇴할 수 있다. 시스템 관리자의 본인 삭제는
+	// 마지막 시스템 관리자 보호와 무관하게 계속 금지한다.
+	if isSelf && !actor.IsCornerOperator() {
 		return withErrorContext("auth_admin.delete_admin", "validate_self_delete", domain.ErrAdminSelfDeleteForbidden, map[string]any{"admin_id": string(actorAdminID)})
 	}
-	target, err := s.admins.Get(ctx, targetAdminID)
-	if err != nil {
-		return withErrorContext("auth_admin.delete_admin", "repository.get_admin", err, map[string]any{"target_admin_id": string(targetAdminID)})
+	if !isSelf && !actor.IsSystemAdmin() {
+		return withErrorContext("auth_admin.delete_admin", "validate_system_admin", domain.ErrAdminForbidden, map[string]any{"actor_admin_id": string(actorAdminID), "role": string(actor.Role())})
 	}
-	if target == nil {
-		return withErrorContext("auth_admin.delete_admin", "validate_admin", domain.ErrAdminNotFound, map[string]any{"target_admin_id": string(targetAdminID), "admin_found": false})
+
+	target := actor
+	if !isSelf {
+		target, err = s.admins.Get(ctx, targetAdminID)
+		if err != nil {
+			return withErrorContext("auth_admin.delete_admin", "repository.get_admin", err, map[string]any{"target_admin_id": string(targetAdminID)})
+		}
+		if target == nil {
+			return withErrorContext("auth_admin.delete_admin", "validate_admin", domain.ErrAdminNotFound, map[string]any{"target_admin_id": string(targetAdminID), "admin_found": false})
+		}
 	}
 	if target.IsSystemAdmin() {
 		count, err := s.admins.CountByRole(ctx, domain.AdminRoleSystemAdmin)
@@ -268,11 +283,35 @@ func (s *AdminAuthService) DeleteAdmin(
 		}
 		return nil
 	}); err != nil {
-		s.recordAuditLog(ctx, domain.None[domain.CampID](), string(actorAdminID), adminActorLabel(ctx, s.admins, actorAdminID, nil), ActionAdminDelete, string(targetAdminID), target.Username(), false, errorAuditMetadata(err, nil))
+		s.recordAuditLog(ctx, domain.None[domain.CampID](), string(actorAdminID), adminActorLabel(ctx, s.admins, actorAdminID, actor), ActionAdminDelete, string(targetAdminID), target.Username(), false, errorAuditMetadata(err, nil))
 		return err // D-2 allowed: already wrapped or handled
 	}
-	s.recordAuditLog(ctx, domain.None[domain.CampID](), string(actorAdminID), adminActorLabel(ctx, s.admins, actorAdminID, nil), ActionAdminDelete, string(targetAdminID), target.Username(), true, nil)
+	s.recordAuditLog(ctx, domain.None[domain.CampID](), string(actorAdminID), adminActorLabel(ctx, s.admins, actorAdminID, actor), ActionAdminDelete, string(targetAdminID), target.Username(), true, map[string]any{"self": isSelf})
 	return nil
+}
+
+// GetAdmin - 세션 소유자 본인 정보를 조회한다. 별도 역할 인가는 필요하지 않다.
+func (s *AdminAuthService) GetAdmin(ctx context.Context, actorAdminID domain.AdminID) (*domain.Admin, error) {
+	admin, err := s.admins.Get(ctx, actorAdminID)
+	if err != nil {
+		return nil, withErrorContext("auth_admin.get_admin", "repository.get_admin", err, map[string]any{"actor_admin_id": string(actorAdminID)})
+	}
+	if admin == nil {
+		return nil, withErrorContext("auth_admin.get_admin", "validate_admin", domain.ErrAdminNotFound, map[string]any{"actor_admin_id": string(actorAdminID), "admin_found": false})
+	}
+	return admin, nil
+}
+
+// ListAdmins - 전체 관리자 목록을 조회한다. SYSTEM_ADMIN만 호출할 수 있다.
+func (s *AdminAuthService) ListAdmins(ctx context.Context, actorAdminID domain.AdminID) ([]*domain.Admin, error) {
+	if _, err := s.authorizeSystemAdmin(ctx, actorAdminID); err != nil {
+		return nil, err // D-2 allowed: already wrapped or handled
+	}
+	admins, err := s.admins.List(ctx)
+	if err != nil {
+		return nil, withErrorContext("auth_admin.list_admins", "repository.list_admins", err, nil)
+	}
+	return admins, nil
 }
 
 func (s *AdminAuthService) authorizeSystemAdmin(ctx context.Context, actorAdminID domain.AdminID) (*domain.Admin, error) {

--- a/backend/internal/usecase/mock_test.go
+++ b/backend/internal/usecase/mock_test.go
@@ -521,6 +521,14 @@ func (r *MockAdminRepository) CountByRole(ctx context.Context, role domain.Admin
 	return count, nil
 }
 
+func (r *MockAdminRepository) List(ctx context.Context) ([]*domain.Admin, error) {
+	admins := make([]*domain.Admin, 0, len(r.Admins))
+	for _, admin := range r.Admins {
+		admins = append(admins, admin)
+	}
+	return admins, nil
+}
+
 // MockAdminSessionRepository
 type MockAdminSessionRepository struct {
 	Sessions map[domain.AdminSessionID]*domain.AdminSession

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -140,6 +140,7 @@ type AdminRepository interface {
 	Delete(ctx context.Context, id domain.AdminID) error
 	Count(ctx context.Context) (int, error)
 	CountByRole(ctx context.Context, role domain.AdminRole) (int, error)
+	List(ctx context.Context) ([]*domain.Admin, error)
 }
 
 // AdminSessionRepository는 관리자 세션 엔티티의 지속성을 담당하는 포트입니다.

--- a/docs/artifacts/plan/20260724_관리자_계정_관리_plan_/00_overview.md
+++ b/docs/artifacts/plan/20260724_관리자_계정_관리_plan_/00_overview.md
@@ -1,0 +1,45 @@
+# 관리자 계정 관리 기능 — 개요
+
+- 이슈: #198 (시스템 관리자의 관리자 계정 생성 기능 추가) + 사용자 추가 요청(비밀번호 변경 화면)
+- 작업 분류: 공통 작업(백엔드+프론트엔드) → 단계별로 디렉토리 분할 (`workflow/plan.md` 규칙)
+
+## 조사 결과 요약 (계획 전 코드 이해)
+
+1. **관리자 추가(CreateAdmin) / 비밀번호 변경(ChangeAdminPassword) / 삭제(DeleteAdmin, SYSTEM_ADMIN→타 관리자)는
+   이미 `main`에 병합되어 있다** (PR #89, #90, `internal/usecase/auth_admin.go`,
+   `internal/infrastructure/web/admin_management_handler.go`, `api/swagger.yaml` `/admins*`).
+   이슈 #198의 "추가"/"삭제" 유즈케이스와 사용자가 요청한 "비밀번호 변경"은 백엔드 로직만 놓고 보면
+   이미 구현되어 있으므로 이번 작업 범위에서 **재구현하지 않는다**.
+2. 실제로 비어 있는 것은 **"운영 관리자 본인 탈퇴(self-delete)"** 뿐이다. 현재 `DeleteAdmin`은
+   `actorAdminID == targetAdminID`이면 역할과 무관하게 무조건 `ErrAdminSelfDeleteForbidden`을 반환한다
+   (`auth_admin.go:246`, 테스트 `ShouldPreventDeletingSelfAndAllowDeletingAnotherSystemAdmin`).
+3. 프론트엔드는 이 세 기능(추가/삭제/비밀번호 변경) 중 **어느 것도 화면이 없다** — 생성된 API
+   클라이언트(`lib/shared/api/gen`)에 메서드는 존재하지만 `lib/admin/**`의 어떤 화면도 호출하지 않는다.
+4. 프론트엔드 조사 중 더 근본적인 공백을 발견했다: **로그인 응답(`AdminLoginResponse`)에 관리자 본인의
+   실제 ID/역할이 없다.** 클라이언트는 로그인 아이디(username)만 `adminId`라는 이름으로 저장하고 있어
+   (`admin_session_provider.dart`), 자기 자신을 대상으로 하는 API(`PATCH /admins/{id}/password`,
+   `DELETE /admins/{id}`)를 호출할 방법이 없다. 또한 세션은 앱 재시작 시 로그인 재수행 없이
+   저장된 토큰만으로 복원되므로(`_restore()`), 로그인 응답에만 id/role을 실어 보내는 방식으로는
+   재시작 후 정보가 유실된다. → **`GET /admins/me` 신규 엔드포인트로 해결한다** (사용자 확인 완료).
+5. SYSTEM_ADMIN이 운영 관리자를 삭제하려면 대상을 고를 목록이 필요한데 **`GET /admins` 목록 조회
+   API도 없다.** → 신규 추가.
+
+## 범위
+
+사용자 확인에 따라 **전체 관리자 계정 관리 화면**을 구현한다:
+
+| 유즈케이스 | 상태 |
+|---|---|
+| SYSTEM_ADMIN이 운영 관리자를 추가한다 | 백엔드 기구현 · 프론트 신규 |
+| SYSTEM_ADMIN이 운영 관리자를 삭제한다 | 백엔드 기구현 · 프론트 신규 |
+| 관리자가 본인 비밀번호를 변경한다 | 백엔드 기구현 · 프론트 신규 |
+| **운영 관리자가 본인 계정을 탈퇴한다** | **백엔드 신규(자기삭제 정책 변경)** · 프론트 신규 |
+| 관리자가 본인 정보(id/role)를 조회한다 | **백엔드 신규(`GET /admins/me`)** · 프론트 신규 |
+| SYSTEM_ADMIN이 관리자 목록을 조회한다 | **백엔드 신규(`GET /admins`)** · 프론트 신규 |
+
+## 단계 구성
+
+1. `01_backend_self_delete_and_query_api.md` — 백엔드: 본인 탈퇴 정책 + `GET /admins/me` + `GET /admins`
+2. `02_frontend_admin_management_screen.md` — 프론트엔드: 관리자 계정 관리 화면 전체
+
+`workflow/implement.md`에 따라 각 단계는 커밋 단위(LOC 300줄 내외)로 더 쪼개서 구현한다.

--- a/docs/artifacts/plan/20260724_관리자_계정_관리_plan_/01_backend_self_delete_and_query_api.md
+++ b/docs/artifacts/plan/20260724_관리자_계정_관리_plan_/01_backend_self_delete_and_query_api.md
@@ -1,0 +1,195 @@
+# 01. 백엔드 — 운영 관리자 본인 탈퇴 + 관리자 조회 API
+
+## 1. 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| **P0** | UC-1: 운영 관리자 본인 탈퇴 | `CORNER_OPERATOR`가 `DELETE /admins/{id}`로 자기 자신을 삭제할 수 있다. `SYSTEM_ADMIN`의 본인 삭제는 계속 금지(기존 정책 유지). | **프로덕션 핵심 로직** |
+| **P0** | UC-2: 관리자 본인 정보 조회 | `GET /admins/me` — 세션의 관리자 본인 id/username/role을 반환한다. 프론트가 자기 자신을 대상으로 한 API(비밀번호 변경, 탈퇴)를 호출하려면 실제 id가 필요하다. | **프로덕션 핵심 로직** |
+| **P0** | UC-3: 관리자 목록 조회 | `GET /admins` — `SYSTEM_ADMIN`만 호출 가능, 전체 관리자 목록(id/username/role)을 반환한다. 관리자 관리 화면의 목록/삭제 대상 선택에 사용. | **프로덕션 핵심 로직** |
+
+기존에 이미 구현되어 변경하지 않는 것: `CreateAdmin`(POST /admins), `ChangeAdminPassword`(PATCH
+/admins/{id}/password), `DeleteAdmin`의 SYSTEM_ADMIN→타 관리자 삭제 경로, 마지막 SYSTEM_ADMIN
+보호(`ErrAdminLastSystemAdmin`).
+
+## 2. 아키텍처 원칙 검증
+
+- Domain은 역할 판별 predicate만 추가(순수 Go, 외부 의존성 없음).
+- 새 포트를 만들지 않고 기존 `AdminRepository`(`internal/usecase/port.go`)에 `List` 메서드만 확장한다.
+- `AdminManagementHandler`/`AdminManagementUsecase` 기존 구조를 그대로 확장한다(새 핸들러 struct
+  생성하지 않음).
+- 읽기 전용 조회(UC-2, UC-3)는 비즈니스 규칙이 거의 없는 단순 조회이지만, UC-3에는 "SYSTEM_ADMIN만"이라는
+  인가 판단이 있으므로 `DEVELOPER_GUIDE.md` CQRS 가이드의 "인가 정책이 개입하면 유즈케이스 레이어 유지"
+  원칙에 따라 기존 `AdminAuthService`(이미 있는 서비스) 메서드로 구현한다 — 신규 Read-only Port를
+  따로 만들지 않는다.
+
+## 3. 계층별 설계
+
+### 3.1 Domain (`internal/domain/admin.go`)
+
+```go
+// 책임: 역할 predicate 추가 (기존 IsSystemAdmin과 대칭)
+func (a *Admin) IsCornerOperator() bool { return a.role == AdminRoleCornerOperator }
+```
+
+도메인 에러/상태 전이는 추가하지 않는다. "본인 탈퇴 가능 여부"는 role 두 가지 predicate의 조합으로
+usecase가 판단한다(기존에도 `IsSystemAdmin()`을 usecase에서 조합해 정책을 만드는 방식과 동일).
+
+### 3.2 Usecase (`internal/usecase/auth_admin.go`)
+
+```go
+// 책임: 본인 탈퇴(CORNER_OPERATOR) 또는 SYSTEM_ADMIN의 타 관리자 삭제 허용.
+// SYSTEM_ADMIN의 본인 삭제는 기존과 동일하게 금지.
+func (s *AdminAuthService) DeleteAdmin(
+    ctx context.Context,
+    actorAdminID domain.AdminID,
+    targetAdminID domain.AdminID,
+) error
+
+// 책임: 세션 소유자 본인 조회. 별도 역할 인가 불필요(누구나 자기 자신은 조회 가능).
+func (s *AdminAuthService) GetAdmin(
+    ctx context.Context,
+    actorAdminID domain.AdminID,
+) (*domain.Admin, error)
+
+// 책임: 전체 관리자 목록 조회. SYSTEM_ADMIN 전용(authorizeSystemAdmin 재사용).
+func (s *AdminAuthService) ListAdmins(
+    ctx context.Context,
+    actorAdminID domain.AdminID,
+) ([]*domain.Admin, error)
+```
+
+`DeleteAdmin`의 인가 분기 의사코드(상세 구현은 개발자 재량):
+
+```
+actor := admins.Get(actorAdminID)  // nil이면 ErrAdminNotFound
+isSelf := actorAdminID == targetAdminID
+switch {
+case isSelf && actor.IsCornerOperator():
+    // 허용 — 별도 SYSTEM_ADMIN 권한 불필요
+case isSelf: // actor는 SYSTEM_ADMIN
+    return ErrAdminSelfDeleteForbidden  // 기존 동작 유지
+default:
+    if !actor.IsSystemAdmin() { return ErrAdminForbidden }
+}
+target := isSelf ? actor : admins.Get(targetAdminID)  // nil이면 ErrAdminNotFound
+// 이하 기존 로직 그대로: target이 SYSTEM_ADMIN이면 CountByRole로 마지막 1인 보호,
+// tx 안에서 Delete, 커밋 후 recordAuditLog(ActionAdminDelete, metadata: {"self": isSelf})
+```
+
+**주의**: 현재 코드는 `authorizeSystemAdmin(ctx, actorAdminID)`을 함수 진입부에서 즉시 호출해 actor를
+가져온다. 이 헬퍼를 그대로 쓰면 CORNER_OPERATOR가 진입 시점에 곧바로 `ErrAdminForbidden`으로 막히므로,
+본인 탈퇴 분기를 먼저 판별할 수 있도록 actor 조회와 SYSTEM_ADMIN 인가 체크를 분리해야 한다
+(`authorizeSystemAdmin` 헬퍼는 `isSelf`가 아닐 때만 사용).
+
+`GetAdmin`/`ListAdmins`는 기존 `recordAuditLog` 패턴을 따르지 않는다 — 코드베이스 관례상 단순 조회
+(`ListSessions`, `ListCamps` 등)는 감사 로그를 남기지 않는다.
+
+### 3.3 Infrastructure — Postgres (`internal/infrastructure/postgres/admin_repo.go`)
+
+```go
+// 책임: 전체 관리자 목록 조회(생성 시각 컬럼이 없으므로 username 오름차순 정렬).
+func (r *pgAdminRepository) List(ctx context.Context) ([]*domain.Admin, error)
+```
+
+`db/query.sql`에 추가:
+
+```sql
+-- name: ListAdmins :many
+SELECT * FROM admins ORDER BY username;
+```
+
+추가 후 `sqlc generate` 실행 → `internal/infrastructure/postgres/db` 재생성 산출물 갱신.
+스키마 변경 없음(마이그레이션 불필요) — `admins` 테이블은 이미 존재.
+
+### 3.4 Port (`internal/usecase/port.go`)
+
+```go
+type AdminRepository interface {
+    Get(ctx context.Context, id domain.AdminID) (*domain.Admin, error)
+    GetByUsername(ctx context.Context, username string) (*domain.Admin, error)
+    Save(ctx context.Context, admin *domain.Admin) error
+    Delete(ctx context.Context, id domain.AdminID) error
+    Count(ctx context.Context) (int, error)
+    CountByRole(ctx context.Context, role domain.AdminRole) (int, error)
+    List(ctx context.Context) ([]*domain.Admin, error) // 신규
+}
+```
+
+### 3.5 Web (`internal/infrastructure/web/admin_management_handler.go`)
+
+```go
+type AdminManagementUsecase interface {
+    CreateAdmin(...) (*domain.Admin, error)          // 기존
+    ChangeAdminPassword(...) error                    // 기존
+    DeleteAdmin(...) error                             // 기존 (내부 정책만 변경)
+    GetAdmin(ctx context.Context, actorAdminID domain.AdminID) (*domain.Admin, error)       // 신규
+    ListAdmins(ctx context.Context, actorAdminID domain.AdminID) ([]*domain.Admin, error)    // 신규
+}
+
+// @Summary 내 관리자 정보 조회
+// @Router  /admins/me [get]
+func (h *AdminManagementHandler) GetMyAdmin(c echo.Context) error
+
+// @Summary 관리자 목록 조회 (SYSTEM_ADMIN 전용)
+// @Router  /admins [get]
+func (h *AdminManagementHandler) ListAdmins(c echo.Context) error
+```
+
+응답 DTO는 기존 `AdminResponse`를 재사용(`GetMyAdmin`은 단일, `ListAdmins`는 `[]AdminResponse`) —
+필드가 이미 `id/username/role`로 API 계약과 1:1 대응한다. 에러 매핑은 기존 로컬 헬퍼
+`adminManagementError(err)`를 그대로 재사용한다(이 핸들러는 중앙 `mapDomainError`가 아니라 자체
+스위치문으로 `ErrAdmin*`를 처리하는 기존 관례 — `error_handler_middleware.go`에는 `ErrAdmin*` 매핑이
+없음을 확인함).
+
+`DeleteAdmin` 핸들러의 swag 설명 주석 갱신 필요:
+> "SYSTEM_ADMIN은 다른 관리자를 삭제할 수 있습니다. CORNER_OPERATOR는 본인 계정만 탈퇴할 수 있습니다.
+> SYSTEM_ADMIN은 자기 자신을 삭제할 수 없습니다(마지막 시스템 관리자 보호)."
+
+### 3.6 Router (`internal/infrastructure/web/router.go`)
+
+```go
+admin.GET("/admins/me", h.AdminManagement.GetMyAdmin)
+admin.GET("/admins", h.AdminManagement.ListAdmins)
+```
+(`AdminAuthMiddleware` 그룹 안에 기존 `/admins` 라우트들과 나란히 추가 — 경로 충돌 없음: `POST/GET
+/admins`, `GET /admins/me` vs `PATCH/DELETE /admins/:id`.)
+
+## 4. 구현 단계
+
+| 순서 | 작업 | 파일 | 예상 소요 |
+|---|---|---|---|
+| A-1 | `Admin.IsCornerOperator()` 추가 | `internal/domain/admin.go` (기존 파일 확장) | 10분 |
+| B-1 | `DeleteAdmin` 인가 로직 분기 수정 | `internal/usecase/auth_admin.go` (기존 파일 확장) | 40분 |
+| B-2 | `GetAdmin`, `ListAdmins` usecase 메서드 추가 | `internal/usecase/auth_admin.go` | 30분 |
+| C-1 | `ListAdmins` sqlc 쿼리 추가 + `sqlc generate` | `backend/db/query.sql` (신규 쿼리) | 15분 |
+| C-2 | `AdminRepository.List` 포트 확장 + pg 구현체 | `internal/usecase/port.go`, `internal/infrastructure/postgres/admin_repo.go` | 20분 |
+| C-3 | `MockAdminRepository.List` 테스트 더블 추가 | `internal/usecase/mock_test.go` (기존 파일 확장) | 10분 |
+| D-1 | `GetMyAdmin`/`ListAdmins` 핸들러 + swag 주석 | `internal/infrastructure/web/admin_management_handler.go` | 40분 |
+| D-2 | 라우트 등록 | `internal/infrastructure/web/router.go` | 10분 |
+| D-3 | `make swag` 실행 → `api/swagger.yaml`/`swagger.json`/`docs.go` 갱신 | (자동 생성, `workflow/Collaborate.md` 준수) | 5분 |
+| E-1 | usecase 테스트: 본인 탈퇴 허용/SYSTEM_ADMIN 본인삭제 금지 유지/타인 삭제 여전히 SYSTEM_ADMIN 전용/GetAdmin/ListAdmins | `internal/usecase/admin_management_test.go` (기존 파일 확장) | 40분 |
+| E-2 | 핸들러 테스트: 신규 두 엔드포인트 에러 매핑 | `internal/infrastructure/web/admin_management_handler_test.go` (기존 파일 확장) | 20분 |
+
+## 5. 검증 체크리스트
+
+### 5.1 아키텍처 검증
+- [ ] `domain` 패키지에서 `infrastructure` import 없음
+- [ ] `AdminManagementHandler`는 `AdminManagementUsecase` 인터페이스에만 의존
+- [ ] 새 리포지토리 메서드는 최소 필요분(`List`)만 추가, 범용 `Update`류 추가하지 않음
+
+### 5.2 유즈케이스 검증 (자동 테스트)
+- [ ] `ShouldAllowCornerOperatorToDeleteSelf`
+- [ ] `ShouldPreventSystemAdminFromDeletingSelf` (기존 테스트명 유지 또는 위 테스트로 흡수)
+- [ ] `ShouldReturnForbiddenWhenCornerOperatorDeletesAnotherAdmin` (본인 탈퇴가 아닌 경로는 여전히 SYSTEM_ADMIN 전용임을 확인)
+- [ ] `ShouldReturnSelfAdminWhenGetAdminCalled`
+- [ ] `ShouldListAllAdminsWhenActorIsSystemAdmin`
+- [ ] `ShouldReturnForbiddenWhenCornerOperatorListsAdmins`
+- [ ] 핸들러 레벨: `GET /admins/me`, `GET /admins` 에러 매핑(403/401) 테스트
+- [ ] `go test ./...` 전체 통과
+- [ ] `gofmt -w . && go vet ./...` 클린
+
+### 5.3 수동 검증
+- [ ] 로컬 서버 기동 후 `curl`로 `GET /admins/me`, `GET /admins`, `DELETE /admins/{자기id}`(CORNER_OPERATOR
+      세션) 실제 호출해 응답 확인
+- [ ] 마지막 SYSTEM_ADMIN 보호가 여전히 동작하는지 확인(회귀 없음)

--- a/docs/artifacts/plan/20260724_관리자_계정_관리_plan_/02_frontend_admin_management_screen.md
+++ b/docs/artifacts/plan/20260724_관리자_계정_관리_plan_/02_frontend_admin_management_screen.md
@@ -1,0 +1,169 @@
+# 02. 프론트엔드 — 관리자 계정 관리 화면
+
+**선행 조건**: `01_backend_self_delete_and_query_api.md`가 먼저 병합되어 `GET /admins/me`,
+`GET /admins`, 그리고 CORNER_OPERATOR 본인 탈퇴가 가능한 `DELETE /admins/{id}`가 배포돼 있어야
+한다. `api/swagger.yaml`이 갱신된 뒤 `openapi-generator`로 `lib/shared/api/gen`을 재생성한다.
+
+## 1. 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| **P0** | UC-F1: 로그인/세션 복원 시 본인 정보 확보 | 로그인 성공 또는 앱 재시작 시 토큰 복원 후 `GET /admins/me`를 호출해 실제 `id`/`role`을 세션 상태에 채운다. | **프로덕션 핵심** — 나머지 모든 유즈케이스의 전제 조건 |
+| **P0** | UC-F2: 관리자 목록 조회 + 추가 | SYSTEM_ADMIN이 `/admins` 화면에서 전체 관리자 목록을 보고, 다이얼로그로 새 CORNER_OPERATOR를 추가한다. | **프로덕션 핵심** |
+| **P0** | UC-F3: 관리자 삭제 (SYSTEM_ADMIN → 타 관리자) | 목록의 각 행에서 삭제, 확인 모달 후 실행. | **프로덕션 핵심** |
+| **P0** | UC-F4: 본인 비밀번호 변경 | 로그인한 관리자가 "내 계정" 섹션에서 새 비밀번호를 입력해 변경한다. | **프로덕션 핵심** |
+| **P0** | UC-F5: 운영 관리자 본인 탈퇴 | CORNER_OPERATOR가 "내 계정" 섹션에서 탈퇴 버튼 → 확인 모달 → 삭제 성공 시 로컬 세션만 정리하고 로그인 화면으로 이동. | **프로덕션 핵심** |
+
+## 2. 조사 결과 — 왜 이런 구조인가
+
+- `/settings`(`lib/admin/features/settings/settings_screen.dart`)는 **캠프에 종속된** 화면이다
+  (`admin_router.dart`의 `_preparingLocations`에만 포함되고, `_campIndependentLocations`에는
+  없음 — ENDED 캠프에서는 아예 진입 불가). 관리자 계정은 캠프와 무관한 전역 개념이므로 여기에
+  얹지 않는다.
+- 캠프와 무관한 화면은 `/camps`, `/badges`, `/setup-wizard`처럼 `AdminScaffold`(사이드바) 없이
+  독립 라우트로 등록되어 있다(`admin_router.dart` `_campIndependentLocations`). 새 화면도 이
+  패턴을 따른다: `/admins` 라우트를 `_campIndependentLocations`에 추가하고, `CampListScreen`의
+  AppBar `actions`(`'/badges'`로 가는 `TextButton.icon`과 동일한 패턴)에 진입점을 둔다.
+- `AdminSession`(`lib/admin/session/admin_session_provider.dart`)은 `_restore()`에서 로그인을
+  다시 하지 않고 저장된 토큰만으로 상태를 복원한다. 따라서 로그인 응답에만 role/id를 실어봐야
+  재시작 후 유실된다 — `_restore()`와 `login()` 양쪽에서 공유하는 헬퍼가 토큰 확보 후
+  `GET /admins/me`를 호출해 상태를 채우는 구조로 만든다(사용자 확인: `/me` 방향 채택).
+- 본인 탈퇴 성공 후에는 **`AdminSession.logout()`을 호출하면 안 된다.** `admin_sessions`는
+  `admins`에 대해 `ON DELETE CASCADE`이므로(`db/migrations/20260723100000_init_schema.up.sql`),
+  본인 삭제 시점에 이미 현재 세션 행이 DB에서 사라진다. 그 상태로 `POST /auth/admin/logout`을
+  호출하면 `AdminAuthMiddleware`가 토큰 검증에 실패해 401만 돌아올 뿐이다. 대신 이미 존재하는
+  **로컬 전용 정리 메서드 `AdminSession.invalidate()`**(서버 호출 없이 토큰 삭제 + 상태 전환,
+  401 자동 처리 경로에서 이미 쓰이는 기존 메서드)를 재사용한다 — 새 메서드를 만들지 않는다.
+
+## 3. 설계
+
+### 3.1 세션 상태 확장 (`lib/admin/session/admin_session_provider.dart`)
+
+```dart
+class AdminSessionAuthenticated extends AdminSessionState {
+  const AdminSessionAuthenticated({
+    required this.accessToken,
+    required this.adminId,   // 실제 서버 ID로 의미 변경 (기존: username 임시값)
+    required this.username,
+    required this.role,      // AdminResponseRoleEnum
+  });
+}
+
+class AdminSession extends Notifier<AdminSessionState> {
+  // 책임: 토큰 확보(_restore 또는 login) 이후 GET /admins/me로 본인 정보를 채운다.
+  Future<void> _loadSelf(String accessToken) async { ... }
+}
+```
+
+`_restore()`/`login()` 모두 토큰을 얻은 뒤 `_loadSelf`를 호출하도록 리팩터링한다. `/admins/me`
+호출 실패(예: 토큰 만료)는 기존 401 처리 경로(`admin_session_token_source.dart`의 자동
+`invalidate()`)에 자연스럽게 위임된다.
+
+### 3.2 API Provider (`lib/shared/api/providers/auth_device_trust_providers.dart` 기존 파일 확장)
+
+기존 `adminLogin`/`adminLogout`/`revokeAdminSession` 등과 동일한 관례(`AAuthDeviceTrustApi` 재사용,
+쓰기 액션은 `@Riverpod(retry: noRetry)`)를 따른다.
+
+```dart
+@riverpod
+Future<AdminResponse> currentAdmin(Ref ref) async { ... } // GET /admins/me
+
+@riverpod
+Future<List<AdminResponse>> adminList(Ref ref) async { ... } // GET /admins
+
+@Riverpod(retry: noRetry)
+Future<AdminResponse> createAdmin(Ref ref, String username, String password) async { ... } // POST /admins, role 고정 CORNER_OPERATOR
+
+@Riverpod(retry: noRetry)
+Future<void> deleteAdminAccount(Ref ref, String adminId) async { ... } // DELETE /admins/{id}
+
+@Riverpod(retry: noRetry)
+Future<void> changeAdminPassword(Ref ref, String adminId, String newPassword) async { ... } // PATCH /admins/{id}/password
+```
+
+### 3.3 화면 (신규 디렉토리 `lib/admin/features/admin_management/`)
+
+`lib/admin/features/group_list/group_list_screen.dart`의 구조(목록 `ConsumerWidget` +
+`.when(loading/error/data)` + `_RegisterGroupDialog` 형태의 `ConsumerStatefulWidget` 다이얼로그,
+로컬 `_busy` bool)를 그대로 미러링한다.
+
+```
+lib/admin/features/admin_management/
+  admin_management_screen.dart   # 목록 + "내 계정" 섹션을 함께 렌더링하는 최상위 화면
+  widgets/
+    _create_admin_dialog.dart     # username/password 입력 다이얼로그 (SYSTEM_ADMIN 전용)
+    _admin_list_tile.dart         # 목록 행 + 삭제 버튼(SYSTEM_ADMIN 전용, showConfirmModal)
+    _my_account_card.dart         # 비밀번호 변경 폼 + (CORNER_OPERATOR인 경우) 탈퇴 버튼
+```
+
+- `AdminManagementScreen`은 `currentAdminProvider`로 본인 role을 읽어 분기한다:
+  - `role == SYSTEM_ADMIN`: `adminListProvider` 목록 + 추가 버튼 + 각 행 삭제 버튼을 보여준다.
+  - `role == CORNER_OPERATOR`: 목록 없이 `_MyAccountCard`만 보여준다(목록/추가/삭제는 서버가
+    403을 반환하므로 애초에 렌더링하지 않는다).
+  - `_MyAccountCard`(비밀번호 변경 + 탈퇴)는 두 role 모두에게 보인다.
+- 삭제/탈퇴 모두 `showConfirmModal(kind: ConfirmModalKind.softConfirm, ...)`을 거친다
+  (`lib/admin/features/session_manage/_admin_sessions_card.dart`의 `revoke()` 패턴과 동일).
+- 탈퇴 성공 콜백:
+  ```dart
+  await ref.read(deleteAdminAccountProvider(myId).future);
+  await ref.read(adminSessionProvider.notifier).invalidate(); // 서버 재호출 없이 로컬 정리
+  if (context.mounted) context.go('/login');
+  ```
+- 에러 표시는 `DEVELOPER_GUIDE.md` §4 규칙(커넥션 유실 → 상단 배너, 그 외 4xx/5xx → SnackBar) 그대로
+  따른다.
+
+### 3.4 라우팅 (`lib/admin/router/admin_router.dart`)
+
+```dart
+const _campIndependentLocations = {
+  '/login', '/setup-wizard', '/camps', '/badges',
+  '/admins', // 신규
+};
+...
+_route('/admins', (_, _) => const AdminManagementScreen()),
+```
+
+`CampListScreen`(`lib/admin/features/camp_list/camp_list_screen.dart`) AppBar `actions`에 진입점
+추가(기존 `'/badges'` 버튼과 동일한 자리):
+
+```dart
+TextButton.icon(
+  onPressed: () => context.go('/admins'),
+  icon: const Icon(Icons.admin_panel_settings_outlined),
+  label: const Text('관리자 계정 관리'),
+),
+```
+
+## 4. 구현 단계
+
+| 순서 | 작업 | 파일 | 예상 소요 |
+|---|---|---|---|
+| F-1 | 백엔드 `swagger.yaml` 갱신분으로 `openapi-generator` 재생성 | `lib/shared/api/gen/**` (자동 생성) | 10분 |
+| F-2 | `AdminSessionAuthenticated`에 `username`/`role` 추가, `_loadSelf()` 도입해 `_restore()`/`login()` 리팩터 | `lib/admin/session/admin_session_provider.dart` | 1시간 |
+| F-3 | `currentAdmin`/`adminList`/`createAdmin`/`deleteAdminAccount`/`changeAdminPassword` provider 추가 | `lib/shared/api/providers/auth_device_trust_providers.dart` (기존 파일 확장) | 40분 |
+| F-4 | `AdminManagementScreen` + 목록/추가 다이얼로그(SYSTEM_ADMIN 경로) | `lib/admin/features/admin_management/admin_management_screen.dart`, `widgets/_create_admin_dialog.dart`, `widgets/_admin_list_tile.dart` (신규) | 2시간 |
+| F-5 | `_MyAccountCard`(비밀번호 변경 + 본인 탈퇴, 두 role 공통) | `lib/admin/features/admin_management/widgets/_my_account_card.dart` (신규) | 1.5시간 |
+| F-6 | 라우팅 등록 + `CampListScreen` 진입점 버튼 | `lib/admin/router/admin_router.dart`, `lib/admin/features/camp_list/camp_list_screen.dart` (기존 파일 확장) | 20분 |
+| F-7 | `dart run build_runner build` 실행 후 `lib/shared/api/gen` 삭제/변경 여부 확인·복구 (`DEVELOPER_GUIDE.md` §1 주의사항) | - | 10분 |
+| F-8 | 위젯 테스트: 목록/추가/삭제/비밀번호변경/탈퇴 각 플로우 | `test/admin/features/admin_management/` (신규) | 1.5시간 |
+
+## 5. 검증 체크리스트
+
+### 5.1 코드 검증
+- [ ] `dart analyze lib/` 클린
+- [ ] `flutter test test/admin/features/admin_management/` 통과
+- [ ] `dart run build_runner build` 후 `git status --porcelain lib/shared/api/gen`이 깨끗함(의도치 않은
+      삭제 없음)
+
+### 5.2 유즈케이스 검증 (실기기/데스크톱 수동 테스트, `make run-admin`)
+- [ ] SYSTEM_ADMIN으로 로그인 → `/camps`에서 "관리자 계정 관리" 진입 → 목록에 본인 포함 전원 표시
+- [ ] SYSTEM_ADMIN이 새 운영 관리자 추가 → 목록에 즉시 반영(`ref.invalidate`)
+- [ ] SYSTEM_ADMIN이 다른 운영 관리자 삭제(확인 모달 경유) → 목록에서 제거
+- [ ] SYSTEM_ADMIN 본인 비밀번호 변경 → 재로그인 시 새 비밀번호로 성공
+- [ ] CORNER_OPERATOR로 로그인 → `/admins` 진입 시 목록/추가 UI 없이 "내 계정" 카드만 노출
+- [ ] CORNER_OPERATOR 본인 비밀번호 변경 성공
+- [ ] **CORNER_OPERATOR 본인 탈퇴 → 확인 모달 → 성공 시 즉시 로그인 화면으로 이동, 재로그인 시도 시
+      실패(계정 삭제 확인)**
+- [ ] 앱 완전 종료 후 재실행 → 로그인 화면 없이 세션 복원되며 역할별 UI가 올바르게(예: 사이드바/화면
+      분기) 유지되는지 확인 (`_restore()` → `_loadSelf()` 경로 검증)
+- [ ] 네트워크 끊긴 상태에서 목록 조회 시도 → 상단 배너, 삭제 실패 시 SnackBar로 구분 표시되는지 확인


### PR DESCRIPTION
## Summary
- 이슈 #198 "시스템 관리자의 관리자 계정 생성 기능 추가"의 조사 결과, 관리자 추가/삭제(SYSTEM_ADMIN→타 관리자)/비밀번호 변경은 이미 구현되어 있었다(PR #89, #90). 실제로 비어 있던 유즈케이스는 "운영 관리자는 탈퇴할 수 있다"(본인 탈퇴)뿐이었다.
- `DeleteAdmin`이 역할과 무관하게 자기 자신 삭제를 무조건 막고 있어, `CORNER_OPERATOR`의 본인 삭제만 예외적으로 허용하도록 정책을 분리했다. `SYSTEM_ADMIN`의 본인 삭제(마지막 시스템 관리자 보호)는 기존과 동일하게 금지된다.
- 프론트엔드가 자기 자신을 대상으로 한 API(비밀번호 변경, 탈퇴)를 호출하려면 실제 admin id가 필요한데 로그인 응답에는 없었다 — `GET /admins/me`를 추가했다.
- `SYSTEM_ADMIN`의 관리자 관리 화면(후속 프론트엔드 PR)에 필요한 `GET /admins` 목록 조회도 함께 추가했다.
- 계획 문서: `docs/artifacts/plan/20260724_관리자_계정_관리_plan_/01_backend_self_delete_and_query_api.md`

## Test plan
- [x] `go test ./...` 전체 통과
- [x] `gofmt -l .` / `go vet ./...` 클린
- [x] 신규 usecase 테스트: 본인 탈퇴 허용(CORNER_OPERATOR)/SYSTEM_ADMIN 본인삭제 금지 유지/타 관리자 삭제 여전히 SYSTEM_ADMIN 전용/GetAdmin/ListAdmins 권한
- [x] 신규 핸들러 테스트: `GET /admins/me`, `GET /admins` 에러 매핑
- [x] `make swag`로 `api/swagger.yaml`/`swagger.json`/`docs.go` 갱신 반영
- [ ] 로컬 서버 기동 후 `curl`로 실제 호출 검증 — 샌드박스 환경 제약(공유 가능성이 있는 고정 이름 DB 컨테이너)으로 미실행. 병합 전 실제 서버로 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)