### PR TITLE
fix: 관리자 조 등록 카메라 QR 프로덕션 크래시 수정 및 인식 영역 표시

### DIFF
--- a/frontend/lib/admin/features/group_list/group_list_screen.dart
+++ b/frontend/lib/admin/features/group_list/group_list_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cornermon/admin/entities/group_ext.dart';
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/shared/api/domain_aliases.dart' as api;
@@ -9,6 +11,7 @@ import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/app_tag.dart';
 import 'package:cornermon/shared/design_system/widgets/pill_tab_bar.dart';
+import 'package:cornermon/shared/design_system/widgets/qr_scan_frame.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -259,6 +262,8 @@ class _RegisterGroupDialog extends ConsumerStatefulWidget {
 class _RegisterGroupDialogState extends ConsumerState<_RegisterGroupDialog> {
   final _name = TextEditingController();
   final _payload = TextEditingController();
+  final MobileScannerController _scannerController =
+      MobileScannerController();
   int _tab = 0;
   bool _busy = false;
   bool _scanned = false;
@@ -266,7 +271,24 @@ class _RegisterGroupDialogState extends ConsumerState<_RegisterGroupDialog> {
   void dispose() {
     _name.dispose();
     _payload.dispose();
+    unawaited(_scannerController.dispose());
     super.dispose();
+  }
+
+  // 카메라 프리뷰(MobileScanner) 위젯을 트리에서 통째로 스왑하면, 아직 처리 중인 네이티브
+  // 프레임 콜백이 이미 dispose된 카메라를 참조해 "Attempt to invoke virtual method ...
+  // on a null object reference"로 프로덕션에서 죽었다(mobile_scanner Android 플랫폼 뷰
+  // 언마운트 레이스). 위젯은 계속 마운트해 두고 controller.stop()으로만 카메라를 멈춘다
+  // — 진행자 QrScanScreen과 동일한 패턴(qr_scan_screen.dart 참고).
+  void _onDetect(BarcodeCapture capture) {
+    if (_scanned) return;
+    final token = capture.barcodes.firstOrNull?.rawValue;
+    if (token == null) return;
+    unawaited(_scannerController.stop());
+    setState(() {
+      _payload.text = token;
+      _scanned = true;
+    });
   }
 
   Future<void> _submit() async {
@@ -318,20 +340,57 @@ class _RegisterGroupDialogState extends ConsumerState<_RegisterGroupDialog> {
             if (_tab == 0)
               SizedBox(
                 height: 220,
-                child: _scanned
-                    ? Center(child: Text('QR 인식 완료: ${_payload.text}'))
-                    : MobileScanner(
-                        onDetect: (capture) {
-                          if (!mounted || _scanned) return;
-                          final token = capture.barcodes.firstOrNull?.rawValue;
-                          if (token != null) {
-                            setState(() {
-                              _payload.text = token;
-                              _scanned = true;
-                            });
-                          }
-                        },
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Stack(
+                    fit: StackFit.expand,
+                    alignment: Alignment.center,
+                    children: [
+                      ColoredBox(
+                        color: Colors.black,
+                        child: MobileScanner(
+                          controller: _scannerController,
+                          onDetect: _onDetect,
+                          errorBuilder: (context, error) => Center(
+                            child: Padding(
+                              padding: const EdgeInsets.all(
+                                AppSpacing.space4,
+                              ),
+                              child: Text(
+                                '카메라를 사용할 수 없습니다. 카메라 권한을 확인해주세요.',
+                                textAlign: TextAlign.center,
+                                style: AppTypography.body.copyWith(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
                       ),
+                      IgnorePointer(
+                        child: QrScanFrame(
+                          state: _scanned
+                              ? QrScanFrameState.success
+                              : QrScanFrameState.scanning,
+                          size: 160,
+                        ),
+                      ),
+                      if (_scanned)
+                        Positioned(
+                          bottom: 8,
+                          left: 8,
+                          right: 8,
+                          child: Text(
+                            'QR 인식 완료: ${_payload.text}',
+                            textAlign: TextAlign.center,
+                            style: AppTypography.caption.copyWith(
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
               )
             else if (_tab == 1)
               SizedBox(

--- a/frontend/lib/facilitator/features/qr_scan/qr_scan_screen.dart
+++ b/frontend/lib/facilitator/features/qr_scan/qr_scan_screen.dart
@@ -18,7 +18,7 @@ import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 
 import 'package:cornermon/facilitator/session/track_session_provider.dart';
-import 'package:cornermon/facilitator/widgets/qr_scan_frame.dart';
+import 'package:cornermon/shared/design_system/widgets/qr_scan_frame.dart';
 
 const _failureScanCooldown = Duration(seconds: 1);
 

--- a/frontend/lib/shared/design_system/widgets/qr_scan_frame.dart
+++ b/frontend/lib/shared/design_system/widgets/qr_scan_frame.dart
@@ -1,13 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:cornermon/shared/design_system/tokens/colors.dart';
 
-/// B3 카메라 프리뷰 위 스캔 가이드 프레임 — 상태(대기/성공/실패)에 따라 테두리색만 바뀜.
+/// 카메라 프리뷰 위 스캔 가이드 프레임(진행자 B3, 관리자 조 등록 카메라 QR 탭 공용) —
+/// 상태(대기/성공/실패)에 따라 테두리색만 바뀜.
 enum QrScanFrameState { scanning, success, failure }
 
 class QrScanFrame extends StatelessWidget {
-  const QrScanFrame({required this.state, super.key});
+  const QrScanFrame({required this.state, this.size = 240.0, super.key});
 
   final QrScanFrameState state;
+  final double size;
 
   @override
   Widget build(BuildContext context) {
@@ -16,6 +18,7 @@ class QrScanFrame extends StatelessWidget {
 
     Color borderColor;
     Widget? icon;
+    final iconSize = size / 240.0 * 64.0;
 
     switch (state) {
       case QrScanFrameState.scanning:
@@ -24,17 +27,21 @@ class QrScanFrame extends StatelessWidget {
         break;
       case QrScanFrameState.success:
         borderColor = colors.statusIdle;
-        icon = Icon(Icons.check_circle, color: colors.statusIdle, size: 64.0);
+        icon = Icon(
+          Icons.check_circle,
+          color: colors.statusIdle,
+          size: iconSize,
+        );
         break;
       case QrScanFrameState.failure:
         borderColor = colors.statusAlert;
-        icon = Icon(Icons.error, color: colors.statusAlert, size: 64.0);
+        icon = Icon(Icons.error, color: colors.statusAlert, size: iconSize);
         break;
     }
 
     return Container(
-      width: 240.0,
-      height: 240.0,
+      width: size,
+      height: size,
       decoration: BoxDecoration(
         border: Border.all(color: borderColor, width: 3.0),
         borderRadius: BorderRadius.circular(16.0),


### PR DESCRIPTION
## Summary
- 관리자 "조 등록 → 카메라 QR" 탭에서 QR 인식 성공 시 `MobileScanner` 위젯을 트리에서 통째로 교체하던 로직이, 컨트롤러 없이(내부 암묵 컨트롤러) 쓰이던 것과 맞물려 프로덕션에서 `Attempt to invoke virtual method ... on a null object reference`로 크래시가 발생했습니다. 진행자 `QrScanScreen`과 동일하게 명시적 `MobileScannerController`를 도입해 `dispose()`에서 1회만 정리하고, 스캔 성공 시에는 위젯을 언마운트하지 않고 `controller.stop()`만 호출하도록 수정했습니다.
- 진행자 전용이던 `QrScanFrame`(스캔 가이드 프레임 오버레이)을 `lib/shared/design_system/widgets/`로 이동해 관리자 카메라 QR 탭에도 동일한 인식 영역 표시(대기/성공 상태에 따른 프레임)를 적용했습니다.

## Test plan
- [x] `dart analyze lib/` — 이슈 없음
- [x] `flutter test test/facilitator/features/qr_scan_test.dart` — 통과 (QrScanFrame 이동에 따른 회귀 없음)
- [x] `flutter test` 전체 실행 — 이번 변경과 무관한 기존 실패 2건(`end_camp_bar_button_test`, `track_event_stream_test`, 둘 다 SSE/타임아웃 관련 기존 플레이키니스, 본 diff가 건드리지 않는 파일) 외 전부 통과
- [ ] 실기기(Android)에서 관리자 앱 "조 등록 → 카메라 QR" 반복 스캔 시 크래시 재현 여부 확인 (로컬 환경 제약으로 미실시, 리뷰어 확인 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)