### PR TITLE
fix: 조 등록 시 임의 캠프에 배정되던 캠프 스코프 버그 수정

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -898,7 +898,7 @@ const docTemplate = `{
                         "required": true
                     },
                     {
-                        "description": "배정할 조 ID",
+                        "description": "배정할 캠프와 조 이름",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -3155,7 +3155,10 @@ const docTemplate = `{
         "AssignBadgeRequest": {
             "type": "object",
             "properties": {
-                "groupId": {
+                "campId": {
+                    "type": "string"
+                },
+                "groupName": {
                     "type": "string"
                 }
             }
@@ -4124,6 +4127,9 @@ const docTemplate = `{
         "ScanAssignBadgeRequest": {
             "type": "object",
             "properties": {
+                "campId": {
+                    "type": "string"
+                },
                 "groupName": {
                     "type": "string"
                 },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -891,7 +891,7 @@
                         "required": true
                     },
                     {
-                        "description": "배정할 조 ID",
+                        "description": "배정할 캠프와 조 이름",
                         "name": "request",
                         "in": "body",
                         "required": true,
@@ -3148,7 +3148,10 @@
         "AssignBadgeRequest": {
             "type": "object",
             "properties": {
-                "groupId": {
+                "campId": {
+                    "type": "string"
+                },
+                "groupName": {
                     "type": "string"
                 }
             }
@@ -4117,6 +4120,9 @@
         "ScanAssignBadgeRequest": {
             "type": "object",
             "properties": {
+                "campId": {
+                    "type": "string"
+                },
                 "groupName": {
                     "type": "string"
                 },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -44,7 +44,9 @@ definitions:
     type: object
   AssignBadgeRequest:
     properties:
-      groupId:
+      campId:
+        type: string
+      groupName:
         type: string
     type: object
   AuditLogPageResponse:
@@ -746,6 +748,8 @@ definitions:
     type: object
   ScanAssignBadgeRequest:
     properties:
+      campId:
+        type: string
       groupName:
         type: string
       qrPayload:
@@ -1432,7 +1436,7 @@ paths:
         name: id
         required: true
         type: string
-      - description: 배정할 조 ID
+      - description: 배정할 캠프와 조 이름
         in: body
         name: request
         required: true

--- a/backend/internal/infrastructure/web/badge_handler.go
+++ b/backend/internal/infrastructure/web/badge_handler.go
@@ -119,7 +119,8 @@ func (h *BadgeHandler) ExportBadges(c echo.Context) error {
 }
 
 type AssignBadgeRequest struct {
-	GroupID string `json:"groupId"`
+	CampID    string `json:"campId"`
+	GroupName string `json:"groupName"`
 } // @name AssignBadgeRequest
 
 // @Summary      배지를 특정 조에 배정 (수동)
@@ -129,19 +130,17 @@ type AssignBadgeRequest struct {
 // @Accept       json
 // @Produce      json
 // @Param        id path string true "배지 ID"
-// @Param        request body AssignBadgeRequest true "배정할 조 ID"
+// @Param        request body AssignBadgeRequest true "배정할 캠프와 조 이름"
 // @Success      200 {object} BadgeResponse
 // @Router       /badges/{id}/register [post]
 func (h *BadgeHandler) AssignBadge(c echo.Context) error {
 	id := domain.BadgeID(c.Param("id"))
-	var req struct {
-		GroupName string `json:"groupName"`
-	}
+	var req AssignBadgeRequest
 	if err := c.Bind(&req); err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: CodeBadRequest, Message: "invalid request"}).SetInternal(err)
 	}
 
-	group, err := h.groupUC.AssignBadge(c.Request().Context(), id, req.GroupName, getAdminID(c))
+	group, err := h.groupUC.AssignBadge(c.Request().Context(), domain.CampID(req.CampID), id, req.GroupName, getAdminID(c))
 	if err != nil {
 		return badgeAssignmentHTTPError(err)
 	}
@@ -150,6 +149,7 @@ func (h *BadgeHandler) AssignBadge(c echo.Context) error {
 }
 
 type ScanAssignBadgeRequest struct {
+	CampID    string `json:"campId"`
 	QRPayload string `json:"qrPayload"`
 	GroupName string `json:"groupName"`
 } // @name ScanAssignBadgeRequest
@@ -169,7 +169,7 @@ func (h *BadgeHandler) ScanAssignBadge(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: CodeBadRequest, Message: "invalid request"}).SetInternal(err)
 	}
 
-	group, err := h.groupUC.ScanAssignBadge(c.Request().Context(), req.QRPayload, req.GroupName, getAdminID(c))
+	group, err := h.groupUC.ScanAssignBadge(c.Request().Context(), domain.CampID(req.CampID), req.QRPayload, req.GroupName, getAdminID(c))
 	if err != nil {
 		return badgeAssignmentHTTPError(err)
 	}
@@ -181,6 +181,8 @@ func badgeAssignmentHTTPError(err error) error {
 	switch {
 	case errors.Is(err, domain.ErrCampNotFound):
 		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: CodeCampNotFound, Message: err.Error()}).SetInternal(err)
+	case errors.Is(err, domain.ErrCampInvalidTransition):
+		return echo.NewHTTPError(http.StatusConflict, ErrorResponse{Code: CodeCampStateConflict, Message: "camp is not available for badge registration"}).SetInternal(err)
 	case errors.Is(err, domain.ErrBadgeNotAssigned):
 		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: CodeBadgeNotFound, Message: err.Error()}).SetInternal(err)
 	case errors.Is(err, domain.ErrBadgeAlreadyAssigned):

--- a/backend/internal/usecase/group.go
+++ b/backend/internal/usecase/group.go
@@ -50,10 +50,11 @@ func NewGroupService(
 	}
 }
 
-// AssignBadge creates a group and assigns the badge identified by its ID to it.
-// The group belongs to the current registration camp (PENDING or ACTIVE).
+// AssignBadge creates a group in the given camp and assigns the badge
+// identified by its ID to it.
 func (s *GroupService) AssignBadge(
 	ctx context.Context,
+	campID domain.CampID,
 	badgeID domain.BadgeID,
 	groupName string,
 	actorAdminID domain.AdminID,
@@ -67,13 +68,14 @@ func (s *GroupService) AssignBadge(
 		return nil, withErrorContext("group.assign_badge", "validate_badge", domain.ErrBadgeNotAssigned, map[string]any{"badge_id": string(badgeID), "badge_found": false})
 	}
 
-	return s.registerBadge(ctx, badge, groupName, actorAdminID)
+	return s.registerBadge(ctx, campID, badge, groupName, actorAdminID)
 }
 
-// ScanAssignBadge creates a group and assigns the badge identified by its QR payload.
-// The group belongs to the current registration camp (PENDING or ACTIVE).
+// ScanAssignBadge creates a group in the given camp and assigns the badge
+// identified by its QR payload.
 func (s *GroupService) ScanAssignBadge(
 	ctx context.Context,
+	campID domain.CampID,
 	qrPayload string,
 	groupName string,
 	actorAdminID domain.AdminID,
@@ -87,23 +89,25 @@ func (s *GroupService) ScanAssignBadge(
 		return nil, withErrorContext("group.scan_assign_badge", "validate_badge", domain.ErrBadgeNotAssigned, map[string]any{"badge_found": false})
 	}
 
-	return s.registerBadge(ctx, badge, groupName, actorAdminID)
+	return s.registerBadge(ctx, campID, badge, groupName, actorAdminID)
 }
 
-func (s *GroupService) registerBadge(ctx context.Context, badge *domain.Badge, groupName string, actorAdminID domain.AdminID) (*domain.Group, error) {
+func (s *GroupService) registerBadge(ctx context.Context, campID domain.CampID, badge *domain.Badge, groupName string, actorAdminID domain.AdminID) (*domain.Group, error) {
 
-	camp, err := s.registrationCamp(ctx)
+	camp, err := s.camps.Get(ctx, campID)
 	if err != nil {
-		return nil, withErrorContext("group.register_badge", "usecase.registration_camp", err, nil)
+		return nil, withErrorContext("group.register_badge", "repository.get_camp", err, map[string]any{"camp_id": string(campID)})
 	}
 	if camp == nil {
-		return nil, withErrorContext("group.register_badge", "validate_camp", domain.ErrCampNotFound, map[string]any{"camp_found": false})
+		return nil, withErrorContext("group.register_badge", "validate_camp", domain.ErrCampNotFound, map[string]any{"camp_id": string(campID), "camp_found": false})
+	}
+	if camp.Status() == domain.CampEnded {
+		return nil, withErrorContext("group.register_badge", "validate_camp", domain.ErrCampInvalidTransition, map[string]any{"camp_id": string(campID), "camp_status": string(camp.Status())})
 	}
 	if badge.Status() == domain.BadgeAssigned {
 		return nil, withErrorContext("group.register_badge", "validate_badge_status", domain.ErrBadgeAlreadyAssigned, map[string]any{"badge_id": string(badge.ID()), "badge_status": string(badge.Status())})
 	}
 
-	campID := camp.ID()
 	corners, err := s.corners.ListByCamp(ctx, campID)
 	if err != nil {
 		return nil, withErrorContext("group.register_badge", "repository.list_corners", err, map[string]any{"camp_id": string(campID)})
@@ -147,25 +151,6 @@ func (s *GroupService) registerBadge(ctx context.Context, badge *domain.Badge, g
 
 	s.recordAuditLog(ctx, domain.Some(campID), string(actorAdminID), adminActorLabel(ctx, s.admins, actorAdminID, nil), ActionGroupCreate, string(groupID), groupName, true, map[string]any{"badgeID": string(badge.ID())})
 	return group, nil
-}
-
-func (s *GroupService) registrationCamp(ctx context.Context) (*domain.Camp, error) {
-
-	camps, err := s.camps.List(ctx)
-	if err != nil {
-		return nil, withErrorContext("group.registration_camp", "repository.list_camps", err, nil)
-	}
-
-	var pendingCamp *domain.Camp
-	for _, camp := range camps {
-		switch camp.Status() {
-		case domain.CampActive:
-			return camp, nil
-		case domain.CampPending:
-			pendingCamp = camp
-		}
-	}
-	return pendingCamp, nil
 }
 
 // ListGroups

--- a/backend/internal/usecase/group_test.go
+++ b/backend/internal/usecase/group_test.go
@@ -44,7 +44,7 @@ func TestGroupService_AssignBadge(t *testing.T) {
 		s.uuidFn = func() string { return "group-uuid" }
 
 		// Act
-		group, err := s.AssignBadge(context.Background(), "badge-1", "1조", "admin-1")
+		group, err := s.AssignBadge(context.Background(), "camp-1", "badge-1", "1조", "admin-1")
 
 		// Assert
 		if err != nil {
@@ -105,7 +105,7 @@ func TestGroupService_AssignBadge(t *testing.T) {
 		s.uuidFn = func() string { return "group-uuid" }
 
 		// Act
-		group, err := s.AssignBadge(context.Background(), "badge-1", "1조", "admin-1")
+		group, err := s.AssignBadge(context.Background(), "camp-1", "badge-1", "1조", "admin-1")
 
 		// Assert
 		if err != nil {
@@ -116,7 +116,23 @@ func TestGroupService_AssignBadge(t *testing.T) {
 		}
 	})
 
-	t.Run("ShouldReturnCampNotFoundWhenNoPendingOrActiveCampExists", func(t *testing.T) {
+	t.Run("ShouldReturnCampNotFoundWhenTargetCampDoesNotExist", func(t *testing.T) {
+		// Arrange
+		camps := NewMockCampRepository()
+		badges := NewMockBadgeRepository()
+		_ = badges.Save(context.Background(), domain.NewBadgeFromProps(domain.BadgeProps{ID: "badge-1", QRPayload: "qr-1", Status: domain.BadgeUnassigned}))
+		service := NewGroupService(camps, NewMockCornerRepository(), NewMockTrackRepository(), NewMockGroupRepository(), badges, NewMockVisitRepository(), NewMockAdminRepository(), &MockAuditLogRepository{}, &MockTxManager{})
+
+		// Act
+		_, err := service.AssignBadge(context.Background(), "camp-missing", "badge-1", "1조", "admin-1")
+
+		// Assert
+		if !errors.Is(err, domain.ErrCampNotFound) {
+			t.Fatalf("expected ErrCampNotFound, got %v", err)
+		}
+	})
+
+	t.Run("ShouldRejectAssignBadgeWhenTargetCampHasEnded", func(t *testing.T) {
 		// Arrange
 		camps := NewMockCampRepository()
 		_ = camps.Save(context.Background(), domain.NewCampFromProps(domain.CampProps{ID: "camp-1", Status: domain.CampEnded}))
@@ -125,11 +141,11 @@ func TestGroupService_AssignBadge(t *testing.T) {
 		service := NewGroupService(camps, NewMockCornerRepository(), NewMockTrackRepository(), NewMockGroupRepository(), badges, NewMockVisitRepository(), NewMockAdminRepository(), &MockAuditLogRepository{}, &MockTxManager{})
 
 		// Act
-		_, err := service.AssignBadge(context.Background(), "badge-1", "1조", "admin-1")
+		_, err := service.AssignBadge(context.Background(), "camp-1", "badge-1", "1조", "admin-1")
 
 		// Assert
-		if !errors.Is(err, domain.ErrCampNotFound) {
-			t.Fatalf("expected ErrCampNotFound, got %v", err)
+		if !errors.Is(err, domain.ErrCampInvalidTransition) {
+			t.Fatalf("expected ErrCampInvalidTransition, got %v", err)
 		}
 	})
 
@@ -143,7 +159,7 @@ func TestGroupService_AssignBadge(t *testing.T) {
 		service.uuidFn = func() string { return "group-uuid" }
 
 		// Act
-		group, err := service.ScanAssignBadge(context.Background(), "qr-1", "1조", "admin-1")
+		group, err := service.ScanAssignBadge(context.Background(), "camp-1", "qr-1", "1조", "admin-1")
 
 		// Assert
 		if err != nil {
@@ -151,6 +167,30 @@ func TestGroupService_AssignBadge(t *testing.T) {
 		}
 		if group == nil || group.BadgeID() != "badge-1" {
 			t.Fatalf("expected badge assignment from QR payload, got %+v", group)
+		}
+	})
+
+	t.Run("ShouldAssignBadgeToRequestedCampWhenMultipleCampsExist", func(t *testing.T) {
+		// Arrange: an ACTIVE camp exists elsewhere in the system, but the
+		// caller explicitly targets a different PENDING camp — the group
+		// must land in the requested camp, not the globally active one.
+		camps := NewMockCampRepository()
+		_ = camps.Save(context.Background(), domain.NewCampFromProps(domain.CampProps{ID: "camp-active", Status: domain.CampActive}))
+		_ = camps.Save(context.Background(), domain.NewCampFromProps(domain.CampProps{ID: "camp-pending", Status: domain.CampPending}))
+		badges := NewMockBadgeRepository()
+		_ = badges.Save(context.Background(), domain.NewBadgeFromProps(domain.BadgeProps{ID: "badge-1", QRPayload: "qr-1", Status: domain.BadgeUnassigned}))
+		service := NewGroupService(camps, NewMockCornerRepository(), NewMockTrackRepository(), NewMockGroupRepository(), badges, NewMockVisitRepository(), NewMockAdminRepository(), &MockAuditLogRepository{}, &MockTxManager{})
+		service.uuidFn = func() string { return "group-uuid" }
+
+		// Act
+		group, err := service.AssignBadge(context.Background(), "camp-pending", "badge-1", "1조", "admin-1")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if group == nil || group.CampID() != "camp-pending" {
+			t.Fatalf("expected group assigned to requested camp-pending, got %+v", group)
 		}
 	})
 }

--- a/frontend/lib/admin/features/group_list/group_list_screen.dart
+++ b/frontend/lib/admin/features/group_list/group_list_screen.dart
@@ -297,6 +297,7 @@ class _RegisterGroupDialogState extends ConsumerState<_RegisterGroupDialog> {
     try {
       await ref.read(
         scanRegisterBadgeProvider(
+          widget.campId.value,
           _payload.text.trim(),
           _name.text.trim(),
         ).future,

--- a/frontend/lib/shared/api/gen/doc/AssignBadgeRequest.md
+++ b/frontend/lib/shared/api/gen/doc/AssignBadgeRequest.md
@@ -8,7 +8,8 @@ import 'package:cornermon_api_gen/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**groupId** | **String** |  | [optional] 
+**campId** | **String** |  | [optional] 
+**groupName** | **String** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/frontend/lib/shared/api/gen/doc/BResourceManagementAdminApi.md
+++ b/frontend/lib/shared/api/gen/doc/BResourceManagementAdminApi.md
@@ -189,7 +189,7 @@ import 'package:cornermon_api_gen/api.dart';
 
 final api = CornermonApiGen().getBResourceManagementAdminApi();
 final String id = id_example; // String | 배지 ID
-final AssignBadgeRequest request = ; // AssignBadgeRequest | 배정할 조 ID
+final AssignBadgeRequest request = ; // AssignBadgeRequest | 배정할 캠프와 조 이름
 
 try {
     final response = api.badgesIdRegisterPost(id, request);
@@ -204,7 +204,7 @@ try {
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **id** | **String**| 배지 ID | 
- **request** | [**AssignBadgeRequest**](AssignBadgeRequest.md)| 배정할 조 ID | 
+ **request** | [**AssignBadgeRequest**](AssignBadgeRequest.md)| 배정할 캠프와 조 이름 | 
 
 ### Return type
 

--- a/frontend/lib/shared/api/gen/doc/ScanAssignBadgeRequest.md
+++ b/frontend/lib/shared/api/gen/doc/ScanAssignBadgeRequest.md
@@ -8,6 +8,7 @@ import 'package:cornermon_api_gen/api.dart';
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**campId** | **String** |  | [optional] 
 **groupName** | **String** |  | [optional] 
 **qrPayload** | **String** |  | [optional] 
 

--- a/frontend/lib/shared/api/gen/lib/src/api/b_resource_management_admin_api.dart
+++ b/frontend/lib/shared/api/gen/lib/src/api/b_resource_management_admin_api.dart
@@ -307,7 +307,7 @@ class BResourceManagementAdminApi {
   ///
   /// Parameters:
   /// * [id] - 배지 ID
-  /// * [request] - 배정할 조 ID
+  /// * [request] - 배정할 캠프와 조 이름
   /// * [cancelToken] - A [CancelToken] that can be used to cancel the operation
   /// * [headers] - Can be used to add additional headers to the request
   /// * [extras] - Can be used to add flags to the request

--- a/frontend/lib/shared/api/gen/lib/src/model/assign_badge_request.dart
+++ b/frontend/lib/shared/api/gen/lib/src/model/assign_badge_request.dart
@@ -12,11 +12,15 @@ part 'assign_badge_request.g.dart';
 /// AssignBadgeRequest
 ///
 /// Properties:
-/// * [groupId] 
+/// * [campId] 
+/// * [groupName] 
 @BuiltValue()
 abstract class AssignBadgeRequest implements Built<AssignBadgeRequest, AssignBadgeRequestBuilder> {
-  @BuiltValueField(wireName: r'groupId')
-  String? get groupId;
+  @BuiltValueField(wireName: r'campId')
+  String? get campId;
+
+  @BuiltValueField(wireName: r'groupName')
+  String? get groupName;
 
   AssignBadgeRequest._();
 
@@ -41,10 +45,17 @@ class _$AssignBadgeRequestSerializer implements PrimitiveSerializer<AssignBadgeR
     AssignBadgeRequest object, {
     FullType specifiedType = FullType.unspecified,
   }) sync* {
-    if (object.groupId != null) {
-      yield r'groupId';
+    if (object.campId != null) {
+      yield r'campId';
       yield serializers.serialize(
-        object.groupId,
+        object.campId,
+        specifiedType: const FullType(String),
+      );
+    }
+    if (object.groupName != null) {
+      yield r'groupName';
+      yield serializers.serialize(
+        object.groupName,
         specifiedType: const FullType(String),
       );
     }
@@ -71,12 +82,19 @@ class _$AssignBadgeRequestSerializer implements PrimitiveSerializer<AssignBadgeR
       final key = serializedList[i] as String;
       final value = serializedList[i + 1];
       switch (key) {
-        case r'groupId':
+        case r'campId':
           final valueDes = serializers.deserialize(
             value,
             specifiedType: const FullType(String),
           ) as String;
-          result.groupId = valueDes;
+          result.campId = valueDes;
+          break;
+        case r'groupName':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.groupName = valueDes;
           break;
         default:
           unhandled.add(key);

--- a/frontend/lib/shared/api/gen/lib/src/model/assign_badge_request.g.dart
+++ b/frontend/lib/shared/api/gen/lib/src/model/assign_badge_request.g.dart
@@ -9,13 +9,15 @@ part of 'assign_badge_request.dart';
 
 class _$AssignBadgeRequest extends AssignBadgeRequest {
   @override
-  final String? groupId;
+  final String? campId;
+  @override
+  final String? groupName;
 
   factory _$AssignBadgeRequest(
           [void Function(AssignBadgeRequestBuilder)? updates]) =>
       (AssignBadgeRequestBuilder()..update(updates))._build();
 
-  _$AssignBadgeRequest._({this.groupId}) : super._();
+  _$AssignBadgeRequest._({this.campId, this.groupName}) : super._();
   @override
   AssignBadgeRequest rebuild(
           void Function(AssignBadgeRequestBuilder) updates) =>
@@ -28,13 +30,16 @@ class _$AssignBadgeRequest extends AssignBadgeRequest {
   @override
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
-    return other is AssignBadgeRequest && groupId == other.groupId;
+    return other is AssignBadgeRequest &&
+        campId == other.campId &&
+        groupName == other.groupName;
   }
 
   @override
   int get hashCode {
     var _$hash = 0;
-    _$hash = $jc(_$hash, groupId.hashCode);
+    _$hash = $jc(_$hash, campId.hashCode);
+    _$hash = $jc(_$hash, groupName.hashCode);
     _$hash = $jf(_$hash);
     return _$hash;
   }
@@ -42,7 +47,8 @@ class _$AssignBadgeRequest extends AssignBadgeRequest {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'AssignBadgeRequest')
-          ..add('groupId', groupId))
+          ..add('campId', campId)
+          ..add('groupName', groupName))
         .toString();
   }
 }
@@ -51,9 +57,13 @@ class AssignBadgeRequestBuilder
     implements Builder<AssignBadgeRequest, AssignBadgeRequestBuilder> {
   _$AssignBadgeRequest? _$v;
 
-  String? _groupId;
-  String? get groupId => _$this._groupId;
-  set groupId(String? groupId) => _$this._groupId = groupId;
+  String? _campId;
+  String? get campId => _$this._campId;
+  set campId(String? campId) => _$this._campId = campId;
+
+  String? _groupName;
+  String? get groupName => _$this._groupName;
+  set groupName(String? groupName) => _$this._groupName = groupName;
 
   AssignBadgeRequestBuilder() {
     AssignBadgeRequest._defaults(this);
@@ -62,7 +72,8 @@ class AssignBadgeRequestBuilder
   AssignBadgeRequestBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
-      _groupId = $v.groupId;
+      _campId = $v.campId;
+      _groupName = $v.groupName;
       _$v = null;
     }
     return this;
@@ -84,7 +95,8 @@ class AssignBadgeRequestBuilder
   _$AssignBadgeRequest _build() {
     final _$result = _$v ??
         _$AssignBadgeRequest._(
-          groupId: groupId,
+          campId: campId,
+          groupName: groupName,
         );
     replace(_$result);
     return _$result;

--- a/frontend/lib/shared/api/gen/lib/src/model/scan_assign_badge_request.dart
+++ b/frontend/lib/shared/api/gen/lib/src/model/scan_assign_badge_request.dart
@@ -12,10 +12,14 @@ part 'scan_assign_badge_request.g.dart';
 /// ScanAssignBadgeRequest
 ///
 /// Properties:
+/// * [campId] 
 /// * [groupName] 
 /// * [qrPayload] 
 @BuiltValue()
 abstract class ScanAssignBadgeRequest implements Built<ScanAssignBadgeRequest, ScanAssignBadgeRequestBuilder> {
+  @BuiltValueField(wireName: r'campId')
+  String? get campId;
+
   @BuiltValueField(wireName: r'groupName')
   String? get groupName;
 
@@ -45,6 +49,13 @@ class _$ScanAssignBadgeRequestSerializer implements PrimitiveSerializer<ScanAssi
     ScanAssignBadgeRequest object, {
     FullType specifiedType = FullType.unspecified,
   }) sync* {
+    if (object.campId != null) {
+      yield r'campId';
+      yield serializers.serialize(
+        object.campId,
+        specifiedType: const FullType(String),
+      );
+    }
     if (object.groupName != null) {
       yield r'groupName';
       yield serializers.serialize(
@@ -82,6 +93,13 @@ class _$ScanAssignBadgeRequestSerializer implements PrimitiveSerializer<ScanAssi
       final key = serializedList[i] as String;
       final value = serializedList[i + 1];
       switch (key) {
+        case r'campId':
+          final valueDes = serializers.deserialize(
+            value,
+            specifiedType: const FullType(String),
+          ) as String;
+          result.campId = valueDes;
+          break;
         case r'groupName':
           final valueDes = serializers.deserialize(
             value,

--- a/frontend/lib/shared/api/gen/lib/src/model/scan_assign_badge_request.g.dart
+++ b/frontend/lib/shared/api/gen/lib/src/model/scan_assign_badge_request.g.dart
@@ -9,6 +9,8 @@ part of 'scan_assign_badge_request.dart';
 
 class _$ScanAssignBadgeRequest extends ScanAssignBadgeRequest {
   @override
+  final String? campId;
+  @override
   final String? groupName;
   @override
   final String? qrPayload;
@@ -17,7 +19,8 @@ class _$ScanAssignBadgeRequest extends ScanAssignBadgeRequest {
           [void Function(ScanAssignBadgeRequestBuilder)? updates]) =>
       (ScanAssignBadgeRequestBuilder()..update(updates))._build();
 
-  _$ScanAssignBadgeRequest._({this.groupName, this.qrPayload}) : super._();
+  _$ScanAssignBadgeRequest._({this.campId, this.groupName, this.qrPayload})
+      : super._();
   @override
   ScanAssignBadgeRequest rebuild(
           void Function(ScanAssignBadgeRequestBuilder) updates) =>
@@ -31,6 +34,7 @@ class _$ScanAssignBadgeRequest extends ScanAssignBadgeRequest {
   bool operator ==(Object other) {
     if (identical(other, this)) return true;
     return other is ScanAssignBadgeRequest &&
+        campId == other.campId &&
         groupName == other.groupName &&
         qrPayload == other.qrPayload;
   }
@@ -38,6 +42,7 @@ class _$ScanAssignBadgeRequest extends ScanAssignBadgeRequest {
   @override
   int get hashCode {
     var _$hash = 0;
+    _$hash = $jc(_$hash, campId.hashCode);
     _$hash = $jc(_$hash, groupName.hashCode);
     _$hash = $jc(_$hash, qrPayload.hashCode);
     _$hash = $jf(_$hash);
@@ -47,6 +52,7 @@ class _$ScanAssignBadgeRequest extends ScanAssignBadgeRequest {
   @override
   String toString() {
     return (newBuiltValueToStringHelper(r'ScanAssignBadgeRequest')
+          ..add('campId', campId)
           ..add('groupName', groupName)
           ..add('qrPayload', qrPayload))
         .toString();
@@ -56,6 +62,10 @@ class _$ScanAssignBadgeRequest extends ScanAssignBadgeRequest {
 class ScanAssignBadgeRequestBuilder
     implements Builder<ScanAssignBadgeRequest, ScanAssignBadgeRequestBuilder> {
   _$ScanAssignBadgeRequest? _$v;
+
+  String? _campId;
+  String? get campId => _$this._campId;
+  set campId(String? campId) => _$this._campId = campId;
 
   String? _groupName;
   String? get groupName => _$this._groupName;
@@ -72,6 +82,7 @@ class ScanAssignBadgeRequestBuilder
   ScanAssignBadgeRequestBuilder get _$this {
     final $v = _$v;
     if ($v != null) {
+      _campId = $v.campId;
       _groupName = $v.groupName;
       _qrPayload = $v.qrPayload;
       _$v = null;
@@ -95,6 +106,7 @@ class ScanAssignBadgeRequestBuilder
   _$ScanAssignBadgeRequest _build() {
     final _$result = _$v ??
         _$ScanAssignBadgeRequest._(
+          campId: campId,
           groupName: groupName,
           qrPayload: qrPayload,
         );

--- a/frontend/lib/shared/api/providers/badge_providers.dart
+++ b/frontend/lib/shared/api/providers/badge_providers.dart
@@ -29,11 +29,20 @@ Future<List<Badge>> exportUnassignedBadges(Ref ref) async {
 }
 
 @riverpod
-Future<Badge> registerBadge(Ref ref, String badgeId, String groupId) async {
+Future<Badge> registerBadge(
+  Ref ref,
+  String badgeId,
+  String campId,
+  String groupName,
+) async {
   final apiInstance = ref.watch(campApiProvider);
   final response = await apiInstance.badgesIdRegisterPost(
     id: badgeId,
-    request: AssignBadgeRequest((b) => b..groupId = groupId),
+    request: AssignBadgeRequest(
+      (b) => b
+        ..campId = campId
+        ..groupName = groupName,
+    ),
   );
   final data = response.data;
   if (data == null) {
@@ -43,11 +52,17 @@ Future<Badge> registerBadge(Ref ref, String badgeId, String groupId) async {
 }
 
 @riverpod
-Future<Group> scanRegisterBadge(Ref ref, String qrPayload, String groupName) async {
+Future<Group> scanRegisterBadge(
+  Ref ref,
+  String campId,
+  String qrPayload,
+  String groupName,
+) async {
   final apiInstance = ref.watch(campApiProvider);
   final response = await apiInstance.badgesScanRegisterPost(
     request: ScanAssignBadgeRequest(
       (b) => b
+        ..campId = campId
         ..qrPayload = qrPayload
         ..groupName = groupName,
     ),

--- a/frontend/lib/shared/api/providers/badge_providers.g.dart
+++ b/frontend/lib/shared/api/providers/badge_providers.g.dart
@@ -172,7 +172,7 @@ final class RegisterBadgeProvider
     with $FutureModifier<Badge>, $FutureProvider<Badge> {
   RegisterBadgeProvider._({
     required RegisterBadgeFamily super.from,
-    required (String, String) super.argument,
+    required (String, String, String) super.argument,
   }) : super(
          retry: null,
          name: r'registerBadgeProvider',
@@ -198,8 +198,8 @@ final class RegisterBadgeProvider
 
   @override
   FutureOr<Badge> create(Ref ref) {
-    final argument = this.argument as (String, String);
-    return registerBadge(ref, argument.$1, argument.$2);
+    final argument = this.argument as (String, String, String);
+    return registerBadge(ref, argument.$1, argument.$2, argument.$3);
   }
 
   @override
@@ -213,10 +213,10 @@ final class RegisterBadgeProvider
   }
 }
 
-String _$registerBadgeHash() => r'76dbd6c08c461f7ebbb99ee796518bb070d25f95';
+String _$registerBadgeHash() => r'd979c5536e3eb380c6deab760206a55b394811e1';
 
 final class RegisterBadgeFamily extends $Family
-    with $FunctionalFamilyOverride<FutureOr<Badge>, (String, String)> {
+    with $FunctionalFamilyOverride<FutureOr<Badge>, (String, String, String)> {
   RegisterBadgeFamily._()
     : super(
         retry: null,
@@ -226,8 +226,11 @@ final class RegisterBadgeFamily extends $Family
         isAutoDispose: true,
       );
 
-  RegisterBadgeProvider call(String badgeId, String groupId) =>
-      RegisterBadgeProvider._(argument: (badgeId, groupId), from: this);
+  RegisterBadgeProvider call(String badgeId, String campId, String groupName) =>
+      RegisterBadgeProvider._(
+        argument: (badgeId, campId, groupName),
+        from: this,
+      );
 
   @override
   String toString() => r'registerBadgeProvider';
@@ -241,7 +244,7 @@ final class ScanRegisterBadgeProvider
     with $FutureModifier<Group>, $FutureProvider<Group> {
   ScanRegisterBadgeProvider._({
     required ScanRegisterBadgeFamily super.from,
-    required (String, String) super.argument,
+    required (String, String, String) super.argument,
   }) : super(
          retry: null,
          name: r'scanRegisterBadgeProvider',
@@ -267,8 +270,8 @@ final class ScanRegisterBadgeProvider
 
   @override
   FutureOr<Group> create(Ref ref) {
-    final argument = this.argument as (String, String);
-    return scanRegisterBadge(ref, argument.$1, argument.$2);
+    final argument = this.argument as (String, String, String);
+    return scanRegisterBadge(ref, argument.$1, argument.$2, argument.$3);
   }
 
   @override
@@ -282,10 +285,10 @@ final class ScanRegisterBadgeProvider
   }
 }
 
-String _$scanRegisterBadgeHash() => r'2d69ad079620acee51fe77a950d835ae26e3ee58';
+String _$scanRegisterBadgeHash() => r'f768b431f627c64553ee458446240410e2b9a30c';
 
 final class ScanRegisterBadgeFamily extends $Family
-    with $FunctionalFamilyOverride<FutureOr<Group>, (String, String)> {
+    with $FunctionalFamilyOverride<FutureOr<Group>, (String, String, String)> {
   ScanRegisterBadgeFamily._()
     : super(
         retry: null,
@@ -295,8 +298,14 @@ final class ScanRegisterBadgeFamily extends $Family
         isAutoDispose: true,
       );
 
-  ScanRegisterBadgeProvider call(String qrPayload, String groupName) =>
-      ScanRegisterBadgeProvider._(argument: (qrPayload, groupName), from: this);
+  ScanRegisterBadgeProvider call(
+    String campId,
+    String qrPayload,
+    String groupName,
+  ) => ScanRegisterBadgeProvider._(
+    argument: (campId, qrPayload, groupName),
+    from: this,
+  );
 
   @override
   String toString() => r'scanRegisterBadgeProvider';


### PR DESCRIPTION
## Summary
- 배지 등록(조 생성) API가 대상 캠프를 요청에서 받지 않고, 서버가 시스템 전체를 훑어 "처음 발견한 ACTIVE 캠프(없으면 아무 PENDING 캠프)"에 조를 생성했습니다. 여러 캠프가 동시에 다른 상태(진행중/준비중/종료)로 공존하는 게 정상 시나리오라, 관리자가 캠프 A 화면에서 조를 등록해도 캠프 B가 ACTIVE면 조가 캠프 B에 생성되는 버그가 있었습니다.
- `AssignBadgeRequest`/`ScanAssignBadgeRequest`에 `campId`를 추가하고, `GroupService.registerBadge`가 그 값으로 캠프를 조회하도록 변경했습니다. 캠프가 없으면 404, 이미 종료된 캠프면 409를 반환합니다.
- 프론트는 현재 선택된 캠프 ID를 요청에 실어 보내도록 수정했습니다.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (backend) 전체 통과
- [x] `dart analyze lib/` (frontend) 이슈 없음
- [x] `flutter test` 전체 통과 (변경과 무관한 flaky 테스트 2개는 main 브랜치에서도 동일하게 실패함을 확인해 배제)
- [x] `api/swagger.yaml`/`docs.go`/`swagger.json`은 `make swag`로, 프론트 API 클라이언트는 `openapi-generator`(Docker) + `build_runner`로 재생성하여 수기 편집 없이 동기화
- [ ] 실기기/로컬 서버로 "관리자가 캠프 B를 보면서 조 등록 → 캠프 B에 생성됨"을 직접 확인하지는 못함 (Go/Flutter 유닛·위젯 테스트로만 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)