### PR TITLE
fix: sync-watch가 android/linux/macos 머신별 생성 파일까지 동기화하던 문제 수정

### DIFF
--- a/sync-watch
+++ b/sync-watch
@@ -6,19 +6,36 @@ REMOTE_IP="100.101.91.104"
 LOCAL_DIR="."
 REMOTE_DIR="~/projects/cornermon-clone"
 
-# Flutter/Xcode가 머신별로 생성하는 파일은 Mac mini에서 다시 만들어야 한다.
-# 이를 동기화하면 iOS Swift Package Manager가 Linux의 ephemeral 경로를 참조해
-# 패키지를 찾지 못할 수 있다. --delete와 함께 써도 exclude 대상은 원격에서 지우지 않는다.
+# Flutter/Gradle/Xcode가 머신별로 생성하는 파일(gradlew, Flutter.podspec, 각 플랫폼의
+# ephemeral/ 등)은 어차피 Mac mini에서 flutter pub get/create/pod install로 다시 만들어야
+# 한다. 이를 동기화 대상에 두면 두 가지 문제가 생긴다: (1) Linux에는 애초에 없는
+# 파일(gradlew 등)이라 동기화해도 못 채워주고, (2) linux/flutter/ephemeral처럼 Flutter
+# 툴이 빌드마다 통째로 지우고 재생성하는 디렉터리는 rsync가 같은 타이밍에 건드리면
+# "Directory not empty" 레이스로 flutter 명령 자체가 죽는다(실제 발생 사례).
+# --delete와 함께 써도 exclude 대상은 원격에서 지우지 않는다.
 RSYNC_EXCLUDES=(
     --exclude='frontend/.dart_tool/'
     --exclude='frontend/build/'
     --exclude='frontend/ios/Flutter/ephemeral/'
+    --exclude='frontend/ios/Flutter/Flutter.podspec'
+    --exclude='frontend/ios/Flutter/Generated.xcconfig'
     --exclude='frontend/ios/Pods/'
     --exclude='frontend/ios/.symlinks/'
+    --exclude='frontend/macos/Flutter/ephemeral/'
+    --exclude='frontend/macos/Pods/'
+    --exclude='frontend/linux/flutter/ephemeral/'
+    --exclude='frontend/windows/flutter/ephemeral/'
+    --exclude='frontend/android/gradlew'
+    --exclude='frontend/android/gradlew.bat'
+    --exclude='frontend/android/.gradle/'
+    --exclude='frontend/android/app/build/'
+    --exclude='frontend/android/build/'
+    --exclude='frontend/android/.cxx/'
+    --exclude='frontend/android/local.properties'
 )
 
 # 제외 대상 변경은 동기화를 다시 시작할 필요도 없으므로 감시에서 함께 제외한다.
-WATCH_EXCLUDE='(^|/)(\|frontend/(\.dart_tool|build|ios/Flutter/ephemeral|ios/Pods|ios/\.symlinks))(/|$)'
+WATCH_EXCLUDE='(^|/)frontend/(\.dart_tool|build|ios/Flutter/(ephemeral|Flutter\.podspec|Generated\.xcconfig)|ios/Pods|ios/\.symlinks|macos/Flutter/ephemeral|macos/Pods|linux/flutter/ephemeral|windows/flutter/ephemeral|android/gradlew(\.bat)?|android/\.gradle|android/app/build|android/build|android/\.cxx|android/local\.properties)(/|$)'
 
 # 스크립트 실행 시 비밀번호 입력받음
 read -sp "SSH Password: " REMOTE_PASS


### PR DESCRIPTION
## Summary
- `sync-watch`의 `RSYNC_EXCLUDES`/`WATCH_EXCLUDE`가 iOS 쪽(`ios/Flutter/ephemeral`, `ios/Pods`, `ios/.symlinks`)만 제외하고 있었고, `frontend/android`(`gradlew`, `.gradle/`, `app/build/` 등), `frontend/linux/flutter/ephemeral`, `frontend/macos/Flutter/ephemeral`은 빠져 있었습니다.
- 실제로 Mac mini 빌드 서버에서 아래가 재현됐습니다:
  - `frontend/android/gradlew: No such file or directory` — Linux 소스에는 애초에 없는(gitignore된) 파일이라 동기화로도 못 채움.
  - `pod install`에서 `Flutter.podspec` ENOENT — 마찬가지로 머신별 생성 파일.
  - `flutter` 크래시: `FileSystemException: Deletion failed, path=.../linux/flutter/ephemeral/.plugin_symlinks (Directory not empty)` — Flutter가 빌드마다 통째로 지우고 재생성하는 디렉터리를 rsync가 같은 타이밍에 건드려서 발생한 레이스.
- 이런 파일들은 원칙적으로 각 머신에서 `flutter pub get`/`flutter create`/`pod install`로 직접 만들어야 하므로(각 플랫폼 폴더의 `.gitignore`가 이미 동일한 대상을 제외하고 있음), 동기화 대상에서도 빼는 게 맞습니다.
- 곁가지로 기존 `WATCH_EXCLUDE` 정규식에 있던 `\|` 오타를 고쳤습니다 — 고쳐지기 전에는 어떤 경로 앞에도 리터럴 `|` 문자가 없어 이 exclude가 실제로 전혀 매칭되지 않고 있었습니다.

## Test plan
- [x] `bash -n sync-watch` — 문법 확인
- [x] `grep -E`로 새 `WATCH_EXCLUDE` 정규식이 `linux/flutter/ephemeral/.plugin_symlinks`, `android/gradlew`, `ios/Flutter/Flutter.podspec`은 걸러내고 `lib/main.dart`, `android/app/src/...` 같은 실제 소스는 통과시키는지 확인
- [ ] 맥미니에서 실제로 `sync-watch` 재실행 후 `flutter run --release`가 더 이상 이 3가지 에러로 죽지 않는지 확인 (원격 환경이라 로컬에서는 직접 검증 불가, 리뷰어 확인 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)