### PR TITLE
feat: 리포트 트랙별 통계/병목 랭킹/규칙변경·트랙운영 카운트 구현 (#172 Phase 1)

### DIFF
--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -380,3 +380,8 @@ SELECT * FROM facilitator_sessions WHERE id = $1;
 
 -- name: ListVisitsByGroup :many
 SELECT * FROM visits WHERE group_id = $1 ORDER BY started_at ASC;
+
+-- name: ListAuditLogsByCamp :many
+-- 캠프 결과 리포트(사후 배치 집계) 전용 — AuditLogQuerier.List(관리자 UI 페이지네이션)와 달리
+-- 커서/limit 없이 캠프 범위 전체를 반환한다.
+SELECT * FROM audit_logs WHERE camp_id = $1;

--- a/backend/docs/artifacts/plan/20260807_리포트_통계_미구현_필드_plan_/00_개요.md
+++ b/backend/docs/artifacts/plan/20260807_리포트_통계_미구현_필드_plan_/00_개요.md
@@ -1,0 +1,35 @@
+# 개요 — Issue #172: 리포트 응답 구조체 미구현 필드 채우기
+
+## 배경
+
+`ReportHandler`의 `CampReportResponse`/`CampSummaryStatsResponse`에 필드는 선언되어 있지만
+실제 계산 로직이 없어 항상 빈 값/0으로 내려가는 필드들을 채운다. 대상 필드와 정의는
+`docs/domain/analytics-model.md` §1.1/§1.3/§1.5/§1.6 참고.
+
+작업 대상: `backend/` only (workflow/implement.md §작업 범위 준수).
+워크트리: `cornermon-issue-172` / 브랜치 `issue-172-report-stats` (main에서 분기).
+
+## 사용자 결정 사항 (진행 전 확인 완료)
+
+1. **`ExceptionApprovalCount`**: 관련 기능(중복 방문 예외 승인)이 이미 전방위로 삭제되어 집계할
+   원장 데이터가 없다. **항상 0을 반환**하고, "기능 삭제로 인해 집계 불가"라는 취지의 주석을
+   남긴다. 필드 자체의 API 제거는 이번 이슈 범위 밖(별도 이슈).
+2. **`OperationalStats`(§1.6)**: 현재 완전히 빈 struct라 필드 설계 자체가 없는 상태. 이번
+   이슈에서 §1.6 전체 지표를 설계+구현하되, PR 크기 제한(LOC 500) 때문에 여러 PR로 나눈다.
+
+## Phase(=PR) 분할
+
+| Phase | 내용 | 파일 |
+|---|---|---|
+| **Phase 1** | `TrackStats`, `BottleneckRanking`, `RuleOverrideCount`, `TrackOperationCount`, `ExceptionApprovalCount`(상수 0) | `01_trackstats_bottleneck_plan.md` |
+| **Phase 2** | `Timeline` (시계열: 진행중 방문 수, 누적 완료 방문 수) | `02_timeline_plan.md` |
+| **Phase 3** | `OperationalStats` (PIN 성공/실패, 기기등록 건수, 관리자별 조작 횟수, 트랙별 DM 발신 횟수, 공지 읽음 도달률) | `03_operational_stats_plan.md` |
+
+각 Phase는 독립적으로 머지 가능하도록 구성한다 (기존 필드를 건드리지 않고 빈 필드만 채움).
+
+## 공통 검증
+
+- `cd backend && go test ./... && gofmt -l . && go vet ./...` — 각 Phase 커밋 전 실행.
+- `docker-check`/`docker-build`는 프론트엔드 전용 규칙(memory: flutter test isolation)이라
+  본 이슈(백엔드)에는 해당 없음 — `go test`는 로컬 실행 가능.
+- swag 주석이 붙은 응답 구조체 필드를 바꾸면 `make swag`로 `api/swagger.yaml` 재생성.

--- a/backend/docs/artifacts/plan/20260807_리포트_통계_미구현_필드_plan_/01_trackstats_bottleneck_plan.md
+++ b/backend/docs/artifacts/plan/20260807_리포트_통계_미구현_필드_plan_/01_trackstats_bottleneck_plan.md
@@ -1,0 +1,123 @@
+# Phase 1: TrackStats / BottleneckRanking / 요약 카운트
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| P0 | UC-1: 트랙별 통계 | 트랙별 처리 완료 방문 수·평균편차·수동처리비율 | 캠프 결과 리포트(사후 조회 API 응답) |
+| P0 | UC-2: 코너별 병목 랭킹 | 전체 코너를 평균편차 내림차순, 컷오프 없이 나열 | 캠프 결과 리포트 요약 |
+| P1 | UC-3: 규칙변경/트랙운영 총 횟수 | 감사 로그 기반 집계 | 캠프 결과 리포트 요약 |
+
+`ExceptionApprovalCount`는 원장 데이터가 없으므로 상수 0 반환(UC 아님, 단순 값 고정).
+
+## 데이터 원장
+
+- 트랙 목록(삭제 포함): `db.ListTracksByCamp` (기존 쿼리, `deleted_at` 무관하게 코너의 camp_id로 필터) — 이미 존재.
+- 방문: `report_querier.go`에서 이미 로드하는 `dbVisits` (`ListVisitsByCamp`, `TrackID` 필드 보유) 재사용 — 신규 쿼리 불필요.
+- 감사 로그: 캠프 범위 전체 조회가 필요한데 기존 `AuditLogQuerier.List`는 관리자 UI 페이지네이션 전용(cursor 기반)이라 재사용하지 않는다. `report_querier.go`는 이미 `db.Queries`를 직접 써서 벌크 집계를 하는 패턴(`ListVisitsByCamp`)이므로 동일하게 신규 sqlc 쿼리를 추가한다:
+
+```sql
+-- name: ListAuditLogsByCamp :many
+SELECT * FROM audit_logs WHERE camp_id = $1;
+```
+
+## 객체 설계
+
+### usecase 계층 (`internal/usecase/port.go`)
+
+```go
+// CampReport (기존 struct에 필드 추가)
+type CampReport struct {
+    // ...기존 필드 유지...
+    TrackReports         []TrackReport
+    RuleOverrideCount    int // ActionCornerUpdate 감사 로그 수
+    TrackOperationCount  int // ActionTrackCreate+Delete+Replace 감사 로그 수
+}
+
+// TrackReport는 트랙별 분석 집계 DTO입니다.
+type TrackReport struct {
+    TrackID        domain.TrackID
+    TrackNo        int
+    CompletedCount int     // 이 트랙에서 COMPLETED된 방문 수
+    ManualCount    int     // 그중 input_method=MANUAL
+    AvgDeviationSec float64 // COMPLETED 방문들의 (실제 - 목표) 평균, 표본 0이면 0
+}
+```
+
+책임: `ReportQuerier.QueryCampReport`가 채운다. Ratio 계산(`ManualCount/CompletedCount`)은 기존
+관례(handler의 `mapSummary`가 raw count로부터 rate 계산)를 따라 **handler 계층에서** 수행 —
+usecase는 raw count만 들고 있는다(`AvgDeviationSec`은 예외적으로 이미 나눗셈 값을 들고 있는
+`CornerReport.AvgDeviationSec` 관례를 그대로 따름).
+
+### infrastructure/postgres (`report_querier.go`)
+
+```go
+// 책임: 캠프 통계 계산에 필요한 원장 데이터 로드 + calculateCampReport 위임
+func (r *pgReportQuerier) QueryCampReport(...) {
+    // ...기존 dbCamp/dbGroups/dbCorners/dbVisits 로드에 이어서
+    dbTracks, err := q.ListTracksByCamp(ctx, string(campID))
+    dbAuditLogs, err := q.ListAuditLogsByCamp(ctx, string(campID))
+    return calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, dbTracks, dbAuditLogs, r.nowFn())
+}
+```
+
+`calculateCampReport`에 트랙/감사로그 집계 블록 추가(의사코드):
+
+```go
+// 트랙별 집계: dbVisits를 TrackID로 그룹핑 (이미 CornerID로 그룹핑하는 것과 동일 패턴)
+trackVisits := map[string][]db.ListVisitsByCampRow{}
+for _, v := range dbVisits {
+    if v.Status == "COMPLETED" {
+        trackVisits[v.TrackID] = append(trackVisits[v.TrackID], v)
+    }
+}
+for _, t := range dbTracks {
+    // completedCount, manualCount, avgDeviation 계산 (기존 corner 집계 루프와 동일 로직 재사용)
+}
+
+// 감사 로그 집계: action 문자열 비교로 카운트
+for _, log := range dbAuditLogs {
+    switch log.Action {
+    case string(usecase.ActionCornerUpdate):
+        ruleOverrideCount++
+    case string(usecase.ActionTrackCreate), string(usecase.ActionTrackDelete), string(usecase.ActionTrackReplace):
+        trackOperationCount++
+    }
+}
+```
+
+> 왜 `success` 필터를 안 거나? — 규칙변경/트랙운영은 "몇 번 시도했는가"가 아니라 실제로 반영된
+> 횟수를 보는 지표(analytics-model.md §1.1)이므로 `success=true`인 로그만 카운트한다. 코드에
+> `log.Success` 체크를 추가한다.
+
+### web 계층 (`report_handler.go`)
+
+```go
+// mapReport에 TrackStats 매핑 추가
+for _, tr := range r.TrackReports {
+    manualRatio := float32(0)
+    avgDeviation := float32(tr.AvgDeviationSec)
+    if tr.CompletedCount > 0 {
+        manualRatio = float32(tr.ManualCount) / float32(tr.CompletedCount) * 100
+    }
+    res.TrackStats = append(res.TrackStats, TrackStatsResponse{
+        TrackID: string(tr.TrackID), TrackNo: tr.TrackNo,
+        HandledVisitCount: tr.CompletedCount,
+        AvgDeviationSeconds: int(avgDeviation),
+        ManualVisitRatio: manualRatio,
+    })
+}
+
+// mapSummary에 BottleneckRanking 추가: CornerReports를 복사해 AvgDeviationSec 내림차순 정렬
+// (컷오프 없음 — CompletedCount==0인 코너도 포함, AvgDeviationSec=0으로 표시)
+// mapSummary에 RuleOverrideCount/TrackOperationCount 그대로 대입
+// ExceptionApprovalCount: 0 // 기능 삭제됨(#171 이전) — 집계 대상 원장 없음. 별도 이슈에서 필드 제거 검토.
+```
+
+## 검증 체크리스트
+
+- [ ] `domain` 패키지 변경 없음(순수 조회 집계라 도메인 불변식 영향 없음)
+- [ ] `go test ./internal/infrastructure/postgres/... ./internal/usecase/... ./internal/infrastructure/web/...` 통과
+- [ ] `report_querier_test.go`에 트랙 2개(방문 0건/N건 혼합), 감사 로그(성공/실패 혼합, 관련 없는 action 포함) 픽스처 추가해 카운트 정확성 검증
+- [ ] `report_handler_test.go`에 BottleneckRanking 정렬 순서, ManualVisitRatio 백분율 계산 검증 추가
+- [ ] `make swag` 재실행 후 `api/swagger.yaml` diff에 `TrackStatsResponse`/`BottleneckRankingResponse` 필드가 기존 그대로인지(응답 구조 자체는 안 바뀜, 값만 채워짐) 확인

--- a/backend/docs/artifacts/plan/20260807_리포트_통계_미구현_필드_plan_/02_timeline_plan.md
+++ b/backend/docs/artifacts/plan/20260807_리포트_통계_미구현_필드_plan_/02_timeline_plan.md
@@ -1,0 +1,67 @@
+# Phase 2: Timeline (시계열 지표)
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| P1 | UC-4: 시간대별 진행중 방문 수 | 5분 버킷마다 그 시각에 IN_PROGRESS였던 방문 수 | 처리량 추이 그래프 |
+| P1 | UC-5: 시간대별 누적 완료 방문 수 | 버킷 종료 시각까지 COMPLETED 누적 개수 | 초반/후반 속도 비교 |
+
+## 데이터 원장
+
+Phase 1과 동일한 `dbVisits`(`started_at`, `ended_at`, `status`)만으로 계산 가능 — 신규 쿼리 불필요.
+버킷 구간: `첫 방문 started_at` ~ `caseRef`(캠프 종료 시각 또는 현재 시각, 기존 `programDurationSec`
+계산에 쓰는 `endRef`와 동일 기준) 를 5분 단위로 나눈다. 방문이 하나도 없으면 빈 배열.
+
+## 객체 설계
+
+```go
+// usecase/port.go
+type CampReport struct {
+    // ...
+    Timeline []TimelineBucket
+}
+
+// TimelineBucket은 5분 단위 시계열 버킷 DTO입니다.
+type TimelineBucket struct {
+    BucketStart        time.Time
+    InProgressCount    int // 버킷 시작 시각 기준 IN_PROGRESS(started_at <= t && (ended_at==nil || ended_at > t))였던 방문 수
+    CumulativeCompleted int // 버킷 종료 시각까지 ended_at <= t인 COMPLETED 누적 수
+}
+```
+
+계산 책임은 `report_querier.go`의 `calculateCampReport` 내 별도 함수로 분리:
+
+```go
+// 책임: dbVisits로부터 5분 버킷 시계열 생성
+func buildTimeline(dbVisits []db.ListVisitsByCampRow, start, end time.Time) []usecase.TimelineBucket
+```
+
+의사코드: `start`를 5분 단위로 내림(floor) 정렬 후 버킷마다 순회하며 조건에 맞는 visit count. 방문
+수가 캠프 규모상 최대 200건(20조×10코너)이라 버킷×방문 O(n·m) 완전탐색으로 충분(사후 배치라 성능
+민감하지 않음, analytics-model.md §0.2).
+
+### web 계층
+
+```go
+type TimelineStatsResponse struct {
+    Buckets []TimelineBucketResponse `json:"buckets"`
+} // @name TimelineStatsResponse
+
+type TimelineBucketResponse struct {
+    BucketStart          time.Time `json:"bucketStart" format:"date-time"`
+    InProgressCount      int       `json:"inProgressCount"`
+    CumulativeCompleted  int       `json:"cumulativeCompleted"`
+} // @name TimelineBucketResponse
+```
+
+> `TimelineStatsResponse{}`가 빈 struct에서 필드를 갖는 struct로 바뀌는 API 계약 변경이다 —
+> `workflow/Collaborate.md` 절차상 이 필드 이름/타입을 프론트와 사전 협의해야 하나, 이슈 발행
+> 주체가 백엔드 자신(#172)이므로 백엔드가 먼저 합리적인 기본 형태로 구현하고 PR 설명에 "프론트
+> 연동 시 피드백 환영" 명시. `api/swagger.yaml`은 `make swag`로 갱신.
+
+## 검증 체크리스트
+
+- [ ] 방문 0건 캠프 → `Timeline.Buckets == []`(nil 아님, 빈 슬라이스)
+- [ ] 버킷 경계값(정확히 5분 배수 시각에 시작/종료하는 방문) 테스트
+- [ ] `go test ./internal/infrastructure/postgres/... ./internal/infrastructure/web/...`

--- a/backend/docs/artifacts/plan/20260807_리포트_통계_미구현_필드_plan_/03_operational_stats_plan.md
+++ b/backend/docs/artifacts/plan/20260807_리포트_통계_미구현_필드_plan_/03_operational_stats_plan.md
@@ -1,0 +1,111 @@
+# Phase 3: OperationalStats (§1.6 운영/보안 지표)
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| P1 | UC-6: PIN 로그인 성공/실패 건수 | `ActionFacilitatorLogin` 성공/실패 카운트 | QR/PIN 입력 안정성 |
+| P1 | UC-7: 기기 등록 요청/승인/거절/회수 건수 | `ActionDeviceRequest/Approved/Rejected/Revoked` 카운트 | 기기 신뢰 흐름 현황 |
+| P2 | UC-8: 관리자별 조작 횟수 | admin 계열 액션을 actor(관리자) 기준 그룹핑 | 운영 부하 분산 확인 |
+| P2 | UC-9: 트랙별 다이렉트 메시지 발신 횟수 | `ActionMessageDirect` 를 actor(트랙ID) 기준 그룹핑 | 도움 요청 잦은 트랙 파악 |
+| P2 | UC-10: 공지별 읽음 도달률 | 공지별 수신 대상 트랙 수 대비 읽은 트랙 수 | 공지 전달 체계 검증 |
+
+## 데이터 원장
+
+- UC-6, UC-7, UC-9: Phase 1에서 추가한 `ListAuditLogsByCamp` 결과 재사용(신규 쿼리 불필요).
+- UC-8: 같은 `ListAuditLogsByCamp` 결과에서 "관리자 주체 액션"만 필터링. 관리자 주체 액션
+  집합은 `usecase/audit_action.go`에 명시적으로 추가한다(액션 종류마다 actor가 admin/track/
+  anonymous 중 무엇인지가 코드 곳곳에 흩어져 있어 단일 소스가 필요 — DEVELOPER_GUIDE §2.4
+  sentinel 컨벤션과 동일하게 "단일 소스" 원칙 적용):
+
+  ```go
+  // audit_action.go
+  // AdminAuditActions는 actor가 관리자 ID인 액션의 집합이다 — 운영 통계(관리자별 조작 횟수)
+  // 집계 시 관리자 주체 액션만 가려내는 데 쓰인다.
+  func AdminAuditActions() map[AuditAction]bool { ... }
+  ```
+
+- UC-10: 신규 쿼리 필요 — 공지·수신자 조인.
+
+  ```sql
+  -- name: ListAnnouncementReceiptSummaryByCamp :many
+  SELECT a.id AS announcement_id, a.message AS announcement_message,
+         COUNT(r.id) AS total_recipients,
+         COUNT(r.id) FILTER (WHERE r.read_at IS NOT NULL) AS read_count
+  FROM announcements a
+  LEFT JOIN announcement_receipts r ON r.announcement_id = a.id
+  WHERE a.camp_id = $1
+  GROUP BY a.id, a.message;
+  ```
+
+  (정확한 컬럼명은 `db/migrations`의 `announcements`/`announcement_receipts` 테이블 정의를
+  구현 착수 시 재확인 — 이 문서는 설계 스케치.)
+
+## 객체 설계
+
+```go
+// usecase/port.go
+type CampReport struct {
+    // ...
+    Operational OperationalStats
+}
+
+type OperationalStats struct {
+    PinLoginSuccessCount   int
+    PinLoginFailureCount   int
+    DeviceRequestCount     int
+    DeviceApprovedCount    int
+    DeviceRejectedCount    int
+    DeviceRevokedCount     int
+    AdminOperationCounts   []AdminOperationCount
+    TrackDirectMessageCounts []TrackMessageCount
+    AnnouncementReadStats  []AnnouncementReadStat
+}
+
+type AdminOperationCount struct {
+    AdminID    string
+    AdminName  string
+    Count      int
+}
+
+type TrackMessageCount struct {
+    TrackID   domain.TrackID
+    TrackNo   int
+    Count     int
+}
+
+type AnnouncementReadStat struct {
+    AnnouncementID string
+    Message        string
+    TotalRecipients int
+    ReadCount       int
+}
+```
+
+### web 계층
+
+```go
+type OperationalStatsResponse struct {
+    PinLoginSuccessCount     int                          `json:"pinLoginSuccessCount"`
+    PinLoginFailureCount     int                          `json:"pinLoginFailureCount"`
+    DeviceRequestCount       int                          `json:"deviceRequestCount"`
+    DeviceApprovedCount      int                          `json:"deviceApprovedCount"`
+    DeviceRejectedCount      int                          `json:"deviceRejectedCount"`
+    DeviceRevokedCount       int                          `json:"deviceRevokedCount"`
+    AdminOperationCounts     []AdminOperationCountResponse `json:"adminOperationCounts"`
+    TrackDirectMessageCounts []TrackMessageCountResponse   `json:"trackDirectMessageCounts"`
+    AnnouncementReadStats    []AnnouncementReadStatResponse `json:"announcementReadStats"`
+} // @name OperationalStatsResponse
+```
+
+(하위 `*Response` 타입들은 usecase DTO와 1:1로 필드 이름만 camelCase로 맞춘다 — 기존
+`mapReport` 패턴 그대로.)
+
+## 검증 체크리스트
+
+- [ ] `AdminAuditActions()`에 신규 admin 액션 추가 누락 시 테스트가 실패하도록
+      `TestAuditActions_AdminSetIsSubsetOfAll` 같은 가드 테스트 추가(전수 목록과의 정합성)
+- [ ] 관리자 2명이 같은 액션을 각각 수행한 캠프 픽스처로 그룹핑 정확성 검증
+- [ ] 공지 수신자 0명(트랙이 하나도 없던 시점에 발송) 엣지케이스 — `ReadCount/TotalRecipients`
+      0으로 나누지 않는지(0/0 → 0%)
+- [ ] `go test ./...`, `make swag`

--- a/backend/internal/infrastructure/postgres/db/querier.go
+++ b/backend/internal/infrastructure/postgres/db/querier.go
@@ -48,6 +48,9 @@ type Querier interface {
 	ListAnnouncementViewsByCampAndTrack(ctx context.Context, arg ListAnnouncementViewsByCampAndTrackParams) ([]ListAnnouncementViewsByCampAndTrackRow, error)
 	ListAnnouncementsByCamp(ctx context.Context, campID string) ([]Announcement, error)
 	ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([]AuditLog, error)
+	// 캠프 결과 리포트(사후 배치 집계) 전용 — AuditLogQuerier.List(관리자 UI 페이지네이션)와 달리
+	// 커서/limit 없이 캠프 범위 전체를 반환한다.
+	ListAuditLogsByCamp(ctx context.Context, campID pgtype.Text) ([]AuditLog, error)
 	ListCamps(ctx context.Context) ([]Camp, error)
 	ListCornerViewsByCamp(ctx context.Context, campID string) ([]ListCornerViewsByCampRow, error)
 	ListCornersByCamp(ctx context.Context, campID string) ([]Corner, error)

--- a/backend/internal/infrastructure/postgres/db/query.sql.go
+++ b/backend/internal/infrastructure/postgres/db/query.sql.go
@@ -928,6 +928,43 @@ func (q *Queries) ListAuditLogs(ctx context.Context, arg ListAuditLogsParams) ([
 	return items, nil
 }
 
+const listAuditLogsByCamp = `-- name: ListAuditLogsByCamp :many
+SELECT id, actor, action, target, success, occurred_at, metadata, camp_id, target_name, actor_name FROM audit_logs WHERE camp_id = $1
+`
+
+// 캠프 결과 리포트(사후 배치 집계) 전용 — AuditLogQuerier.List(관리자 UI 페이지네이션)와 달리
+// 커서/limit 없이 캠프 범위 전체를 반환한다.
+func (q *Queries) ListAuditLogsByCamp(ctx context.Context, campID pgtype.Text) ([]AuditLog, error) {
+	rows, err := q.db.Query(ctx, listAuditLogsByCamp, campID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []AuditLog
+	for rows.Next() {
+		var i AuditLog
+		if err := rows.Scan(
+			&i.ID,
+			&i.Actor,
+			&i.Action,
+			&i.Target,
+			&i.Success,
+			&i.OccurredAt,
+			&i.Metadata,
+			&i.CampID,
+			&i.TargetName,
+			&i.ActorName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listCamps = `-- name: ListCamps :many
 SELECT id, name, start_at, end_at, activated_at, ended_at, status, bottleneck_min_samples, bottleneck_ratio_pct, registration_code FROM camps
 `

--- a/backend/internal/infrastructure/postgres/report_querier.go
+++ b/backend/internal/infrastructure/postgres/report_querier.go
@@ -10,6 +10,7 @@ import (
 	"cornermon/backend/internal/errs"
 	"cornermon/backend/internal/infrastructure/postgres/db"
 	"cornermon/backend/internal/usecase"
+	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -52,16 +53,27 @@ func (r *pgReportQuerier) QueryCampReport(ctx context.Context, campID domain.Cam
 		return nil, errs.Wrap(ctx, err)
 	}
 
-	return calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, r.nowFn())
+	dbTracks, err := q.ListTracksByCamp(ctx, string(campID))
+	if err != nil {
+		return nil, errs.Wrap(ctx, err)
+	}
+
+	dbAuditLogs, err := q.ListAuditLogsByCamp(ctx, pgtype.Text{String: string(campID), Valid: true})
+	if err != nil {
+		return nil, errs.Wrap(ctx, err)
+	}
+
+	return calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, dbTracks, dbAuditLogs, r.nowFn())
 }
 
-func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Group, dbCorners []db.Corner, dbVisits []db.ListVisitsByCampRow, now time.Time) (*usecase.CampReport, error) {
+func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Group, dbCorners []db.Corner, dbVisits []db.ListVisitsByCampRow, dbTracks []db.Track, dbAuditLogs []db.AuditLog, now time.Time) (*usecase.CampReport, error) {
 	totalGroups := len(dbGroups)
 	finishedGroupsCount := 0
 
 	groupReports := make([]usecase.GroupReport, 0, len(dbGroups))
 	groupCompletedVisits := make(map[string][]db.ListVisitsByCampRow)
 	cornerDurations := make(map[string][]float64)
+	trackCompletedVisits := make(map[string][]db.ListVisitsByCampRow)
 
 	for _, dbG := range dbGroups {
 		g, err := mapGroup(dbG)
@@ -86,6 +98,7 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 	for _, v := range dbVisits {
 		if v.Status == "COMPLETED" {
 			groupCompletedVisits[v.GroupID] = append(groupCompletedVisits[v.GroupID], v)
+			trackCompletedVisits[v.TrackID] = append(trackCompletedVisits[v.TrackID], v)
 
 			if v.EndedAt.Valid {
 				duration := v.EndedAt.Time.Sub(v.StartedAt.Time).Seconds()
@@ -214,17 +227,65 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 		})
 	}
 
+	trackReports := make([]usecase.TrackReport, 0, len(dbTracks))
+	for _, dbT := range dbTracks {
+		completedVisits := trackCompletedVisits[dbT.ID]
+		completedCount := len(completedVisits)
+
+		var manualCount int
+		var deviationSum float64
+		for _, cv := range completedVisits {
+			if cv.InputMethod == "MANUAL" {
+				manualCount++
+			}
+			if cv.EndedAt.Valid {
+				duration := cv.EndedAt.Time.Sub(cv.StartedAt.Time).Seconds()
+				targetSec := float64(cv.TargetMinutes * 60)
+				deviationSum += duration - targetSec
+			}
+		}
+
+		avgDeviation := 0.0
+		if completedCount > 0 {
+			avgDeviation = deviationSum / float64(completedCount)
+		}
+
+		trackReports = append(trackReports, usecase.TrackReport{
+			TrackID:         domain.TrackID(dbT.ID),
+			TrackNo:         int(dbT.TrackNo),
+			CompletedCount:  completedCount,
+			ManualCount:     manualCount,
+			AvgDeviationSec: avgDeviation,
+		})
+	}
+
+	ruleOverrideCount, trackOperationCount := 0, 0
+	for _, log := range dbAuditLogs {
+		if !log.Success {
+			continue
+		}
+		switch usecase.AuditAction(log.Action) {
+		case usecase.ActionCornerUpdate:
+			ruleOverrideCount++
+		case usecase.ActionTrackCreate, usecase.ActionTrackDelete, usecase.ActionTrackReplace:
+			trackOperationCount++
+		}
+	}
+
 	report := &usecase.CampReport{
-		CampID:             campID,
-		TotalGroups:        totalGroups,
-		FinishedGroups:     finishedGroupsCount,
-		TotalVisits:        totalVisits,
-		CompletedVisits:    completedVisitsCount,
-		ManualVisits:       manualVisitsCount,
-		ProgramDurationSec: programDurationSec,
-		AvgDeviationSec:    avgDeviationSec,
-		CornerReports:      cornerReports,
-		GroupReports:       groupReports,
+		CampID:              campID,
+		TotalGroups:         totalGroups,
+		FinishedGroups:      finishedGroupsCount,
+		TotalVisits:         totalVisits,
+		CompletedVisits:     completedVisitsCount,
+		ManualVisits:        manualVisitsCount,
+		ProgramDurationSec:  programDurationSec,
+		AvgDeviationSec:     avgDeviationSec,
+		CornerReports:       cornerReports,
+		GroupReports:        groupReports,
+		TrackReports:        trackReports,
+		RuleOverrideCount:   ruleOverrideCount,
+		TrackOperationCount: trackOperationCount,
 	}
 
 	return report, nil

--- a/backend/internal/infrastructure/postgres/report_querier_test.go
+++ b/backend/internal/infrastructure/postgres/report_querier_test.go
@@ -76,8 +76,20 @@ func TestCalculateCampReport(t *testing.T) {
 			},
 		}
 
+		dbTracks := []db.Track{
+			{ID: "track-1", CornerID: "corner-1", TrackNo: 1, Status: "ACTIVE", PinHash: "h1"},
+			{ID: "track-2", CornerID: "corner-2", TrackNo: 1, Status: "ACTIVE", PinHash: "h2"},
+		}
+		dbAuditLogs := []db.AuditLog{
+			{ID: "log-1", Actor: "admin-1", Action: string(usecase.ActionCornerUpdate), Success: true, CampID: pgtype.Text{String: "camp-1", Valid: true}},
+			{ID: "log-2", Actor: "admin-1", Action: string(usecase.ActionCornerUpdate), Success: false, CampID: pgtype.Text{String: "camp-1", Valid: true}},
+			{ID: "log-3", Actor: "admin-1", Action: string(usecase.ActionTrackCreate), Success: true, CampID: pgtype.Text{String: "camp-1", Valid: true}},
+			{ID: "log-4", Actor: "admin-1", Action: string(usecase.ActionTrackDelete), Success: true, CampID: pgtype.Text{String: "camp-1", Valid: true}},
+			{ID: "log-5", Actor: "admin-1", Action: string(usecase.ActionAdminLogin), Success: true, CampID: pgtype.Text{String: "camp-1", Valid: true}},
+		}
+
 		// Act
-		report, err := calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, now)
+		report, err := calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, dbTracks, dbAuditLogs, now)
 
 		// Assert
 		if err != nil {
@@ -146,6 +158,45 @@ func TestCalculateCampReport(t *testing.T) {
 		if c1Report.PositiveDeviationRatio != 0 {
 			t.Errorf("expected corner-1 PositiveDeviationRatio 0, got %f", c1Report.PositiveDeviationRatio)
 		}
+
+		var t1Report, t2Report usecase.TrackReport
+		for _, tr := range report.TrackReports {
+			switch tr.TrackID {
+			case "track-1":
+				t1Report = tr
+			case "track-2":
+				t2Report = tr
+			}
+		}
+		// track-1: visit-1 (deviation 0) + visit-3 (deviation -120) -> avg -60
+		if t1Report.CompletedCount != 2 {
+			t.Errorf("expected track-1 CompletedCount 2, got %d", t1Report.CompletedCount)
+		}
+		if t1Report.ManualCount != 0 {
+			t.Errorf("expected track-1 ManualCount 0, got %d", t1Report.ManualCount)
+		}
+		if t1Report.AvgDeviationSec != -60 {
+			t.Errorf("expected track-1 AvgDeviationSec -60, got %f", t1Report.AvgDeviationSec)
+		}
+		// track-2: visit-2 (MANUAL, deviation +300)
+		if t2Report.CompletedCount != 1 {
+			t.Errorf("expected track-2 CompletedCount 1, got %d", t2Report.CompletedCount)
+		}
+		if t2Report.ManualCount != 1 {
+			t.Errorf("expected track-2 ManualCount 1, got %d", t2Report.ManualCount)
+		}
+		if t2Report.AvgDeviationSec != 300 {
+			t.Errorf("expected track-2 AvgDeviationSec 300, got %f", t2Report.AvgDeviationSec)
+		}
+
+		// log-2(CORNER_UPDATE)는 실패라 제외 -> RuleOverrideCount는 log-1만 카운트.
+		if report.RuleOverrideCount != 1 {
+			t.Errorf("expected RuleOverrideCount 1, got %d", report.RuleOverrideCount)
+		}
+		// log-3(TRACK_CREATE) + log-4(TRACK_DELETE), log-5(ADMIN_LOGIN)는 무관 액션이라 제외.
+		if report.TrackOperationCount != 2 {
+			t.Errorf("expected TrackOperationCount 2, got %d", report.TrackOperationCount)
+		}
 	})
 
 	t.Run("ShouldCalculateOverDeviationRatioWhenSomeVisitsExceedTarget", func(t *testing.T) {
@@ -189,7 +240,7 @@ func TestCalculateCampReport(t *testing.T) {
 		}
 
 		// Act
-		report, err := calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, now)
+		report, err := calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, nil, nil, now)
 
 		// Assert
 		if err != nil {

--- a/backend/internal/infrastructure/web/report_handler.go
+++ b/backend/internal/infrastructure/web/report_handler.go
@@ -3,6 +3,7 @@ package web
 import (
 	"errors"
 	"net/http"
+	"sort"
 	"time"
 
 	"cornermon/backend/internal/domain"
@@ -106,6 +107,20 @@ func mapSummary(r *usecase.CampReport) CampSummaryStatsResponse {
 		manualVisitRatio = float32(r.ManualVisits) / float32(r.TotalVisits) * 100
 	}
 
+	bottleneckRanking := make([]BottleneckRankingResponse, 0, len(r.CornerReports))
+	for _, cr := range r.CornerReports {
+		bottleneckRanking = append(bottleneckRanking, BottleneckRankingResponse{
+			CornerID:            string(cr.CornerID),
+			CornerName:          cr.CornerName,
+			AvgDeviationSeconds: float32(cr.AvgDeviationSec),
+		})
+	}
+	// 컷오프 없이 전체 코너를 평균편차 내림차순으로 보여준다(analytics-model.md §1.1) — 실시간
+	// 대시보드의 "병목" 이진 판정(표본/비율 임계치)과는 별개 지표다.
+	sort.SliceStable(bottleneckRanking, func(i, j int) bool {
+		return bottleneckRanking[i].AvgDeviationSeconds > bottleneckRanking[j].AvgDeviationSeconds
+	})
+
 	return CampSummaryStatsResponse{
 		TotalGroups:            r.TotalGroups,
 		FinishedGroupCount:     r.FinishedGroups,
@@ -115,6 +130,12 @@ func mapSummary(r *usecase.CampReport) CampSummaryStatsResponse {
 		ProgramDurationSeconds: r.ProgramDurationSec,
 		AvgDeviationSeconds:    float32(r.AvgDeviationSec),
 		ManualVisitRatio:       manualVisitRatio,
+		RuleOverrideCount:      r.RuleOverrideCount,
+		TrackOperationCount:    r.TrackOperationCount,
+		// ExceptionApprovalCount: 중복 방문 예외 승인 기능은 #171 이전에 전방위로 삭제되어
+		// 집계할 원장 데이터가 없다(missing_features_report_20260711.md §3.1). 항상 0.
+		ExceptionApprovalCount: 0,
+		BottleneckRanking:      bottleneckRanking,
 	}
 }
 
@@ -148,6 +169,19 @@ func mapReport(r *usecase.CampReport) CampReportResponse {
 			GroupName:            gr.GroupName,
 			CompletedCount:       gr.CompletedCount,
 			TotalDurationSeconds: gr.TotalDurationSec,
+		})
+	}
+	for _, tr := range r.TrackReports {
+		manualVisitRatio := float32(0)
+		if tr.CompletedCount > 0 {
+			manualVisitRatio = float32(tr.ManualCount) / float32(tr.CompletedCount) * 100
+		}
+		res.TrackStats = append(res.TrackStats, TrackStatsResponse{
+			TrackID:             string(tr.TrackID),
+			TrackNo:             tr.TrackNo,
+			HandledVisitCount:   tr.CompletedCount,
+			AvgDeviationSeconds: int(tr.AvgDeviationSec),
+			ManualVisitRatio:    manualVisitRatio,
 		})
 	}
 	return res

--- a/backend/internal/infrastructure/web/report_handler_test.go
+++ b/backend/internal/infrastructure/web/report_handler_test.go
@@ -108,6 +108,71 @@ func TestMapReportShouldMapCampAndGroupAggregatesWhenReportProvided(t *testing.T
 	}
 }
 
+func TestMapSummaryShouldRankBottlenecksByDeviationDescWhenCornerReportsProvided(t *testing.T) {
+	// Arrange
+	report := &usecase.CampReport{
+		CampID: "camp-1",
+		CornerReports: []usecase.CornerReport{
+			{CornerID: "corner-1", CornerName: "코너 1", CompletedCount: 2, AvgDeviationSec: 40},
+			{CornerID: "corner-2", CornerName: "코너 2", CompletedCount: 0, AvgDeviationSec: 0},
+			{CornerID: "corner-3", CornerName: "코너 3", CompletedCount: 5, AvgDeviationSec: 120},
+		},
+		RuleOverrideCount:   3,
+		TrackOperationCount: 2,
+	}
+
+	// Act
+	summary := mapSummary(report)
+
+	// Assert
+	if len(summary.BottleneckRanking) != 3 {
+		t.Fatalf("expected 3 bottleneck entries (no cutoff), got %d", len(summary.BottleneckRanking))
+	}
+	if got := summary.BottleneckRanking[0].CornerID; got != "corner-3" {
+		t.Errorf("expected corner-3 ranked first, got %s", got)
+	}
+	if got := summary.BottleneckRanking[len(summary.BottleneckRanking)-1].CornerID; got != "corner-2" {
+		t.Errorf("expected corner-2 (0 completed) ranked last, got %s", got)
+	}
+	if summary.RuleOverrideCount != 3 {
+		t.Errorf("expected RuleOverrideCount 3, got %d", summary.RuleOverrideCount)
+	}
+	if summary.TrackOperationCount != 2 {
+		t.Errorf("expected TrackOperationCount 2, got %d", summary.TrackOperationCount)
+	}
+	if summary.ExceptionApprovalCount != 0 {
+		t.Errorf("expected ExceptionApprovalCount always 0 (feature removed), got %d", summary.ExceptionApprovalCount)
+	}
+}
+
+func TestMapReportShouldMapTrackStatsAndManualRatioWhenTrackReportsProvided(t *testing.T) {
+	// Arrange
+	report := &usecase.CampReport{
+		CampID: "camp-1",
+		TrackReports: []usecase.TrackReport{
+			{TrackID: "track-1", TrackNo: 1, CompletedCount: 4, ManualCount: 1, AvgDeviationSec: -30},
+			{TrackID: "track-2", TrackNo: 2, CompletedCount: 0, ManualCount: 0, AvgDeviationSec: 0},
+		},
+	}
+
+	// Act
+	res := mapReport(report)
+
+	// Assert
+	if len(res.TrackStats) != 2 {
+		t.Fatalf("expected 2 track stats, got %d", len(res.TrackStats))
+	}
+	if got := res.TrackStats[0].ManualVisitRatio; got != float32(25) {
+		t.Errorf("expected track-1 ManualVisitRatio 25, got %f", got)
+	}
+	if got := res.TrackStats[0].AvgDeviationSeconds; got != -30 {
+		t.Errorf("expected track-1 AvgDeviationSeconds -30, got %d", got)
+	}
+	if got := res.TrackStats[1].ManualVisitRatio; got != 0 {
+		t.Errorf("expected track-2 ManualVisitRatio 0 (no completed visits), got %f", got)
+	}
+}
+
 func TestGetCurrentReportShoudKeepCampScopeWhenRequestsRunConcurrently(t *testing.T) {
 	// Arrange
 	camps := &campRepositoryStub{camps: map[domain.CampID]*domain.Camp{

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -286,6 +286,11 @@ type CampReport struct {
 	AvgDeviationSec    float64 // 모든 COMPLETED 방문의 (실제 소요시간 - 목표시간) 평균
 	CornerReports      []CornerReport
 	GroupReports       []GroupReport
+	TrackReports       []TrackReport
+	// RuleOverrideCount는 캠프 기간 중 성공한 코너 규칙 변경(CORNER_UPDATE) 감사 로그 수입니다.
+	RuleOverrideCount int
+	// TrackOperationCount는 캠프 기간 중 성공한 트랙 생성/삭제/교체 감사 로그 수입니다.
+	TrackOperationCount int
 }
 
 // CornerReport는 코너별 분석 집계 DTO입니다.
@@ -298,6 +303,19 @@ type CornerReport struct {
 	StdDevDurationSec      float64
 	AvgDeviationSec        float64
 	PositiveDeviationRatio float64
+}
+
+// TrackReport는 트랙별 분석 집계 DTO입니다. DELETED된 과거 트랙도 포함합니다
+// (analytics-model.md §1.3).
+type TrackReport struct {
+	TrackID domain.TrackID
+	TrackNo int
+	// CompletedCount는 이 트랙에서 COMPLETED된 방문 수입니다.
+	CompletedCount int
+	// ManualCount는 CompletedCount 중 input_method=MANUAL인 방문 수입니다.
+	ManualCount int
+	// AvgDeviationSec은 COMPLETED 방문들의 (실제 소요시간 - 목표시간) 평균입니다. 표본이 없으면 0.
+	AvgDeviationSec float64
 }
 
 // GroupReport는 조별 분석 집계 DTO입니다.


### PR DESCRIPTION
## 변경 사항과 이유
#172(리포트 응답 구조체 미구현 필드 채우기)의 Phase 1. `CampReportResponse`/`CampSummaryStatsResponse`에 선언만 되어 있고 항상 빈 값/0이던 필드 중 기존 데이터(방문/트랙/감사 로그)만으로 바로 계산 가능한 부분을 채운다.

- `TrackStats`: 트랙별 처리 완료 방문 수, 평균편차, 수동 처리 비율
- `BottleneckRanking`: 코너를 평균편차 내림차순, 컷오프 없이 전체 표시 (analytics-model.md §1.1)
- `RuleOverrideCount` / `TrackOperationCount`: 성공한 `CORNER_UPDATE` / `TRACK_CREATE,DELETE,REPLACE` 감사 로그 카운트
- `ExceptionApprovalCount`: 관련 기능이 #171 이전에 이미 전방위로 삭제되어 원장 데이터가 없음 → 상수 0 유지, 사유를 주석으로 명시 (필드 자체 제거는 범위 밖)

Timeline/OperationalStats는 PR 크기 제한(LOC 500) 때문에 별도 PR(#172 Phase 2/3)로 분리한다. 계획 문서: `backend/docs/artifacts/plan/20260807_리포트_통계_미구현_필드_plan_/`.

## 검증
- `go build ./...`, `go vet ./...`, `gofmt -l .` (변경 없음)
- `go test ./...` 전체 통과
- `report_querier_test.go`: 트랙별 완료수/수동비율/평균편차, 성공/실패 혼합 감사 로그의 RuleOverrideCount/TrackOperationCount 카운트 검증 케이스 추가
- `report_handler_test.go`: BottleneckRanking 정렬 순서(컷오프 없음 포함), TrackStats 매핑(ManualVisitRatio 백분율) 검증 케이스 추가
- `make swag` 재실행 → `api/swagger.yaml` diff 없음(응답 구조 자체는 기존과 동일, 값만 채워짐)

🤖 Generated with [Claude Code](https://claude.com/claude-code)