### PR TITLE
refactor: dashboard_screen.dart를 상태/순수로직/액션으로 분리

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -72,7 +72,7 @@ docker-check:
 		docker create --name "$$container" --workdir /app \
 			-v '$(FLUTTER_PUB_CACHE_VOLUME):/root/.pub-cache' \
 			--entrypoint sh '$(FLUTTER_DOCKER_IMAGE)' \
-			-lc 'flutter pub get && flutter analyze && flutter test' >/dev/null; \
+			-lc 'flutter pub get && (cd packages/cornermon_api_gen && dart pub get) && flutter analyze && flutter test' >/dev/null; \
 		tar --exclude='./.dart_tool' --exclude='./build' --exclude='./.git' -cf - . \
 			| docker cp - "$$container:/app"; \
 		docker start -a "$$container"

--- a/frontend/lib/admin/features/dashboard/dashboard_actions.dart
+++ b/frontend/lib/admin/features/dashboard/dashboard_actions.dart
@@ -1,0 +1,100 @@
+import 'package:cornermon/admin/features/dashboard/dashboard_entries.dart';
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/providers/corner_track_providers.dart';
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon/shared/design_system/widgets/confirm_modal.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+Future<void> showAddCornerDialog(
+  BuildContext context,
+  WidgetRef ref,
+  CampId campId,
+) async {
+  final nameController = TextEditingController();
+  final minutesController = TextEditingController(text: '10');
+  final confirmed = await showDialog<bool>(
+    context: context,
+    builder: (context) {
+      final isDark = Theme.of(context).brightness == Brightness.dark;
+      final colors = isDark ? AppColors.dark : AppColors.light;
+      return AlertDialog(
+        title: Text(
+          '코너 추가',
+          style: AppTypography.title3.copyWith(color: colors.textPrimary),
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: nameController,
+              autofocus: true,
+              decoration: const InputDecoration(labelText: '코너 이름'),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              controller: minutesController,
+              keyboardType: TextInputType.number,
+              decoration: const InputDecoration(labelText: '목표시간(분)'),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('취소'),
+          ),
+          AppButton(
+            variant: AppButtonVariant.primary,
+            size: AppButtonSize.compact,
+            label: '추가',
+            onPressed: () => Navigator.pop(context, true),
+          ),
+        ],
+      );
+    },
+  );
+  if (confirmed != true) return;
+  final name = nameController.text.trim();
+  final minutes = int.tryParse(minutesController.text) ?? 10;
+  if (name.isEmpty) return;
+  await ref.read(createCornerProvider(campId, name, minutes).future);
+  ref.invalidate(cornerListProvider(campId));
+}
+
+Future<void> deleteCorner(
+  BuildContext context,
+  WidgetRef ref,
+  CampId campId,
+  CornerDashboardEntry entry,
+) async {
+  if (entry.hasBusyTrack) {
+    await showConfirmModal(
+      context,
+      kind: ConfirmModalKind.hardBlock,
+      title: '작업할 수 없습니다',
+      body: '진행 중인 방문이 있어 삭제할 수 없습니다',
+    );
+    return;
+  }
+  final confirmed = await showConfirmModal(
+    context,
+    kind: ConfirmModalKind.softConfirm,
+    title: '코너 "${entry.corner.name ?? entry.corner.id}"를 삭제하시겠습니까?',
+    body: '연결된 트랙과 방문 기록도 함께 삭제됩니다.',
+  );
+  if (!confirmed) return;
+  try {
+    await ref.read(deleteCornerProvider(CornerId(entry.corner.id!)).future);
+    ref.invalidate(cornerListProvider(campId));
+  } catch (_) {
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('코너 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.')),
+      );
+    }
+  }
+}

--- a/frontend/lib/admin/features/dashboard/dashboard_entries.dart
+++ b/frontend/lib/admin/features/dashboard/dashboard_entries.dart
@@ -1,0 +1,84 @@
+import 'package:cornermon/admin/features/dashboard/dashboard_state.dart';
+import 'package:cornermon/shared/api/domain_aliases.dart' as api;
+
+class CornerDashboardEntry {
+  const CornerDashboardEntry(this.corner, {this.avgDeviationSeconds});
+  final api.Corner corner;
+  final num? avgDeviationSeconds;
+  bool get inactive => corner.status == api.CornerOperationalStatus.INACTIVE;
+  bool get hasBusyTrack => (corner.activeTracks?.toList() ?? const []).any(
+    (track) => track.operationalStatus?.name == 'BUSY',
+  );
+}
+
+List<CornerDashboardEntry> buildDashboardEntries(
+  List<api.Corner> corners,
+  Iterable<api.BottleneckRanking> ranking,
+) {
+  final deviations = {
+    for (final item in ranking) item.cornerId: item.avgDeviationSeconds,
+  };
+  return [
+    for (final corner in corners)
+      CornerDashboardEntry(corner, avgDeviationSeconds: deviations[corner.id]),
+  ];
+}
+
+List<CornerDashboardEntry> filterEntries(
+  List<CornerDashboardEntry> entries,
+  CornerFilterChip filter,
+) => entries
+    .where(
+      (entry) => switch (filter) {
+        CornerFilterChip.all => true,
+        CornerFilterChip.busy =>
+          entry.corner.status == api.CornerOperationalStatus.BUSY,
+        CornerFilterChip.idle =>
+          entry.corner.status == api.CornerOperationalStatus.IDLE,
+        CornerFilterChip.inactive => entry.inactive,
+        CornerFilterChip.bottleneckOnly => entry.corner.isBottleneck ?? false,
+      },
+    )
+    .toList();
+List<CornerDashboardEntry> sortEntries(
+  List<CornerDashboardEntry> entries,
+  CornerSortOption option,
+) {
+  final result = [...entries];
+  int number(CornerDashboardEntry value) =>
+      int.tryParse(
+        RegExp(r'\d+').firstMatch(value.corner.name ?? '')?.group(0) ?? '',
+      ) ??
+      1 << 30;
+  result.sort((a, b) {
+    if (a.inactive != b.inactive) return a.inactive ? 1 : -1;
+    return switch (option) {
+      CornerSortOption.cornerNo => number(a).compareTo(number(b)),
+      CornerSortOption.name => (a.corner.name ?? '').compareTo(
+        b.corner.name ?? '',
+      ),
+      CornerSortOption.avgDeviationDesc =>
+        (b.avgDeviationSeconds ?? double.negativeInfinity).compareTo(
+          a.avgDeviationSeconds ?? double.negativeInfinity,
+        ),
+      CornerSortOption.avgDeviationAsc =>
+        (a.avgDeviationSeconds ?? double.infinity).compareTo(
+          b.avgDeviationSeconds ?? double.infinity,
+        ),
+    };
+  });
+  return result;
+}
+
+String formatCornerCardSubtitle({
+  required int avgDurationSeconds,
+  required int sampleCount,
+  num? avgDeviationSeconds,
+}) {
+  String duration(num seconds) =>
+      '${seconds ~/ 60}:${(seconds % 60).round().toString().padLeft(2, '0')}';
+  final deviation = avgDeviationSeconds == null
+      ? ''
+      : ' (${avgDeviationSeconds >= 0 ? '+' : '-'}${duration(avgDeviationSeconds.abs())})';
+  return '평균 ${duration(avgDurationSeconds)}$deviation · 최근 $sampleCount건';
+}

--- a/frontend/lib/admin/features/dashboard/dashboard_screen.dart
+++ b/frontend/lib/admin/features/dashboard/dashboard_screen.dart
@@ -1,15 +1,18 @@
+import 'package:cornermon/admin/features/dashboard/dashboard_actions.dart';
+import 'package:cornermon/admin/features/dashboard/dashboard_entries.dart';
+import 'package:cornermon/admin/features/dashboard/dashboard_state.dart';
 import 'package:cornermon/admin/features/track_bulk_manage/track_pin_export_controller.dart';
 import 'package:cornermon/admin/features/track_direct/track_direct_providers.dart';
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/shared/api/domain_aliases.dart' as api;
 import 'package:cornermon/shared/api/ids.dart';
-import 'package:cornermon/shared/api/providers/corner_track_providers.dart';
+import 'package:cornermon/shared/api/providers/corner_track_providers.dart'
+    hide deleteCorner;
 import 'package:cornermon/shared/api/providers/report_providers.dart';
 import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/app_dropdown.dart';
-import 'package:cornermon/shared/design_system/widgets/confirm_modal.dart';
 import 'package:cornermon/shared/design_system/widgets/empty_state.dart';
 import 'package:cornermon/shared/design_system/widgets/connection_banner.dart';
 import 'package:cornermon/shared/design_system/widgets/pill_tab_bar.dart';
@@ -19,203 +22,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-enum CornerSortOption { cornerNo, name, avgDeviationDesc, avgDeviationAsc }
-
-enum CornerFilterChip { all, busy, idle, inactive, bottleneckOnly }
-
 final dashboardPinExportButtonKey = GlobalKey();
-
-final dashboardSortProvider = NotifierProvider<DashboardSort, CornerSortOption>(
-  DashboardSort.new,
-);
-
-class DashboardSort extends Notifier<CornerSortOption> {
-  @override
-  CornerSortOption build() => CornerSortOption.cornerNo;
-  void select(CornerSortOption value) => state = value;
-}
-
-final dashboardFilterProvider =
-    NotifierProvider<DashboardFilter, CornerFilterChip>(DashboardFilter.new);
-
-class DashboardFilter extends Notifier<CornerFilterChip> {
-  @override
-  CornerFilterChip build() => CornerFilterChip.all;
-  void select(CornerFilterChip value) => state = value;
-}
-
-class CornerDashboardEntry {
-  const CornerDashboardEntry(this.corner, {this.avgDeviationSeconds});
-  final api.Corner corner;
-  final num? avgDeviationSeconds;
-  bool get inactive => corner.status == api.CornerOperationalStatus.INACTIVE;
-  bool get hasBusyTrack => (corner.activeTracks?.toList() ?? const []).any(
-    (track) => track.operationalStatus?.name == 'BUSY',
-  );
-}
-
-Future<void> _showAddCornerDialog(
-  BuildContext context,
-  WidgetRef ref,
-  CampId campId,
-) async {
-  final nameController = TextEditingController();
-  final minutesController = TextEditingController(text: '10');
-  final confirmed = await showDialog<bool>(
-    context: context,
-    builder: (context) {
-      final isDark = Theme.of(context).brightness == Brightness.dark;
-      final colors = isDark ? AppColors.dark : AppColors.light;
-      return AlertDialog(
-        title: Text(
-          '코너 추가',
-          style: AppTypography.title3.copyWith(color: colors.textPrimary),
-        ),
-        content: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            TextField(
-              controller: nameController,
-              autofocus: true,
-              decoration: const InputDecoration(labelText: '코너 이름'),
-            ),
-            const SizedBox(height: 12),
-            TextField(
-              controller: minutesController,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(labelText: '목표시간(분)'),
-            ),
-          ],
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('취소'),
-          ),
-          AppButton(
-            variant: AppButtonVariant.primary,
-            size: AppButtonSize.compact,
-            label: '추가',
-            onPressed: () => Navigator.pop(context, true),
-          ),
-        ],
-      );
-    },
-  );
-  if (confirmed != true) return;
-  final name = nameController.text.trim();
-  final minutes = int.tryParse(minutesController.text) ?? 10;
-  if (name.isEmpty) return;
-  await ref.read(createCornerProvider(campId, name, minutes).future);
-  ref.invalidate(cornerListProvider(campId));
-}
-
-Future<void> _deleteCorner(
-  BuildContext context,
-  WidgetRef ref,
-  CampId campId,
-  CornerDashboardEntry entry,
-) async {
-  if (entry.hasBusyTrack) {
-    await showConfirmModal(
-      context,
-      kind: ConfirmModalKind.hardBlock,
-      title: '작업할 수 없습니다',
-      body: '진행 중인 방문이 있어 삭제할 수 없습니다',
-    );
-    return;
-  }
-  final confirmed = await showConfirmModal(
-    context,
-    kind: ConfirmModalKind.softConfirm,
-    title: '코너 "${entry.corner.name ?? entry.corner.id}"를 삭제하시겠습니까?',
-    body: '연결된 트랙과 방문 기록도 함께 삭제됩니다.',
-  );
-  if (!confirmed) return;
-  try {
-    await ref.read(deleteCornerProvider(CornerId(entry.corner.id!)).future);
-    ref.invalidate(cornerListProvider(campId));
-  } catch (_) {
-    if (context.mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('코너 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.')),
-      );
-    }
-  }
-}
-
-List<CornerDashboardEntry> buildDashboardEntries(
-  List<api.Corner> corners,
-  Iterable<api.BottleneckRanking> ranking,
-) {
-  final deviations = {
-    for (final item in ranking) item.cornerId: item.avgDeviationSeconds,
-  };
-  return [
-    for (final corner in corners)
-      CornerDashboardEntry(corner, avgDeviationSeconds: deviations[corner.id]),
-  ];
-}
-
-List<CornerDashboardEntry> filterEntries(
-  List<CornerDashboardEntry> entries,
-  CornerFilterChip filter,
-) => entries
-    .where(
-      (entry) => switch (filter) {
-        CornerFilterChip.all => true,
-        CornerFilterChip.busy =>
-          entry.corner.status == api.CornerOperationalStatus.BUSY,
-        CornerFilterChip.idle =>
-          entry.corner.status == api.CornerOperationalStatus.IDLE,
-        CornerFilterChip.inactive => entry.inactive,
-        CornerFilterChip.bottleneckOnly => entry.corner.isBottleneck ?? false,
-      },
-    )
-    .toList();
-List<CornerDashboardEntry> sortEntries(
-  List<CornerDashboardEntry> entries,
-  CornerSortOption option,
-) {
-  final result = [...entries];
-  int number(CornerDashboardEntry value) =>
-      int.tryParse(
-        RegExp(r'\d+').firstMatch(value.corner.name ?? '')?.group(0) ?? '',
-      ) ??
-      1 << 30;
-  result.sort((a, b) {
-    if (a.inactive != b.inactive) return a.inactive ? 1 : -1;
-    return switch (option) {
-      CornerSortOption.cornerNo => number(a).compareTo(number(b)),
-      CornerSortOption.name => (a.corner.name ?? '').compareTo(
-        b.corner.name ?? '',
-      ),
-      CornerSortOption.avgDeviationDesc =>
-        (b.avgDeviationSeconds ?? double.negativeInfinity).compareTo(
-          a.avgDeviationSeconds ?? double.negativeInfinity,
-        ),
-      CornerSortOption.avgDeviationAsc =>
-        (a.avgDeviationSeconds ?? double.infinity).compareTo(
-          b.avgDeviationSeconds ?? double.infinity,
-        ),
-    };
-  });
-  return result;
-}
-
-String formatCornerCardSubtitle({
-  required int avgDurationSeconds,
-  required int sampleCount,
-  num? avgDeviationSeconds,
-}) {
-  String duration(num seconds) =>
-      '${seconds ~/ 60}:${(seconds % 60).round().toString().padLeft(2, '0')}';
-  final deviation = avgDeviationSeconds == null
-      ? ''
-      : ' (${avgDeviationSeconds >= 0 ? '+' : '-'}${duration(avgDeviationSeconds.abs())})';
-  return '평균 ${duration(avgDurationSeconds)}$deviation · 최근 $sampleCount건';
-}
 
 class DashboardScreen extends ConsumerWidget {
   const DashboardScreen({super.key});
@@ -350,7 +157,7 @@ class DashboardScreen extends ConsumerWidget {
                           : Icons.filter_alt_off,
                       actionLabel: noCorners ? '코너 추가' : null,
                       onAction: noCorners
-                          ? () => _showAddCornerDialog(context, ref, id)
+                          ? () => showAddCornerDialog(context, ref, id)
                           : null,
                     ),
                   );
@@ -376,7 +183,7 @@ class DashboardScreen extends ConsumerWidget {
                               '/dashboard/corners/${entry.corner.id}',
                             )
                           : null,
-                      onDelete: () => _deleteCorner(context, ref, id, entry),
+                      onDelete: () => deleteCorner(context, ref, id, entry),
                     );
                   },
                 );
@@ -502,7 +309,7 @@ class _Controls extends ConsumerWidget {
         size: AppButtonSize.compact,
         icon: Icons.add,
         label: '코너 추가',
-        onPressed: () => _showAddCornerDialog(context, ref, campId),
+        onPressed: () => showAddCornerDialog(context, ref, campId),
       ),
       AppButton(
         variant: AppButtonVariant.secondary,

--- a/frontend/lib/admin/features/dashboard/dashboard_state.dart
+++ b/frontend/lib/admin/features/dashboard/dashboard_state.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+enum CornerSortOption { cornerNo, name, avgDeviationDesc, avgDeviationAsc }
+
+enum CornerFilterChip { all, busy, idle, inactive, bottleneckOnly }
+
+final dashboardSortProvider = NotifierProvider<DashboardSort, CornerSortOption>(
+  DashboardSort.new,
+);
+
+class DashboardSort extends Notifier<CornerSortOption> {
+  @override
+  CornerSortOption build() => CornerSortOption.cornerNo;
+  void select(CornerSortOption value) => state = value;
+}
+
+final dashboardFilterProvider =
+    NotifierProvider<DashboardFilter, CornerFilterChip>(DashboardFilter.new);
+
+class DashboardFilter extends Notifier<CornerFilterChip> {
+  @override
+  CornerFilterChip build() => CornerFilterChip.all;
+  void select(CornerFilterChip value) => state = value;
+}

--- a/frontend/test/admin/features/dashboard/dashboard_screen_test.dart
+++ b/frontend/test/admin/features/dashboard/dashboard_screen_test.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
+import 'package:cornermon/admin/features/dashboard/dashboard_entries.dart';
 import 'package:cornermon/admin/features/dashboard/dashboard_screen.dart';
+import 'package:cornermon/admin/features/dashboard/dashboard_state.dart';
 import 'package:cornermon/admin/features/track_bulk_manage/track_pin_export_controller.dart';
 import 'package:cornermon/admin/features/track_direct/track_direct_providers.dart';
 import 'package:cornermon/admin/session/selected_camp_provider.dart';


### PR DESCRIPTION
## Summary
- `admin/features/dashboard/dashboard_screen.dart`(751줄)에 뒤섞여 있던 UI, 상태(Notifier provider), 순수 로직(정렬/필터/포맷), 액션(다이얼로그/삭제)을 `dashboard_state.dart` / `dashboard_entries.dart` / `dashboard_actions.dart`로 분리하고 `dashboard_screen.dart`는 위젯 트리만 남김. `track_bulk_manage` 등 다른 feature가 이미 따르는 분리 컨벤션에 맞춤.
- (부수) `frontend/Makefile`의 `docker-check`가 `packages/cornermon_api_gen`(자체 pubspec을 가진 별도 패키지)에서 `pub get`을 하지 않아 컨테이너 안에서 dio/built_value 등 전부 미해결로 뜨던 기존 버그를 발견해 함께 수정.

## Test plan
- [x] Docker 격리 환경(`cornermon-flutter:3.44.7`, `packages/cornermon_api_gen` pub get 포함)에서 `flutter analyze` 통과 (사전 존재하는 생성 코드 warning 17건 제외, 후속 이슈로 분리)
- [x] Docker 격리 환경에서 `flutter test` 실행, `dashboard_screen_test.dart` 전체 통과 (실패 2건은 `end_camp_bar_button_test.dart`, `track_event_stream_test.dart`로 오늘 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)