### PR TITLE
chore: 인프라 로그에 요청 trace ID 전파 (#187)

### DIFF
--- a/backend/docs/DEVELOPER_GUIDE.md
+++ b/backend/docs/DEVELOPER_GUIDE.md
@@ -215,21 +215,28 @@ func (r *pgBadgeRepository) queries(ctx context.Context) *db.Queries {
 usecase는 이 구현을 모르고 인터페이스로만 호출하므로, 브로드캐스터 구현을 교체해도(예: Redis
 pub/sub로 전환) usecase 코드는 변경되지 않습니다.
 
-#### 4.3.1 trace_id 상관관계 한계 (Issue #187)
+#### 4.3.1 trace_id 상관관계 한계와 cause_trace_id (Issue #187)
 
-인프라 로그(Postgres tracer, SSE broadcaster/event handler)는 `*Context` 계열 slog 호출로
-`ctx`의 `trace_id`를 전파하지만, 두 경로의 `ctx` 수명이 다르다는 점을 알고 상관 분석해야 합니다.
+요청 trace_id(HTTP 요청 1건 단위)와 SSE 연결의 ctx(연결 수명 전체, 여러 요청에 걸침)는
+서로 다른 수명을 가지므로 같은 이름(`trace_id`)이라고 해서 같은 것을 가리키지 않습니다.
+이 혼동을 막기 위해 SSE 관련 로그는 세 필드를 구분해서 씁니다.
 
-- **요청 trace_id**: `web.Logger()`가 HTTP 요청 1건마다 생성/전파합니다. `Broadcast(ctx, ...)`
-  호출은 usecase가 트랜잭션 커밋 이후 이 요청 ctx로 호출하므로, "무엇이 이 알림을 유발했는가"는
-  `BroadcasterImpl.Broadcast`의 `SSE broadcast dispatched` 로그 trace_id로 추적할 수 있습니다.
-- **SSE 연결 trace_id**: `EventHandler.streamEvents`의 `ctx`는 SSE 연결이 열린 시점(구독
-  요청)의 ctx로, 연결이 유지되는 동안 고정됩니다. 이후 그 연결로 전달되는 모든 이벤트의 write
-  로그(`SSE event write failed` 등)는 연결 시점의 trace_id를 공유할 뿐, 알림을 유발한 원본
-  요청의 trace_id와는 다릅니다.
-- 따라서 "어떤 요청이 어떤 클라이언트에게 무엇을 언제 전달했는가"를 추적하려면 두 로그를
-  `trace_id`가 아니라 `event`/`scope`/타임스탬프로 연결해야 합니다. 두 trace_id를 동일시하지
-  마세요.
+- **`trace_id`** (모든 `*Context` slog 호출에 `errs.SlogWrappedHandler`가 자동 주입): 그
+  로그 라인을 호출한 시점의 ctx가 가진 trace_id — 의미는 호출 위치마다 다릅니다.
+- **`connection_id`** (`EventHandler.streamEvents`가 명시적으로 남김): SSE 연결이 열릴 때
+  (구독 요청) 발급된 trace_id로, 그 연결이 살아있는 동안 고정됩니다. 이 연결로 전달되는
+  모든 이벤트의 로그가 같은 `connection_id`를 공유합니다. `EventHandler` 로그의 `trace_id`는
+  결국 이 값과 동일합니다.
+- **`cause_trace_id`** (`usecase.SSEMessage.CauseTraceID`, `BroadcasterImpl.Broadcast`가
+  `ctx`에서 추출해 message에 실음): 이 알림을 유발한 원본 요청(상태를 변경해 커밋한 요청)의
+  trace_id. `Broadcast`가 호출된 시점의 `trace_id`와 동일한 값이지만, 이후 메시지에 실려
+  SSE 연결(다른 `connection_id`를 가진 여러 구독자)에까지 전달되어 `EventHandler`의
+  `SSE event delivered`/`SSE event write failed` 로그에도 그대로 남습니다.
+
+즉 "어떤 요청이 발행한 알림을 어떤 연결이 언제 받았는가"는 `cause_trace_id`로 두 계층의
+로그를 조인해서 추적하고, "이 연결 자체에 무슨 일이 있었는가"는 `connection_id`로 봅니다.
+`trace_id`만 보고 두 로그를 엮으면 안 됩니다 — SSE 쪽 `trace_id`는 발행 요청이 아니라
+연결 자신을 가리키기 때문입니다.
 
 ## 5. 인증
 

--- a/backend/docs/DEVELOPER_GUIDE.md
+++ b/backend/docs/DEVELOPER_GUIDE.md
@@ -215,7 +215,7 @@ func (r *pgBadgeRepository) queries(ctx context.Context) *db.Queries {
 usecase는 이 구현을 모르고 인터페이스로만 호출하므로, 브로드캐스터 구현을 교체해도(예: Redis
 pub/sub로 전환) usecase 코드는 변경되지 않습니다.
 
-#### 4.3.1 trace_id 상관관계 한계와 cause_trace_id (Issue #187)
+#### 4.3.1 trace_id 상관관계 한계와 causation_id (Issue #187)
 
 요청 trace_id(HTTP 요청 1건 단위)와 SSE 연결의 ctx(연결 수명 전체, 여러 요청에 걸침)는
 서로 다른 수명을 가지므로 같은 이름(`trace_id`)이라고 해서 같은 것을 가리키지 않습니다.
@@ -227,13 +227,21 @@ pub/sub로 전환) usecase 코드는 변경되지 않습니다.
   (구독 요청) 발급된 trace_id로, 그 연결이 살아있는 동안 고정됩니다. 이 연결로 전달되는
   모든 이벤트의 로그가 같은 `connection_id`를 공유합니다. `EventHandler` 로그의 `trace_id`는
   결국 이 값과 동일합니다.
-- **`cause_trace_id`** (`usecase.SSEMessage.CauseTraceID`, `BroadcasterImpl.Broadcast`가
-  `ctx`에서 추출해 message에 실음): 이 알림을 유발한 원본 요청(상태를 변경해 커밋한 요청)의
-  trace_id. `Broadcast`가 호출된 시점의 `trace_id`와 동일한 값이지만, 이후 메시지에 실려
-  SSE 연결(다른 `connection_id`를 가진 여러 구독자)에까지 전달되어 `EventHandler`의
-  `SSE event delivered`/`SSE event write failed` 로그에도 그대로 남습니다.
+- **`causation_id`** (`usecase.SSEMessage.CausationID`, `BroadcasterImpl.Broadcast`가
+  message에 실어 SSE 연결까지 전달): 이 알림을 유발한 원본 요청/커맨드를 가리키는 식별자.
+  CQRS/이벤트 소싱의 **Causation ID** 패턴("이 이벤트가 왜 존재하는가"에 대한 이벤트 자신의
+  계보 메타데이터, `CorrelationID`와 자매 개념)을 그대로 따른 것으로, 로그 상관분석용 부가
+  정보가 아니라 `SSEMessage`가 스스로 알아야 할 정상적인 메타데이터로 봅니다.
 
-즉 "어떤 요청이 발행한 알림을 어떤 연결이 언제 받았는가"는 `cause_trace_id`로 두 계층의
+  **구현상으로는 지금 HTTP 요청의 trace_id를 그대로 재사용**하고 있습니다 — 커밋까지 이어진
+  이 요청을 가리키는 식별자가 코드베이스에 trace_id 말고는 아직 없어서 택한 재사용일 뿐,
+  `CausationID`의 정의가 "trace_id"라는 뜻은 아닙니다. 별도의 커맨드/이벤트 ID 체계가
+  생기면 그쪽으로 교체될 수 있는 자리입니다. `Broadcast` 호출 시점의 `trace_id`와 값은
+  같지만, 이후 message에 실려 SSE 연결(다른 `connection_id`를 가진 여러 구독자)에까지
+  전달되어 `EventHandler`의 `SSE event delivered`/`SSE event write failed` 로그에도 그대로
+  남습니다.
+
+즉 "어떤 요청이 발행한 알림을 어떤 연결이 언제 받았는가"는 `causation_id`로 두 계층의
 로그를 조인해서 추적하고, "이 연결 자체에 무슨 일이 있었는가"는 `connection_id`로 봅니다.
 `trace_id`만 보고 두 로그를 엮으면 안 됩니다 — SSE 쪽 `trace_id`는 발행 요청이 아니라
 연결 자신을 가리키기 때문입니다.

--- a/backend/docs/DEVELOPER_GUIDE.md
+++ b/backend/docs/DEVELOPER_GUIDE.md
@@ -215,6 +215,22 @@ func (r *pgBadgeRepository) queries(ctx context.Context) *db.Queries {
 usecase는 이 구현을 모르고 인터페이스로만 호출하므로, 브로드캐스터 구현을 교체해도(예: Redis
 pub/sub로 전환) usecase 코드는 변경되지 않습니다.
 
+#### 4.3.1 trace_id 상관관계 한계 (Issue #187)
+
+인프라 로그(Postgres tracer, SSE broadcaster/event handler)는 `*Context` 계열 slog 호출로
+`ctx`의 `trace_id`를 전파하지만, 두 경로의 `ctx` 수명이 다르다는 점을 알고 상관 분석해야 합니다.
+
+- **요청 trace_id**: `web.Logger()`가 HTTP 요청 1건마다 생성/전파합니다. `Broadcast(ctx, ...)`
+  호출은 usecase가 트랜잭션 커밋 이후 이 요청 ctx로 호출하므로, "무엇이 이 알림을 유발했는가"는
+  `BroadcasterImpl.Broadcast`의 `SSE broadcast dispatched` 로그 trace_id로 추적할 수 있습니다.
+- **SSE 연결 trace_id**: `EventHandler.streamEvents`의 `ctx`는 SSE 연결이 열린 시점(구독
+  요청)의 ctx로, 연결이 유지되는 동안 고정됩니다. 이후 그 연결로 전달되는 모든 이벤트의 write
+  로그(`SSE event write failed` 등)는 연결 시점의 trace_id를 공유할 뿐, 알림을 유발한 원본
+  요청의 trace_id와는 다릅니다.
+- 따라서 "어떤 요청이 어떤 클라이언트에게 무엇을 언제 전달했는가"를 추적하려면 두 로그를
+  `trace_id`가 아니라 `event`/`scope`/타임스탬프로 연결해야 합니다. 두 trace_id를 동일시하지
+  마세요.
+
 ## 5. 인증
 
 - 모든 토큰(진행자 트랙 PIN 세션, 기기 신뢰 토큰, 관리자 access/refresh)은 **opaque token**이며

--- a/backend/docs/artifacts/plan/20260807_infra_trace_id_propagation_plan.md
+++ b/backend/docs/artifacts/plan/20260807_infra_trace_id_propagation_plan.md
@@ -1,0 +1,74 @@
+# 인프라 로그 trace ID 전파 (Issue #187)
+
+## 배경
+
+`web.Logger()` 미들웨어는 요청 context에 `trace_id`를 심고, `errs.SlogWrappedHandler`가
+context 기반(`*Context` 계열) slog 호출에서 자동으로 `trace_id`를 로그 속성에 주입한다.
+하지만 `postgres.SlogQueryTracer`는 `slog.Error/Warn/Debug` 전역 호출을 사용해 이 context를
+버리고, `sse.BroadcasterImpl`은 특정 이벤트(#184 진단용)에만 임시로 `DebugContext`를 쓰고
+있어 일반적인 운영 로그 지점이 없다. 결과적으로 같은 요청에서 발생한 DB 쿼리 로그와
+SSE fan-out 로그를 `trace_id`로 상관 분석할 수 없다.
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| **P0** | UC-1: DB 쿼리 에러/느린 쿼리 로그에 trace_id 포함 | `SlogQueryTracer`가 `ctx`를 사용해 `*Context` slog 호출로 전환 | 프로덕션 장애 분석 |
+| **P0** | UC-2: SSE broadcast fan-out 로그 상시화 | `#184` 임시 디버그 로그를 제거하고 모든 이벤트에 적용되는 상시 로그로 대체 | 프로덕션 운영 모니터링 |
+| P1 | UC-3: SSE 연결 write 실패 로그 | `streamEvents`에서 클라이언트 write 실패 시 구조화 로그 | 장애 진단 |
+| P1 | UC-4: 요청 trace_id ↔ SSE 연결 trace_id 상관관계 한계 문서화 | 코드 주석 + 개발자 가이드에 명시 | 온보딩/운영 지식 |
+
+## 설계
+
+### UC-1: `internal/infrastructure/postgres/tracer.go`
+
+- `TraceQueryEnd(ctx, ...)`는 이미 `ctx`를 받고 있으므로, `slog.Error/Warn/Debug` →
+  `slog.ErrorContext(ctx, ...)/WarnContext(ctx, ...)/DebugContext(ctx, ...)`로 교체.
+- `LogParameterValues` 게이트(민감 파라미터 마스킹)는 기존 동작 유지 — 변경하지 않음.
+
+### UC-2: `internal/infrastructure/sse/broadcaster.go`
+
+- `Broadcast`의 `#184` 전용 임시 로그(`if event == usecase.EventMessagesChanged`)를 제거하고,
+  모든 이벤트에 대해 `DebugContext`로 동일한 필드(delivered/full subscriber 수)를 로그.
+- 버퍼가 가득 차 구독자를 제거하는 경로(`len(fullAdminSubs) > 0 || len(fullTrackSubs) > 0`)는
+  클라이언트가 뒤처지고 있다는 신호이므로 `WarnContext`로 별도 로그 추가.
+- `Broadcast(ctx, ...)`는 커밋 이후 요청 흐름의 `ctx`를 그대로 받으므로 trace_id가 자동 전파됨
+  (usecase 계층 규약, DEVELOPER_GUIDE.md §3.2 참고).
+
+### UC-3: `internal/infrastructure/web/event_handler.go`
+
+- `streamEvents`에서 `#184` 임시 로그를 제거.
+- `c.Response().Write` 실패(클라이언트 연결 끊김 등)는 이미 `return err`로 상위 echo 에러
+  처리로 넘어가지만, SSE 스트림은 `ErrorHandler` 미들웨어가 잡지 못하는 경로(스트리밍 도중
+  에러)이므로 반환 직전 `WarnContext`로 1회 로그를 남긴다. (클라이언트가 그냥 연결을 끊는
+  정상 케이스와 실제 네트워크 에러를 구분할 필요는 없음 — 어차피 재연결 유도가 목적.)
+
+### UC-4: 문서화
+
+- `backend/docs/DEVELOPER_GUIDE.md` §4.3(SSE Broadcaster)에 아래 내용 추가:
+  - 요청 `trace_id`(HTTP 요청 1건 단위)와 SSE 연결의 `ctx`(연결 수명 전체, 여러 요청에 걸침)는
+    서로 다른 수명을 가지므로 하나의 `trace_id`로 상관 분석할 수 없다.
+  - `Broadcast` 호출 시점의 trace_id는 "무엇이 이 알림을 유발했는가"를, `streamEvents`의 로그는
+    "이 연결이 무엇을 언제 받았는가"를 각각 나타내며 두 로그를 연결하려면 `scope`/`event`/시간을
+    함께 봐야 한다.
+
+## 검증
+
+### 자동화 테스트
+
+- `internal/infrastructure/postgres/tracer_test.go`에 회귀 테스트 추가:
+  `ShouldLogTraceIDWhenQueryErrors` — context에 trace_id를 심고 에러 쿼리를 트레이스,
+  캡처된 slog 출력에 trace_id가 포함되는지 확인.
+- `internal/infrastructure/sse/broadcaster_test.go`(신규) 또는 기존 테스트 파일에
+  `ShouldLogTraceIDWhenBroadcastDispatched` 추가.
+- `internal/infrastructure/web/event_handler_test.go`에 write 실패 시 경고 로그 회귀 테스트
+  추가(선택, 구현 난이도에 따라 P2로 낮출 수 있음).
+
+### 체크리스트
+
+- [ ] `postgres.SlogQueryTracer`가 에러/느린쿼리/디버그 로그 모두 `*Context` 계열로 전환됨
+- [ ] `sse.BroadcasterImpl.Broadcast`가 모든 이벤트에 대해 상시 구조화 로그를 남김 (임시 진단 로그 제거)
+- [ ] `EventHandler.streamEvents`가 write 실패 시 trace_id 포함 경고 로그를 남김
+- [ ] DEVELOPER_GUIDE.md에 trace_id 상관관계 한계 문서화
+- [ ] 토큰/헤더/메시지 본문 등 민감 정보가 새로 로그에 노출되지 않음
+- [ ] `go test ./...`, `gofmt -w .`, `go vet ./...` 통과

--- a/backend/docs/artifacts/plan/20260807_infra_trace_id_propagation_plan.md
+++ b/backend/docs/artifacts/plan/20260807_infra_trace_id_propagation_plan.md
@@ -73,7 +73,7 @@ SSE fan-out 로그를 `trace_id`로 상관 분석할 수 없다.
 - [x] 토큰/헤더/메시지 본문 등 민감 정보가 새로 로그에 노출되지 않음
 - [x] `go test ./...`, `gofmt -w .`, `go vet ./...` 통과
 
-## Addendum: connection_id / cause_trace_id 분리 (PR 리뷰 피드백)
+## Addendum 1: connection_id / cause_trace_id 분리 (PR 리뷰 피드백)
 
 최초 구현은 요청 trace_id와 SSE 연결 trace_id의 수명이 다르다는 점을 **문서로만** 경고했다.
 리뷰 중 "결국 남는 건 로그뿐이니 어떤 요청이 이벤트를 발행했는지 로그만으로 추적 가능해야
@@ -99,4 +99,27 @@ SSE fan-out 로그를 `trace_id`로 상관 분석할 수 없다.
       남는지 검증
 - [x] `event_handler_test.go`: `connection_id`와 `cause_trace_id`가 서로 다른 값으로
       로그에 남는지(write 실패/정상 delivered 양쪽) 검증
+- [x] `go test ./...`, `gofmt -w .`, `go vet ./...` 재통과
+
+## Addendum 2: CauseTraceID → CausationID 리네이밍 (레이어링 논의)
+
+Addendum 1에서 `usecase.SSEMessage`에 로깅 전용 필드를 얹은 게 "usecase 포트가 옵저버빌리티
+관심사를 안다"는 레이어링 위반 아니냐는 논의가 있었다. 결론은 위반이 아니라는 쪽이었지만
+(usecase는 이 값을 생성·해석하지 않고 그냥 통과시킬 뿐이며, `sse` ↔ `web` 두 infra 패키지가
+공유하는 채널 타입이 이 필드가 지나갈 유일한 통로다), 이름이 `*TraceID`라서 "trace_id를
+로깅용으로 복붙한 것"처럼 읽히는 게 문제였다.
+
+이를 CQRS/이벤트 소싱의 **Causation ID** 패턴("이 이벤트가 왜 존재하는가"를 나타내는, 이벤트
+자신의 정상적인 계보 메타데이터 — `CorrelationID`의 자매 개념)으로 명시적으로 재프레이밍했다.
+
+- `SSEMessage.CauseTraceID` → `SSEMessage.CausationID`로 리네이밍.
+- 필드 주석에 "왜 이 정보가 usecase까지 넘어오는가"(위 레이어링 논의 요약)와 "지금은 HTTP
+  요청의 trace_id를 우연히 재사용하는 구현 디테일일 뿐, CausationID의 정의 자체가 trace_id는
+  아니다"를 명시.
+- 로그 필드명도 `cause_trace_id` → `causation_id`로 통일.
+- DEVELOPER_GUIDE.md §4.3.1 제목/본문을 causation_id 기준으로 갱신.
+- 관련 테스트/plan 문서 전부 리네이밍 반영.
+
+### 추가 검증
+- [x] `CauseTraceID`/`cause_trace_id` 잔존 참조 없음 (`grep -rl` 확인)
 - [x] `go test ./...`, `gofmt -w .`, `go vet ./...` 재통과

--- a/backend/docs/artifacts/plan/20260807_infra_trace_id_propagation_plan.md
+++ b/backend/docs/artifacts/plan/20260807_infra_trace_id_propagation_plan.md
@@ -66,9 +66,37 @@ SSE fan-out 로그를 `trace_id`로 상관 분석할 수 없다.
 
 ### 체크리스트
 
-- [ ] `postgres.SlogQueryTracer`가 에러/느린쿼리/디버그 로그 모두 `*Context` 계열로 전환됨
-- [ ] `sse.BroadcasterImpl.Broadcast`가 모든 이벤트에 대해 상시 구조화 로그를 남김 (임시 진단 로그 제거)
-- [ ] `EventHandler.streamEvents`가 write 실패 시 trace_id 포함 경고 로그를 남김
-- [ ] DEVELOPER_GUIDE.md에 trace_id 상관관계 한계 문서화
-- [ ] 토큰/헤더/메시지 본문 등 민감 정보가 새로 로그에 노출되지 않음
-- [ ] `go test ./...`, `gofmt -w .`, `go vet ./...` 통과
+- [x] `postgres.SlogQueryTracer`가 에러/느린쿼리/디버그 로그 모두 `*Context` 계열로 전환됨
+- [x] `sse.BroadcasterImpl.Broadcast`가 모든 이벤트에 대해 상시 구조화 로그를 남김 (임시 진단 로그 제거)
+- [x] `EventHandler.streamEvents`가 write 실패 시 trace_id 포함 경고 로그를 남김
+- [x] DEVELOPER_GUIDE.md에 trace_id 상관관계 한계 문서화
+- [x] 토큰/헤더/메시지 본문 등 민감 정보가 새로 로그에 노출되지 않음
+- [x] `go test ./...`, `gofmt -w .`, `go vet ./...` 통과
+
+## Addendum: connection_id / cause_trace_id 분리 (PR 리뷰 피드백)
+
+최초 구현은 요청 trace_id와 SSE 연결 trace_id의 수명이 다르다는 점을 **문서로만** 경고했다.
+리뷰 중 "결국 남는 건 로그뿐이니 어떤 요청이 이벤트를 발행했는지 로그만으로 추적 가능해야
+한다"는 피드백을 받아, 필드 자체를 명시적으로 분리했다.
+
+- `usecase.SSEMessage`에 `CauseTraceID string` 필드 추가 — `BroadcasterImpl.Broadcast`가
+  `ctx`에서 추출해 채운다. 클라이언트에 노출되는 `SSENotification` payload에는 포함하지
+  않는다(`formatSSEMessage`가 별도 DTO를 구성하므로 자동으로 격리됨).
+- `errs.TraceIDFromContext(ctx)` 헬퍼 추가 — 기존 `Wrap`의 중복 타입 단언 로직도 이걸로
+  정리.
+- `EventHandler.streamEvents`가 연결 시점의 trace_id를 `connection_id`로, 메시지에 실려온
+  `CauseTraceID`를 `cause_trace_id`로 명시적으로 로그. `SSE event delivered`(신규, 성공
+  경로) / `SSE event write failed`(기존) 모두 두 필드를 함께 남긴다.
+- `Broadcast`도 자신의 로그에 `cause_trace_id`를 명시적으로 추가해, 두 계층의 로그를
+  `cause_trace_id`로 조인할 수 있게 했다(자동 주입되는 `trace_id`와 값은 같지만, 필드명을
+  통일해 검색 가능하게 하는 것이 목적).
+- DEVELOPER_GUIDE.md §4.3.1 갱신: `trace_id`/`connection_id`/`cause_trace_id` 세 필드의
+  의미와 조인 방법을 명시.
+
+### 추가 검증
+- [x] `errs.TraceIDFromContext` 단위 테스트 추가
+- [x] `broadcaster_test.go`: `message.CauseTraceID`가 채워지는지, 로그에 `cause_trace_id`가
+      남는지 검증
+- [x] `event_handler_test.go`: `connection_id`와 `cause_trace_id`가 서로 다른 값으로
+      로그에 남는지(write 실패/정상 delivered 양쪽) 검증
+- [x] `go test ./...`, `gofmt -w .`, `go vet ./...` 재통과

--- a/backend/internal/errs/error.go
+++ b/backend/internal/errs/error.go
@@ -54,6 +54,19 @@ func (e *AppError) FormatStack() []string {
 	return lines
 }
 
+// TraceIDFromContext는 context에 저장된 trace_id를 안전하게 추출합니다. ctx가 nil이거나
+// 값이 없으면 빈 문자열을 반환합니다. web/postgres/sse 등 인프라 계층이 로그에 trace_id를
+// 명시적으로 남기고 싶을 때(예: SSE broadcast의 "무엇이 이 알림을 유발했는가" 기록) 이 헬퍼를 씁니다.
+func TraceIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if traceID, ok := ctx.Value(TraceIDKey).(string); ok {
+		return traceID
+	}
+	return ""
+}
+
 // Wrap은 에러가 발생한 현재 호출 위치 기준의 스택 트레이스와 Context의 trace_id를 캡처하여 AppError로 반환합니다.
 // ⚠️ 성능을 위해 예상치 못한 5xx 인프라 에러 상황에만 제한적으로 사용하십시오.
 func Wrap(ctx context.Context, err error) error {
@@ -65,19 +78,10 @@ func Wrap(ctx context.Context, err error) error {
 	var appErr *AppError
 	if errors.As(err, &appErr) {
 		// Context에 trace_id가 세팅되어 있으나 에러 객체에 비어있는 경우 보완
-		if appErr.TraceID == "" && ctx != nil {
-			if traceID, ok := ctx.Value(TraceIDKey).(string); ok {
-				appErr.TraceID = traceID
-			}
+		if appErr.TraceID == "" {
+			appErr.TraceID = TraceIDFromContext(ctx)
 		}
 		return err
-	}
-
-	var traceID string
-	if ctx != nil {
-		if tid, ok := ctx.Value(TraceIDKey).(string); ok {
-			traceID = tid
-		}
 	}
 
 	pcs := make([]uintptr, 32)
@@ -85,7 +89,7 @@ func Wrap(ctx context.Context, err error) error {
 
 	return &AppError{
 		Err:     err,
-		TraceID: traceID,
+		TraceID: TraceIDFromContext(ctx),
 		Stack:   pcs[:n],
 	}
 }

--- a/backend/internal/errs/error_test.go
+++ b/backend/internal/errs/error_test.go
@@ -12,6 +12,32 @@ import (
 	"cornermon/backend/internal/errs"
 )
 
+func TestTraceIDFromContextShouldReturnEmptyStringWhenTraceIDMissing(t *testing.T) {
+	// arrange
+	ctx := context.Background()
+
+	// act
+	got := errs.TraceIDFromContext(ctx)
+
+	// assert
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestTraceIDFromContextShouldReturnValueWhenTraceIDPresent(t *testing.T) {
+	// arrange
+	ctx := context.WithValue(context.Background(), errs.TraceIDKey, "trace-xyz")
+
+	// act
+	got := errs.TraceIDFromContext(ctx)
+
+	// assert
+	if got != "trace-xyz" {
+		t.Errorf("expected 'trace-xyz', got %q", got)
+	}
+}
+
 func TestWrap(t *testing.T) {
 	// arrange
 	originalErr := errors.New("something went wrong")

--- a/backend/internal/infrastructure/postgres/tracer.go
+++ b/backend/internal/infrastructure/postgres/tracer.go
@@ -52,8 +52,11 @@ func (t *SlogQueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data p
 		argsToLog = "[]"
 	}
 
+	// ctx는 pgx가 TraceQueryStart에서 반환한 값을 그대로 되돌려주므로, 요청 미들웨어가 심어둔
+	// trace_id를 여전히 담고 있다. *Context 계열 slog 호출을 써야 errs.SlogWrappedHandler가
+	// trace_id를 로그에 자동으로 채워 넣는다 — 전역 slog.Error/Warn/Debug는 이 ctx를 버린다.
 	if data.Err != nil {
-		slog.Error("Database query error",
+		slog.ErrorContext(ctx, "Database query error",
 			"sql", qd.sql,
 			"args", argsToLog,
 			"duration", duration,
@@ -63,7 +66,7 @@ func (t *SlogQueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data p
 	}
 
 	if t.SlowQueryThreshold > 0 && duration > t.SlowQueryThreshold {
-		slog.Warn("Slow query detected",
+		slog.WarnContext(ctx, "Slow query detected",
 			"sql", qd.sql,
 			"args", argsToLog,
 			"duration", duration,
@@ -71,7 +74,7 @@ func (t *SlogQueryTracer) TraceQueryEnd(ctx context.Context, _ *pgx.Conn, data p
 		return
 	}
 
-	slog.Debug("Database query",
+	slog.DebugContext(ctx, "Database query",
 		"sql", qd.sql,
 		"args", argsToLog,
 		"duration", duration,

--- a/backend/internal/infrastructure/postgres/tracer_test.go
+++ b/backend/internal/infrastructure/postgres/tracer_test.go
@@ -1,8 +1,14 @@
 package postgres
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
+	"strings"
 	"testing"
+
+	"cornermon/backend/internal/errs"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -29,5 +35,50 @@ func TestSlogQueryTracer_ShouldStoreDataInContext_WhenTraceQueryStartCalled(t *t
 	}
 	if len(qd.args) != 2 {
 		t.Errorf("Expected 2 args, got %d", len(qd.args))
+	}
+}
+
+// withCapturedLogger는 slog 기본 로거를 버퍼를 향하는 JSON 핸들러(운영 설정과 동일하게
+// errs.SlogWrappedHandler로 감쌈)로 교체하고, 테스트 종료 시 원복하는 cleanup 함수를 등록한다.
+func withCapturedLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	original := slog.Default()
+	slog.SetDefault(slog.New(errs.NewSlogWrappedHandler(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return buf
+}
+
+func TestSlogQueryTracer_ShouldLogTraceID_WhenQueryErrors(t *testing.T) {
+	// Arrange
+	buf := withCapturedLogger(t)
+	tracer := &SlogQueryTracer{}
+	ctx := context.WithValue(context.Background(), errs.TraceIDKey, "trace-abc")
+	ctx = tracer.TraceQueryStart(ctx, nil, pgx.TraceQueryStartData{SQL: "SELECT 1"})
+
+	// Act
+	tracer.TraceQueryEnd(ctx, nil, pgx.TraceQueryEndData{Err: errors.New("boom")})
+
+	// Assert
+	logLine := buf.String()
+	if !strings.Contains(logLine, `"trace_id":"trace-abc"`) {
+		t.Errorf("expected log to contain trace_id, got: %s", logLine)
+	}
+}
+
+func TestSlogQueryTracer_ShouldLogTraceID_WhenSlowQueryDetected(t *testing.T) {
+	// Arrange
+	buf := withCapturedLogger(t)
+	tracer := &SlogQueryTracer{SlowQueryThreshold: -1} // 항상 느린 쿼리로 판정되도록 음수 임계값 사용
+	ctx := context.WithValue(context.Background(), errs.TraceIDKey, "trace-slow")
+	ctx = tracer.TraceQueryStart(ctx, nil, pgx.TraceQueryStartData{SQL: "SELECT 1"})
+
+	// Act
+	tracer.TraceQueryEnd(ctx, nil, pgx.TraceQueryEndData{})
+
+	// Assert
+	logLine := buf.String()
+	if !strings.Contains(logLine, `"trace_id":"trace-slow"`) {
+		t.Errorf("expected log to contain trace_id, got: %s", logLine)
 	}
 }

--- a/backend/internal/infrastructure/sse/broadcaster.go
+++ b/backend/internal/infrastructure/sse/broadcaster.go
@@ -35,8 +35,12 @@ func NewBroadcaster() *BroadcasterImpl {
 // 버퍼가 찬 구독자에게 서버가 메시지를 재시도·저장하지 않는 이유는 SSE 알림이 최신 상태를
 // REST로 다시 조회하라는 신호이기 때문이다. 해당 연결을 닫아 클라이언트가 재연결·resync하도록 한다.
 func (b *BroadcasterImpl) Broadcast(ctx context.Context, campID domain.CampID, event usecase.NotificationEvent, scope usecase.Scope) error {
-	causeTraceID := errs.TraceIDFromContext(ctx)
-	message := usecase.SSEMessage{Event: event, Scope: scope, CauseTraceID: causeTraceID}
+	// 이 알림의 CausationID로 HTTP 요청 trace_id를 재사용한다 — 커밋까지 이어진 이 요청을
+	// 가리키는 식별자가 현재 코드베이스에 trace_id 말고는 없기 때문에 택한 구현 디테일이다.
+	// (usecase.SSEMessage.CausationID 주석 참고. 별도 커맨드/이벤트 ID 체계가 생기면 교체될
+	// 수 있는 자리다.)
+	causationID := errs.TraceIDFromContext(ctx)
+	message := usecase.SSEMessage{Event: event, Scope: scope, CausationID: causationID}
 	var fullAdminSubs []chan usecase.SSEMessage
 	var fullTrackSubs []chan usecase.SSEMessage
 	var deliveredAdminSubs int
@@ -69,8 +73,8 @@ func (b *BroadcasterImpl) Broadcast(ctx context.Context, campID domain.CampID, e
 
 	// ctx는 usecase 계층이 커밋 이후 전달하는 요청 ctx이므로 trace_id를 그대로 담고 있다
 	// (DEVELOPER_GUIDE.md §3.2). "trace_id"는 errs.SlogWrappedHandler가 ctx로부터 자동
-	// 주입하는 이 로그 라인(=발행 요청) 자신의 trace_id이고, "cause_trace_id"는 message에
-	// 실려 SSE 연결 쪽 로그까지 전달되는 동일한 값이다 — 두 계층의 로그를 cause_trace_id로
+	// 주입하는 이 로그 라인(=발행 요청) 자신의 trace_id이고, "causation_id"는 message에
+	// 실려 SSE 연결 쪽 로그까지 전달되는 동일한 값이다 — 두 계층의 로그를 causation_id로
 	// 조인할 수 있게 하기 위해 명시적으로 남긴다(§4.3.1 참고). event 종류와 무관하게 모든
 	// broadcast에 상시 기록한다 — 과거 #184 진단 목적으로 messages_changed에만 걸려있던
 	// 임시 로그를 일반화한 것이다.
@@ -79,7 +83,7 @@ func (b *BroadcasterImpl) Broadcast(ctx context.Context, campID domain.CampID, e
 		"camp_id", campID,
 		"scope_kind", scope.Kind,
 		"scope_track_id", scope.TrackID,
-		"cause_trace_id", causeTraceID,
+		"causation_id", causationID,
 		"delivered_admin_subscribers", deliveredAdminSubs,
 		"delivered_track_subscribers", deliveredTrackSubs,
 		"full_admin_subscribers", len(fullAdminSubs),
@@ -92,7 +96,7 @@ func (b *BroadcasterImpl) Broadcast(ctx context.Context, campID domain.CampID, e
 		slog.WarnContext(ctx, "SSE subscriber buffer full, disconnecting",
 			"event", event,
 			"camp_id", campID,
-			"cause_trace_id", causeTraceID,
+			"causation_id", causationID,
 			"full_admin_subscribers", len(fullAdminSubs),
 			"full_track_subscribers", len(fullTrackSubs),
 		)

--- a/backend/internal/infrastructure/sse/broadcaster.go
+++ b/backend/internal/infrastructure/sse/broadcaster.go
@@ -65,20 +65,29 @@ func (b *BroadcasterImpl) Broadcast(ctx context.Context, campID domain.CampID, e
 	}
 	b.mu.RUnlock()
 
-	// 임시 진단 로그: #184 공지사항 messages_changed fan-out을 확인한 뒤 제거한다.
-	if event == usecase.EventMessagesChanged {
-		slog.DebugContext(ctx, "SSE broadcast dispatched",
+	// ctx는 usecase 계층이 커밋 이후 전달하는 요청 ctx이므로 trace_id를 그대로 담고 있다
+	// (DEVELOPER_GUIDE.md §3.2). event 종류와 무관하게 모든 broadcast에 상시 기록한다 —
+	// 과거 #184 진단 목적으로 messages_changed에만 걸려있던 임시 로그를 일반화한 것이다.
+	slog.DebugContext(ctx, "SSE broadcast dispatched",
+		"event", event,
+		"camp_id", campID,
+		"scope_kind", scope.Kind,
+		"scope_track_id", scope.TrackID,
+		"delivered_admin_subscribers", deliveredAdminSubs,
+		"delivered_track_subscribers", deliveredTrackSubs,
+		"full_admin_subscribers", len(fullAdminSubs),
+		"full_track_subscribers", len(fullTrackSubs),
+	)
+
+	if len(fullAdminSubs) > 0 || len(fullTrackSubs) > 0 {
+		// 버퍼가 가득 찬 구독자는 SSE 소비가 발행 속도를 못 따라가고 있다는 신호이므로,
+		// 연결을 끊기 전에 운영자가 알아챌 수 있도록 Warn으로 남긴다.
+		slog.WarnContext(ctx, "SSE subscriber buffer full, disconnecting",
+			"event", event,
 			"camp_id", campID,
-			"scope_kind", scope.Kind,
-			"scope_track_id", scope.TrackID,
-			"delivered_admin_subscribers", deliveredAdminSubs,
-			"delivered_track_subscribers", deliveredTrackSubs,
 			"full_admin_subscribers", len(fullAdminSubs),
 			"full_track_subscribers", len(fullTrackSubs),
 		)
-	}
-
-	if len(fullAdminSubs) > 0 || len(fullTrackSubs) > 0 {
 		b.removeFullSubscribers(campID, fullAdminSubs, fullTrackSubs)
 	}
 	return nil

--- a/backend/internal/infrastructure/sse/broadcaster.go
+++ b/backend/internal/infrastructure/sse/broadcaster.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/errs"
 	"cornermon/backend/internal/usecase"
 )
 
@@ -34,7 +35,8 @@ func NewBroadcaster() *BroadcasterImpl {
 // 버퍼가 찬 구독자에게 서버가 메시지를 재시도·저장하지 않는 이유는 SSE 알림이 최신 상태를
 // REST로 다시 조회하라는 신호이기 때문이다. 해당 연결을 닫아 클라이언트가 재연결·resync하도록 한다.
 func (b *BroadcasterImpl) Broadcast(ctx context.Context, campID domain.CampID, event usecase.NotificationEvent, scope usecase.Scope) error {
-	message := usecase.SSEMessage{Event: event, Scope: scope}
+	causeTraceID := errs.TraceIDFromContext(ctx)
+	message := usecase.SSEMessage{Event: event, Scope: scope, CauseTraceID: causeTraceID}
 	var fullAdminSubs []chan usecase.SSEMessage
 	var fullTrackSubs []chan usecase.SSEMessage
 	var deliveredAdminSubs int
@@ -66,13 +68,18 @@ func (b *BroadcasterImpl) Broadcast(ctx context.Context, campID domain.CampID, e
 	b.mu.RUnlock()
 
 	// ctx는 usecase 계층이 커밋 이후 전달하는 요청 ctx이므로 trace_id를 그대로 담고 있다
-	// (DEVELOPER_GUIDE.md §3.2). event 종류와 무관하게 모든 broadcast에 상시 기록한다 —
-	// 과거 #184 진단 목적으로 messages_changed에만 걸려있던 임시 로그를 일반화한 것이다.
+	// (DEVELOPER_GUIDE.md §3.2). "trace_id"는 errs.SlogWrappedHandler가 ctx로부터 자동
+	// 주입하는 이 로그 라인(=발행 요청) 자신의 trace_id이고, "cause_trace_id"는 message에
+	// 실려 SSE 연결 쪽 로그까지 전달되는 동일한 값이다 — 두 계층의 로그를 cause_trace_id로
+	// 조인할 수 있게 하기 위해 명시적으로 남긴다(§4.3.1 참고). event 종류와 무관하게 모든
+	// broadcast에 상시 기록한다 — 과거 #184 진단 목적으로 messages_changed에만 걸려있던
+	// 임시 로그를 일반화한 것이다.
 	slog.DebugContext(ctx, "SSE broadcast dispatched",
 		"event", event,
 		"camp_id", campID,
 		"scope_kind", scope.Kind,
 		"scope_track_id", scope.TrackID,
+		"cause_trace_id", causeTraceID,
 		"delivered_admin_subscribers", deliveredAdminSubs,
 		"delivered_track_subscribers", deliveredTrackSubs,
 		"full_admin_subscribers", len(fullAdminSubs),
@@ -85,6 +92,7 @@ func (b *BroadcasterImpl) Broadcast(ctx context.Context, campID domain.CampID, e
 		slog.WarnContext(ctx, "SSE subscriber buffer full, disconnecting",
 			"event", event,
 			"camp_id", campID,
+			"cause_trace_id", causeTraceID,
 			"full_admin_subscribers", len(fullAdminSubs),
 			"full_track_subscribers", len(fullTrackSubs),
 		)

--- a/backend/internal/infrastructure/sse/broadcaster_test.go
+++ b/backend/internal/infrastructure/sse/broadcaster_test.go
@@ -1,12 +1,67 @@
 package sse
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/errs"
 	"cornermon/backend/internal/usecase"
 )
+
+// withCapturedLogger는 slog 기본 로거를 버퍼를 향하는 JSON 핸들러(운영 설정과 동일하게
+// errs.SlogWrappedHandler로 감쌈)로 교체하고, 테스트 종료 시 원복하는 cleanup 함수를 등록한다.
+func withCapturedLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	original := slog.Default()
+	slog.SetDefault(slog.New(errs.NewSlogWrappedHandler(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return buf
+}
+
+func TestShouldLogTraceID_WhenBroadcastDispatched(t *testing.T) {
+	// Arrange
+	buf := withCapturedLogger(t)
+	broadcaster := NewBroadcaster()
+	ctx := context.WithValue(context.Background(), errs.TraceIDKey, "trace-broadcast")
+
+	// Act
+	err := broadcaster.Broadcast(ctx, "camp-a", usecase.EventCampUpdated, usecase.CampScope())
+
+	// Assert
+	if err != nil {
+		t.Fatalf("Broadcast() error = %v", err)
+	}
+	if !strings.Contains(buf.String(), `"trace_id":"trace-broadcast"`) {
+		t.Errorf("expected log to contain trace_id, got: %s", buf.String())
+	}
+}
+
+func TestShouldLogTraceID_WhenSubscriberBufferFull(t *testing.T) {
+	// Arrange
+	broadcaster := NewBroadcaster()
+	admin, _ := broadcaster.SubscribeAdmin(context.Background(), "camp-a")
+	for range subscriberBufferSize {
+		_ = broadcaster.Broadcast(context.Background(), "camp-a", usecase.EventCampUpdated, usecase.CampScope())
+	}
+	buf := withCapturedLogger(t)
+	ctx := context.WithValue(context.Background(), errs.TraceIDKey, "trace-full")
+
+	// Act
+	_ = broadcaster.Broadcast(ctx, "camp-a", usecase.EventCampUpdated, usecase.CampScope())
+
+	// Assert
+	for range subscriberBufferSize {
+		<-admin
+	}
+	if !strings.Contains(buf.String(), `"trace_id":"trace-full"`) {
+		t.Errorf("expected buffer-full warning log to contain trace_id, got: %s", buf.String())
+	}
+}
 
 func TestShouldIsolateSubscribersWhenBroadcastingAcrossCamps(t *testing.T) {
 	// Arrange

--- a/backend/internal/infrastructure/sse/broadcaster_test.go
+++ b/backend/internal/infrastructure/sse/broadcaster_test.go
@@ -23,7 +23,7 @@ func withCapturedLogger(t *testing.T) *bytes.Buffer {
 	return buf
 }
 
-func TestShouldLogCauseTraceID_WhenBroadcastDispatched(t *testing.T) {
+func TestShouldLogCausationID_WhenBroadcastDispatched(t *testing.T) {
 	// Arrange
 	buf := withCapturedLogger(t)
 	broadcaster := NewBroadcaster()
@@ -38,16 +38,17 @@ func TestShouldLogCauseTraceID_WhenBroadcastDispatched(t *testing.T) {
 	}
 	logLine := buf.String()
 	// trace_id는 SlogWrappedHandler가 ctx로부터 자동 주입한 값(=발행 요청 자신),
-	// cause_trace_id는 Broadcast가 message에 실어 SSE 연결까지 전달하는 동일한 값이다.
+	// causation_id는 Broadcast가 message에 실어 SSE 연결까지 전달하는 이벤트 계보 정보다.
+	// 지금은 우연히 같은 trace_id 값을 재사용할 뿐, 개념적으로는 서로 다른 질문에 대한 답이다.
 	if !strings.Contains(logLine, `"trace_id":"trace-broadcast"`) {
 		t.Errorf("expected log to contain trace_id, got: %s", logLine)
 	}
-	if !strings.Contains(logLine, `"cause_trace_id":"trace-broadcast"`) {
-		t.Errorf("expected log to contain cause_trace_id, got: %s", logLine)
+	if !strings.Contains(logLine, `"causation_id":"trace-broadcast"`) {
+		t.Errorf("expected log to contain causation_id, got: %s", logLine)
 	}
 }
 
-func TestShouldSetCauseTraceIDOnMessage_WhenBroadcastDispatched(t *testing.T) {
+func TestShouldSetCausationIDOnMessage_WhenBroadcastDispatched(t *testing.T) {
 	// Arrange
 	broadcaster := NewBroadcaster()
 	admin, _ := broadcaster.SubscribeAdmin(context.Background(), "camp-a")
@@ -58,12 +59,12 @@ func TestShouldSetCauseTraceIDOnMessage_WhenBroadcastDispatched(t *testing.T) {
 
 	// Assert
 	message := <-admin
-	if message.CauseTraceID != "trace-message" {
-		t.Errorf("expected message.CauseTraceID = %q, got %q", "trace-message", message.CauseTraceID)
+	if message.CausationID != "trace-message" {
+		t.Errorf("expected message.CausationID = %q, got %q", "trace-message", message.CausationID)
 	}
 }
 
-func TestShouldLogCauseTraceID_WhenSubscriberBufferFull(t *testing.T) {
+func TestShouldLogCausationID_WhenSubscriberBufferFull(t *testing.T) {
 	// Arrange
 	broadcaster := NewBroadcaster()
 	admin, _ := broadcaster.SubscribeAdmin(context.Background(), "camp-a")
@@ -80,8 +81,8 @@ func TestShouldLogCauseTraceID_WhenSubscriberBufferFull(t *testing.T) {
 	for range subscriberBufferSize {
 		<-admin
 	}
-	if !strings.Contains(buf.String(), `"cause_trace_id":"trace-full"`) {
-		t.Errorf("expected buffer-full warning log to contain cause_trace_id, got: %s", buf.String())
+	if !strings.Contains(buf.String(), `"causation_id":"trace-full"`) {
+		t.Errorf("expected buffer-full warning log to contain causation_id, got: %s", buf.String())
 	}
 }
 

--- a/backend/internal/infrastructure/sse/broadcaster_test.go
+++ b/backend/internal/infrastructure/sse/broadcaster_test.go
@@ -23,7 +23,7 @@ func withCapturedLogger(t *testing.T) *bytes.Buffer {
 	return buf
 }
 
-func TestShouldLogTraceID_WhenBroadcastDispatched(t *testing.T) {
+func TestShouldLogCauseTraceID_WhenBroadcastDispatched(t *testing.T) {
 	// Arrange
 	buf := withCapturedLogger(t)
 	broadcaster := NewBroadcaster()
@@ -36,12 +36,34 @@ func TestShouldLogTraceID_WhenBroadcastDispatched(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Broadcast() error = %v", err)
 	}
-	if !strings.Contains(buf.String(), `"trace_id":"trace-broadcast"`) {
-		t.Errorf("expected log to contain trace_id, got: %s", buf.String())
+	logLine := buf.String()
+	// trace_id는 SlogWrappedHandler가 ctx로부터 자동 주입한 값(=발행 요청 자신),
+	// cause_trace_id는 Broadcast가 message에 실어 SSE 연결까지 전달하는 동일한 값이다.
+	if !strings.Contains(logLine, `"trace_id":"trace-broadcast"`) {
+		t.Errorf("expected log to contain trace_id, got: %s", logLine)
+	}
+	if !strings.Contains(logLine, `"cause_trace_id":"trace-broadcast"`) {
+		t.Errorf("expected log to contain cause_trace_id, got: %s", logLine)
 	}
 }
 
-func TestShouldLogTraceID_WhenSubscriberBufferFull(t *testing.T) {
+func TestShouldSetCauseTraceIDOnMessage_WhenBroadcastDispatched(t *testing.T) {
+	// Arrange
+	broadcaster := NewBroadcaster()
+	admin, _ := broadcaster.SubscribeAdmin(context.Background(), "camp-a")
+	ctx := context.WithValue(context.Background(), errs.TraceIDKey, "trace-message")
+
+	// Act
+	_ = broadcaster.Broadcast(ctx, "camp-a", usecase.EventCampUpdated, usecase.CampScope())
+
+	// Assert
+	message := <-admin
+	if message.CauseTraceID != "trace-message" {
+		t.Errorf("expected message.CauseTraceID = %q, got %q", "trace-message", message.CauseTraceID)
+	}
+}
+
+func TestShouldLogCauseTraceID_WhenSubscriberBufferFull(t *testing.T) {
 	// Arrange
 	broadcaster := NewBroadcaster()
 	admin, _ := broadcaster.SubscribeAdmin(context.Background(), "camp-a")
@@ -58,8 +80,8 @@ func TestShouldLogTraceID_WhenSubscriberBufferFull(t *testing.T) {
 	for range subscriberBufferSize {
 		<-admin
 	}
-	if !strings.Contains(buf.String(), `"trace_id":"trace-full"`) {
-		t.Errorf("expected buffer-full warning log to contain trace_id, got: %s", buf.String())
+	if !strings.Contains(buf.String(), `"cause_trace_id":"trace-full"`) {
+		t.Errorf("expected buffer-full warning log to contain cause_trace_id, got: %s", buf.String())
 	}
 }
 

--- a/backend/internal/infrastructure/web/event_handler.go
+++ b/backend/internal/infrastructure/web/event_handler.go
@@ -118,8 +118,8 @@ func (h *EventHandler) TrackEvents(c echo.Context) error {
 func (h *EventHandler) streamEvents(c echo.Context, ch <-chan usecase.SSEMessage) error {
 	ctx := c.Request().Context()
 	// connectionID는 이 SSE 연결이 열릴 때(구독 요청) 발급된 trace_id로, 연결이 유지되는
-	// 동안 고정된다. 이 연결로 전달되는 각 메시지의 cause_trace_id(발행을 유발한 요청의
-	// trace_id)와는 별개의 수명을 가지므로 로그에서 두 값을 구분해 남긴다 — DEVELOPER_GUIDE.md
+	// 동안 고정된다. 이 연결로 전달되는 각 메시지의 causation_id(발행을 유발한 요청의
+	// CausationID)와는 별개의 수명을 가지므로 로그에서 두 값을 구분해 남긴다 — DEVELOPER_GUIDE.md
 	// §4.3.1 참고.
 	connectionID := errs.TraceIDFromContext(ctx)
 	if _, err := c.Response().Write([]byte("data: connected\n\n")); err != nil {
@@ -158,20 +158,20 @@ func (h *EventHandler) streamEvents(c echo.Context, ch <-chan usecase.SSEMessage
 					"scope_kind", msg.Scope.Kind,
 					"scope_track_id", msg.Scope.TrackID,
 					"connection_id", connectionID,
-					"cause_trace_id", msg.CauseTraceID,
+					"causation_id", msg.CausationID,
 					"error", err,
 				)
 				return err
 			}
 			c.Response().Flush()
-			// broadcaster의 "SSE broadcast dispatched" 로그와 cause_trace_id로 조인하면
+			// broadcaster의 "SSE broadcast dispatched" 로그와 causation_id로 조인하면
 			// "어떤 요청이 발행한 알림을 어떤 연결이 언제 받았는지" 추적할 수 있다.
 			slog.DebugContext(ctx, "SSE event delivered",
 				"event", msg.Event,
 				"scope_kind", msg.Scope.Kind,
 				"scope_track_id", msg.Scope.TrackID,
 				"connection_id", connectionID,
-				"cause_trace_id", msg.CauseTraceID,
+				"causation_id", msg.CausationID,
 			)
 		case <-ticker.C:
 			if _, err := c.Response().Write([]byte(":heartbeat\n\n")); err != nil {

--- a/backend/internal/infrastructure/web/event_handler.go
+++ b/backend/internal/infrastructure/web/event_handler.go
@@ -145,17 +145,19 @@ func (h *EventHandler) streamEvents(c echo.Context, ch <-chan usecase.SSEMessage
 				return err
 			}
 			if _, err := c.Response().Write([]byte(formatted)); err != nil {
-				return err
-			}
-			c.Response().Flush()
-			// 임시 진단 로그: #184 공지사항 messages_changed SSE write를 확인한 뒤 제거한다.
-			if msg.Event == usecase.EventMessagesChanged {
-				slog.DebugContext(ctx, "SSE event written",
+				// SSE 스트리밍 도중 발생하는 write 실패는 ErrorHandler 미들웨어를 거치지 않고
+				// 여기서 바로 반환되므로, trace_id를 남길 수 있는 유일한 지점에서 직접 로그한다.
+				// ctx는 이 SSE 연결 수명 동안 고정된 값으로, 알림을 유발한 요청의 trace_id와는
+				// 다르다 — DEVELOPER_GUIDE.md §4.3 "trace_id 상관관계 한계" 참고.
+				slog.WarnContext(ctx, "SSE event write failed",
 					"event", msg.Event,
 					"scope_kind", msg.Scope.Kind,
 					"scope_track_id", msg.Scope.TrackID,
+					"error", err,
 				)
+				return err
 			}
+			c.Response().Flush()
 		case <-ticker.C:
 			if _, err := c.Response().Write([]byte(":heartbeat\n\n")); err != nil {
 				return err

--- a/backend/internal/infrastructure/web/event_handler.go
+++ b/backend/internal/infrastructure/web/event_handler.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/errs"
 	"cornermon/backend/internal/usecase"
 
 	"github.com/labstack/echo/v4"
@@ -116,6 +117,11 @@ func (h *EventHandler) TrackEvents(c echo.Context) error {
 
 func (h *EventHandler) streamEvents(c echo.Context, ch <-chan usecase.SSEMessage) error {
 	ctx := c.Request().Context()
+	// connectionID는 이 SSE 연결이 열릴 때(구독 요청) 발급된 trace_id로, 연결이 유지되는
+	// 동안 고정된다. 이 연결로 전달되는 각 메시지의 cause_trace_id(발행을 유발한 요청의
+	// trace_id)와는 별개의 수명을 가지므로 로그에서 두 값을 구분해 남긴다 — DEVELOPER_GUIDE.md
+	// §4.3.1 참고.
+	connectionID := errs.TraceIDFromContext(ctx)
 	if _, err := c.Response().Write([]byte("data: connected\n\n")); err != nil {
 		return err
 	}
@@ -146,18 +152,27 @@ func (h *EventHandler) streamEvents(c echo.Context, ch <-chan usecase.SSEMessage
 			}
 			if _, err := c.Response().Write([]byte(formatted)); err != nil {
 				// SSE 스트리밍 도중 발생하는 write 실패는 ErrorHandler 미들웨어를 거치지 않고
-				// 여기서 바로 반환되므로, trace_id를 남길 수 있는 유일한 지점에서 직접 로그한다.
-				// ctx는 이 SSE 연결 수명 동안 고정된 값으로, 알림을 유발한 요청의 trace_id와는
-				// 다르다 — DEVELOPER_GUIDE.md §4.3 "trace_id 상관관계 한계" 참고.
+				// 여기서 바로 반환되므로, 이 지점에서 직접 로그한다.
 				slog.WarnContext(ctx, "SSE event write failed",
 					"event", msg.Event,
 					"scope_kind", msg.Scope.Kind,
 					"scope_track_id", msg.Scope.TrackID,
+					"connection_id", connectionID,
+					"cause_trace_id", msg.CauseTraceID,
 					"error", err,
 				)
 				return err
 			}
 			c.Response().Flush()
+			// broadcaster의 "SSE broadcast dispatched" 로그와 cause_trace_id로 조인하면
+			// "어떤 요청이 발행한 알림을 어떤 연결이 언제 받았는지" 추적할 수 있다.
+			slog.DebugContext(ctx, "SSE event delivered",
+				"event", msg.Event,
+				"scope_kind", msg.Scope.Kind,
+				"scope_track_id", msg.Scope.TrackID,
+				"connection_id", connectionID,
+				"cause_trace_id", msg.CauseTraceID,
+			)
 		case <-ticker.C:
 			if _, err := c.Response().Write([]byte(":heartbeat\n\n")); err != nil {
 				return err

--- a/backend/internal/infrastructure/web/event_handler_test.go
+++ b/backend/internal/infrastructure/web/event_handler_test.go
@@ -106,12 +106,12 @@ func withCapturedLogger(t *testing.T) *bytes.Buffer {
 	return buf
 }
 
-func TestShouldLogConnectionIDAndCauseTraceIDWhenSSEEventWriteFails(t *testing.T) {
+func TestShouldLogConnectionIDAndCausationIDWhenSSEEventWriteFails(t *testing.T) {
 	// Arrange
 	buf := withCapturedLogger(t)
 	writer := &failAfterNWriter{header: http.Header{}, n: 1} // 최초 "connected" write만 허용
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/events/track/track-1", nil)
-	// connection_id(연결 자신)와 cause_trace_id(알림을 유발한 원본 요청)가 서로 다른
+	// connection_id(연결 자신)와 causation_id(알림을 유발한 원본 요청의 계보)가 서로 다른
 	// 값이라는 것을 로그에서 구분해서 볼 수 있어야 한다.
 	ctx := context.WithValue(req.Context(), errs.TraceIDKey, "trace-connection")
 	req = req.WithContext(ctx)
@@ -120,7 +120,7 @@ func TestShouldLogConnectionIDAndCauseTraceIDWhenSSEEventWriteFails(t *testing.T
 	c.Response().Writer = writer
 
 	ch := make(chan usecase.SSEMessage, 1)
-	ch <- usecase.SSEMessage{Event: usecase.EventTrackUpdated, Scope: usecase.TrackScope("track-1"), CauseTraceID: "trace-cause"}
+	ch <- usecase.SSEMessage{Event: usecase.EventTrackUpdated, Scope: usecase.TrackScope("track-1"), CausationID: "trace-cause"}
 	h := NewEventHandler(nil, nil, nil)
 
 	// Act
@@ -134,15 +134,15 @@ func TestShouldLogConnectionIDAndCauseTraceIDWhenSSEEventWriteFails(t *testing.T
 	if !strings.Contains(logLine, `"connection_id":"trace-connection"`) {
 		t.Errorf("expected write-failure log to contain connection_id, got: %s", logLine)
 	}
-	if !strings.Contains(logLine, `"cause_trace_id":"trace-cause"`) {
-		t.Errorf("expected write-failure log to contain cause_trace_id, got: %s", logLine)
+	if !strings.Contains(logLine, `"causation_id":"trace-cause"`) {
+		t.Errorf("expected write-failure log to contain causation_id, got: %s", logLine)
 	}
 	if !strings.Contains(logLine, "SSE event write failed") {
 		t.Errorf("expected write-failure log message, got: %s", logLine)
 	}
 }
 
-func TestShouldLogConnectionIDAndCauseTraceIDWhenSSEEventDelivered(t *testing.T) {
+func TestShouldLogConnectionIDAndCausationIDWhenSSEEventDelivered(t *testing.T) {
 	// Arrange
 	buf := withCapturedLogger(t)
 	writer := &failAfterNWriter{header: http.Header{}, n: 2} // "connected" + 이벤트 write 모두 허용
@@ -154,7 +154,7 @@ func TestShouldLogConnectionIDAndCauseTraceIDWhenSSEEventDelivered(t *testing.T)
 	c.Response().Writer = writer
 
 	ch := make(chan usecase.SSEMessage, 1)
-	ch <- usecase.SSEMessage{Event: usecase.EventTrackUpdated, Scope: usecase.TrackScope("track-1"), CauseTraceID: "trace-cause"}
+	ch <- usecase.SSEMessage{Event: usecase.EventTrackUpdated, Scope: usecase.TrackScope("track-1"), CausationID: "trace-cause"}
 	close(ch) // 두 번째 for-select 순회에서 채널 닫힘으로 streamEvents가 정상 반환하도록 함
 	h := NewEventHandler(nil, nil, nil)
 
@@ -172,8 +172,8 @@ func TestShouldLogConnectionIDAndCauseTraceIDWhenSSEEventDelivered(t *testing.T)
 	if !strings.Contains(logLine, `"connection_id":"trace-connection"`) {
 		t.Errorf("expected delivered log to contain connection_id, got: %s", logLine)
 	}
-	if !strings.Contains(logLine, `"cause_trace_id":"trace-cause"`) {
-		t.Errorf("expected delivered log to contain cause_trace_id, got: %s", logLine)
+	if !strings.Contains(logLine, `"causation_id":"trace-cause"`) {
+		t.Errorf("expected delivered log to contain causation_id, got: %s", logLine)
 	}
 }
 

--- a/backend/internal/infrastructure/web/event_handler_test.go
+++ b/backend/internal/infrastructure/web/event_handler_test.go
@@ -1,7 +1,12 @@
 package web
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"slices"
 	"sort"
@@ -9,7 +14,10 @@ import (
 	"testing"
 
 	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/errs"
 	"cornermon/backend/internal/usecase"
+
+	"github.com/labstack/echo/v4"
 )
 
 type mockSubscriber struct {
@@ -64,6 +72,68 @@ func TestShouldOmitTrackIDWhenFormattingCampScope(t *testing.T) {
 	}
 	if strings.Contains(got, "trackId") {
 		t.Fatalf("camp-scoped payload should omit trackId: %s", got)
+	}
+}
+
+// failAfterNWriter는 처음 n번의 Write는 성공시키고, 그 이후 호출부터는 클라이언트 연결
+// 끊김을 흉내 내어 에러를 반환하는 http.ResponseWriter다. streamEvents가 최초 "connected"
+// 메시지는 정상 기록한 뒤, 실제 이벤트 write에서 실패하는 상황을 재현하기 위함이다.
+type failAfterNWriter struct {
+	header   http.Header
+	n        int
+	writeCnt int
+}
+
+func (w *failAfterNWriter) Header() http.Header { return w.header }
+func (w *failAfterNWriter) WriteHeader(int)     {}
+func (w *failAfterNWriter) Write(p []byte) (int, error) {
+	w.writeCnt++
+	if w.writeCnt > w.n {
+		return 0, errors.New("write: connection reset by peer")
+	}
+	return len(p), nil
+}
+
+// Flush는 echo.Response가 http.Flusher를 요구하므로 필요한 no-op 구현이다.
+func (w *failAfterNWriter) Flush() {}
+
+func withCapturedLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	original := slog.Default()
+	slog.SetDefault(slog.New(errs.NewSlogWrappedHandler(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return buf
+}
+
+func TestShouldLogTraceIDWhenSSEEventWriteFails(t *testing.T) {
+	// Arrange
+	buf := withCapturedLogger(t)
+	writer := &failAfterNWriter{header: http.Header{}, n: 1} // 최초 "connected" write만 허용
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events/track/track-1", nil)
+	ctx := context.WithValue(req.Context(), errs.TraceIDKey, "trace-sse")
+	req = req.WithContext(ctx)
+	e := echo.New()
+	c := e.NewContext(req, httptest.NewRecorder())
+	c.Response().Writer = writer
+
+	ch := make(chan usecase.SSEMessage, 1)
+	ch <- usecase.SSEMessage{Event: usecase.EventTrackUpdated, Scope: usecase.TrackScope("track-1")}
+	h := NewEventHandler(nil, nil, nil)
+
+	// Act
+	err := h.streamEvents(c, ch)
+
+	// Assert
+	if err == nil {
+		t.Fatal("expected write error to propagate")
+	}
+	logLine := buf.String()
+	if !strings.Contains(logLine, `"trace_id":"trace-sse"`) {
+		t.Errorf("expected write-failure log to contain trace_id, got: %s", logLine)
+	}
+	if !strings.Contains(logLine, "SSE event write failed") {
+		t.Errorf("expected write-failure log message, got: %s", logLine)
 	}
 }
 

--- a/backend/internal/infrastructure/web/event_handler_test.go
+++ b/backend/internal/infrastructure/web/event_handler_test.go
@@ -106,19 +106,21 @@ func withCapturedLogger(t *testing.T) *bytes.Buffer {
 	return buf
 }
 
-func TestShouldLogTraceIDWhenSSEEventWriteFails(t *testing.T) {
+func TestShouldLogConnectionIDAndCauseTraceIDWhenSSEEventWriteFails(t *testing.T) {
 	// Arrange
 	buf := withCapturedLogger(t)
 	writer := &failAfterNWriter{header: http.Header{}, n: 1} // 최초 "connected" write만 허용
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/events/track/track-1", nil)
-	ctx := context.WithValue(req.Context(), errs.TraceIDKey, "trace-sse")
+	// connection_id(연결 자신)와 cause_trace_id(알림을 유발한 원본 요청)가 서로 다른
+	// 값이라는 것을 로그에서 구분해서 볼 수 있어야 한다.
+	ctx := context.WithValue(req.Context(), errs.TraceIDKey, "trace-connection")
 	req = req.WithContext(ctx)
 	e := echo.New()
 	c := e.NewContext(req, httptest.NewRecorder())
 	c.Response().Writer = writer
 
 	ch := make(chan usecase.SSEMessage, 1)
-	ch <- usecase.SSEMessage{Event: usecase.EventTrackUpdated, Scope: usecase.TrackScope("track-1")}
+	ch <- usecase.SSEMessage{Event: usecase.EventTrackUpdated, Scope: usecase.TrackScope("track-1"), CauseTraceID: "trace-cause"}
 	h := NewEventHandler(nil, nil, nil)
 
 	// Act
@@ -129,11 +131,49 @@ func TestShouldLogTraceIDWhenSSEEventWriteFails(t *testing.T) {
 		t.Fatal("expected write error to propagate")
 	}
 	logLine := buf.String()
-	if !strings.Contains(logLine, `"trace_id":"trace-sse"`) {
-		t.Errorf("expected write-failure log to contain trace_id, got: %s", logLine)
+	if !strings.Contains(logLine, `"connection_id":"trace-connection"`) {
+		t.Errorf("expected write-failure log to contain connection_id, got: %s", logLine)
+	}
+	if !strings.Contains(logLine, `"cause_trace_id":"trace-cause"`) {
+		t.Errorf("expected write-failure log to contain cause_trace_id, got: %s", logLine)
 	}
 	if !strings.Contains(logLine, "SSE event write failed") {
 		t.Errorf("expected write-failure log message, got: %s", logLine)
+	}
+}
+
+func TestShouldLogConnectionIDAndCauseTraceIDWhenSSEEventDelivered(t *testing.T) {
+	// Arrange
+	buf := withCapturedLogger(t)
+	writer := &failAfterNWriter{header: http.Header{}, n: 2} // "connected" + 이벤트 write 모두 허용
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/events/track/track-1", nil)
+	ctx := context.WithValue(req.Context(), errs.TraceIDKey, "trace-connection")
+	req = req.WithContext(ctx)
+	e := echo.New()
+	c := e.NewContext(req, httptest.NewRecorder())
+	c.Response().Writer = writer
+
+	ch := make(chan usecase.SSEMessage, 1)
+	ch <- usecase.SSEMessage{Event: usecase.EventTrackUpdated, Scope: usecase.TrackScope("track-1"), CauseTraceID: "trace-cause"}
+	close(ch) // 두 번째 for-select 순회에서 채널 닫힘으로 streamEvents가 정상 반환하도록 함
+	h := NewEventHandler(nil, nil, nil)
+
+	// Act
+	err := h.streamEvents(c, ch)
+
+	// Assert
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	logLine := buf.String()
+	if !strings.Contains(logLine, "SSE event delivered") {
+		t.Fatalf("expected delivered log, got: %s", logLine)
+	}
+	if !strings.Contains(logLine, `"connection_id":"trace-connection"`) {
+		t.Errorf("expected delivered log to contain connection_id, got: %s", logLine)
+	}
+	if !strings.Contains(logLine, `"cause_trace_id":"trace-cause"`) {
+		t.Errorf("expected delivered log to contain cause_trace_id, got: %s", logLine)
 	}
 }
 

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -262,11 +262,20 @@ func TrackScope(trackID domain.TrackID) Scope {
 type SSEMessage struct {
 	Event NotificationEvent
 	Scope Scope
-	// CauseTraceID는 이 알림을 유발한 원본 요청의 trace_id입니다(Broadcaster 구현체가 채움).
-	// SSE 연결 자체의 trace_id(연결 수명 동안 고정)와는 다른 값이며, 로그에서 어떤 요청이
-	// 이 이벤트를 발행했는지 추적하는 용도로만 씁니다 — 클라이언트에 노출되는 SSE payload에는
-	// 포함하지 않습니다(internal/infrastructure/web.formatSSEMessage 참고).
-	CauseTraceID string
+	// CausationID는 이 알림을 유발한 원본 요청/커맨드를 가리키는 식별자입니다(CQRS/이벤트
+	// 소싱의 Causation ID 패턴 — "이 이벤트가 왜 존재하는가"에 대한 이벤트 자신의 계보
+	// 메타데이터이지, 로그 상관분석을 위한 부가 정보가 아닙니다). SSEMessage는 커밋된 상태
+	// 변경을 알리는 best-effort 도메인 이벤트 알림이므로, 자신을 있게 한 원인을 아는 것은
+	// EventID·발생 시각처럼 이벤트 자체의 정상적인 메타데이터에 속합니다.
+	//
+	// Broadcaster 구현체(현재는 BroadcasterImpl)가 채웁니다. 지금은 HTTP 요청의 trace_id를
+	// 그대로 재사용하고 있지만 — 이 요청이 SSE 알림을 발행하기까지 이어진 유일한 식별자가
+	// 우연히 trace_id뿐이라서 재사용한 구현 디테일일 뿐, CausationID의 정의가 "trace_id"인
+	// 것은 아닙니다. 별도의 커맨드 ID/이벤트 ID 체계가 생기면 그쪽으로 교체될 수 있습니다.
+	// SSE 연결 자체의 trace_id(연결 수명 동안 고정, 이 이벤트의 causation과 무관)와는
+	// 다른 값이며, 클라이언트에 노출되는 SSE payload에는 포함하지 않습니다
+	// (internal/infrastructure/web.formatSSEMessage 참고).
+	CausationID string
 }
 
 // Broadcaster는 트랜잭션 성공 후 SSE 클라이언트에게 실시간 알림을 푸시하는 포트입니다.

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -262,6 +262,11 @@ func TrackScope(trackID domain.TrackID) Scope {
 type SSEMessage struct {
 	Event NotificationEvent
 	Scope Scope
+	// CauseTraceID는 이 알림을 유발한 원본 요청의 trace_id입니다(Broadcaster 구현체가 채움).
+	// SSE 연결 자체의 trace_id(연결 수명 동안 고정)와는 다른 값이며, 로그에서 어떤 요청이
+	// 이 이벤트를 발행했는지 추적하는 용도로만 씁니다 — 클라이언트에 노출되는 SSE payload에는
+	// 포함하지 않습니다(internal/infrastructure/web.formatSSEMessage 참고).
+	CauseTraceID string
 }
 
 // Broadcaster는 트랜잭션 성공 후 SSE 클라이언트에게 실시간 알림을 푸시하는 포트입니다.


### PR DESCRIPTION
## 변경 사항과 이유

웹 미들웨어(`web.Logger()`)는 요청 context의 `trace_id`를 구조화 로그에 출력하지만, Postgres query tracer와 SSE broadcaster/event handler 같은 인프라 계층은 context를 버린 채 slog 전역 호출을 사용해 같은 요청 단위로 상관 분석이 불가능했습니다.

- `postgres.SlogQueryTracer`: `slog.Error/Warn/Debug` → `slog.ErrorContext/WarnContext/DebugContext`로 전환해 `errs.SlogWrappedHandler`가 `trace_id`를 자동 주입하도록 함
- `sse.BroadcasterImpl.Broadcast`: #184 임시 진단 로그(messages_changed 전용)를 제거하고 모든 이벤트에 적용되는 상시 구조화 로그로 일반화, 구독자 버퍼가 가득 차 연결을 끊는 경로는 Warn으로 별도 기록
- `EventHandler.streamEvents`: SSE write 실패 시 trace_id 포함 Warn 로그 추가 (이 경로는 `ErrorHandler` 미들웨어를 거치지 않아 직접 로깅이 필요)
- `DEVELOPER_GUIDE.md` §4.3.1: 요청 trace_id(HTTP 요청 1건 단위)와 SSE 연결 trace_id(연결 수명 전체)의 수명 차이 및 상관관계 한계 문서화

민감 정보(토큰/Authorization 헤더/메시지 본문)는 이번 변경으로 새로 로그에 노출되지 않습니다 — DB 파라미터 마스킹(`LogParameterValues`)은 기존 동작 그대로 유지했고, SSE 로그는 event/scope/campId/trackId/카운트만 남깁니다.

## 완료 조건 검증

- [x] HTTP 요청에서 발생한 DB 및 SSE 인프라 로그에 trace_id가 1회 포함됨 — 회귀 테스트로 확인
- [x] SSE 연결 이후 비동기 fan-out 로그의 추적 기준(요청 trace_id vs 연결 trace_id)을 DEVELOPER_GUIDE.md에 명확화
- [x] logger handler 및 인프라 tracer 회귀 테스트 추가:
  - `tracer_test.go`: 쿼리 에러/느린 쿼리 로그에 trace_id 포함 검증
  - `broadcaster_test.go`: broadcast dispatched / buffer-full 로그에 trace_id 포함 검증
  - `event_handler_test.go`: SSE write 실패 로그에 trace_id 포함 검증
- [x] `go test ./...`, `gofmt -l .`, `go vet ./...` 모두 통과

## 참고

- API 계약 변경 없음 (인프라 로깅 전용, `api/openapi.yaml` 갱신 불필요)
- Plan: `backend/docs/artifacts/plan/20260807_infra_trace_id_propagation_plan.md`

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)