### PR TITLE
feat : 관리자 로그아웃 기능 프론트엔드 연동

### DIFF
--- a/frontend/lib/admin/features/camp_list/camp_list_screen.dart
+++ b/frontend/lib/admin/features/camp_list/camp_list_screen.dart
@@ -1,11 +1,15 @@
 import 'package:cornermon/admin/entities/camp_ext.dart';
+import 'package:cornermon/admin/session/admin_session_provider.dart';
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
+import 'package:cornermon/shared/api/dio_error.dart';
 import 'package:cornermon/shared/api/domain_aliases.dart' as api;
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/camp_providers.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon/shared/design_system/widgets/confirm_modal.dart';
 import 'package:cornermon/shared/design_system/widgets/empty_state.dart';
 import 'package:cornermon/shared/design_system/widgets/app_tag.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -38,6 +42,12 @@ class CampListScreen extends ConsumerWidget {
             icon: Icons.add,
             label: '새 캠프 시작',
             onPressed: () => context.go('/setup-wizard'),
+          ),
+          const SizedBox(width: 8),
+          TextButton.icon(
+            onPressed: () => _confirmLogout(context, ref),
+            icon: const Icon(Icons.logout),
+            label: const Text('로그아웃'),
           ),
           const SizedBox(width: 18),
         ],
@@ -82,6 +92,33 @@ class CampListScreen extends ConsumerWidget {
         },
       ),
     );
+  }
+}
+
+/// 로그아웃 성공/실패와 무관하게 `AdminSession.logout()`이 로컬 세션을 항상 정리하므로
+/// (best-effort 서버 revoke), 라우터가 곧 `/login`으로 리다이렉트한다 — 여기서 직접
+/// 내비게이션하지 않는다.
+Future<void> _confirmLogout(BuildContext context, WidgetRef ref) async {
+  final confirmed = await showConfirmModal(
+    context,
+    kind: ConfirmModalKind.softConfirm,
+    title: '로그아웃하시겠습니까?',
+    body: '다시 사용하려면 로그인이 필요합니다.',
+  );
+  if (!confirmed) return;
+
+  try {
+    await ref.read(adminSessionProvider.notifier).logout();
+  } on DioException catch (error, stackTrace) {
+    debugPrint(
+      '[camp_list] logout failed: type=${error.type} '
+      'statusCode=${error.response?.statusCode}\n$stackTrace',
+    );
+    if (isConnectionLost(error)) return;
+    if (!context.mounted) return;
+    ScaffoldMessenger.of(
+      context,
+    ).showSnackBar(const SnackBar(content: Text('로그아웃 처리 중 오류가 발생했습니다.')));
   }
 }
 

--- a/frontend/test/admin/features/camp_list/camp_list_screen_test.dart
+++ b/frontend/test/admin/features/camp_list/camp_list_screen_test.dart
@@ -1,4 +1,5 @@
 import 'package:cornermon/admin/features/camp_list/camp_list_screen.dart';
+import 'package:cornermon/admin/session/admin_session_provider.dart';
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/shared/api/domain_aliases.dart' as api;
 import 'package:cornermon/shared/api/ids.dart';
@@ -200,4 +201,68 @@ void main() {
     // assert
     expect(calls, 2);
   });
+
+  testWidgets('ShoudCallLogoutWhenLogoutConfirmed', (tester) async {
+    // arrange
+    final fakeSession = _RecordingLogoutAdminSession();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          campListProvider.overrideWith((ref) async => const []),
+          adminSessionProvider.overrideWith(() => fakeSession),
+        ],
+        child: const MaterialApp(home: CampListScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // act
+    await tester.tap(find.text('로그아웃'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('진행'));
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(fakeSession.logoutCallCount, 1);
+  });
+
+  testWidgets('ShoudNotCallLogoutWhenLogoutConfirmationCancelled', (
+    tester,
+  ) async {
+    // arrange
+    final fakeSession = _RecordingLogoutAdminSession();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          campListProvider.overrideWith((ref) async => const []),
+          adminSessionProvider.overrideWith(() => fakeSession),
+        ],
+        child: const MaterialApp(home: CampListScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // act
+    await tester.tap(find.text('로그아웃'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('취소'));
+    await tester.pumpAndSettle();
+
+    // assert
+    expect(fakeSession.logoutCallCount, 0);
+  });
+}
+
+/// 실제 로그아웃 API 호출 없이 CampListScreen의 로그아웃 버튼 → 확인 모달 연결만
+/// 검증한다.
+class _RecordingLogoutAdminSession extends AdminSession {
+  int logoutCallCount = 0;
+
+  @override
+  AdminSessionState build() => const AdminSessionUnauthenticated();
+
+  @override
+  Future<void> logout() async {
+    logoutCallCount++;
+  }
 }


### PR DESCRIPTION
## Summary
- 로그인/로그아웃 API(`POST /auth/admin/logout`)와 `AdminSession.logout()`은 이미 구현돼 있었지만 이를 호출하는 UI가 없었다. 캠프 목록(로그인 직후 진입점) 앱바에 "로그아웃" 버튼을 추가했다.
- 진행자 트랙 로그아웃(`frontend/lib/facilitator/features/main_track/_main_track_header.dart`)에서 검증된 패턴을 재사용: 확인 모달(`softConfirm`) → `AdminSession.logout()` 호출 → 커넥션 유실은 무시(로컬 세션은 이미 정리됨), 그 외 API 에러는 SnackBar.
- API 스키마 변경 없음(기존 엔드포인트 재사용) — `api/openapi.yaml` 수정 불필요.

## Test plan
- [x] `dart analyze lib/` — 이슈 없음
- [x] `flutter test test/admin/features/camp_list/camp_list_screen_test.dart` — 신규 2개 포함 7개 전부 통과
  - `ShoudCallLogoutWhenLogoutConfirmed`
  - `ShoudNotCallLogoutWhenLogoutConfirmationCancelled`
- [x] `flutter test test/admin/` 전체 실행 결과 이번 변경과 무관한 `end_camp_bar_button_test.dart` 기존 실패 1건 확인(변경분 stash 후에도 동일하게 실패 — 회귀 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)