### PR TITLE
feat: 리포트 Timeline(시계열) 지표 구현 (#172 Phase 2)

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -4138,8 +4138,31 @@ const docTemplate = `{
                 }
             }
         },
+        "TimelineBucketResponse": {
+            "type": "object",
+            "properties": {
+                "bucketStart": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "cumulativeCompleted": {
+                    "type": "integer"
+                },
+                "inProgressCount": {
+                    "type": "integer"
+                }
+            }
+        },
         "TimelineStatsResponse": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "buckets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TimelineBucketResponse"
+                    }
+                }
+            }
         },
         "TrackLoginRequest": {
             "type": "object",

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4131,8 +4131,31 @@
                 }
             }
         },
+        "TimelineBucketResponse": {
+            "type": "object",
+            "properties": {
+                "bucketStart": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "cumulativeCompleted": {
+                    "type": "integer"
+                },
+                "inProgressCount": {
+                    "type": "integer"
+                }
+            }
+        },
         "TimelineStatsResponse": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "buckets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TimelineBucketResponse"
+                    }
+                }
+            }
         },
         "TrackLoginRequest": {
             "type": "object",

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -755,7 +755,22 @@ definitions:
       qrPayload:
         type: string
     type: object
+  TimelineBucketResponse:
+    properties:
+      bucketStart:
+        format: date-time
+        type: string
+      cumulativeCompleted:
+        type: integer
+      inProgressCount:
+        type: integer
+    type: object
   TimelineStatsResponse:
+    properties:
+      buckets:
+        items:
+          $ref: '#/definitions/TimelineBucketResponse'
+        type: array
     type: object
   TrackLoginRequest:
     properties:

--- a/backend/internal/infrastructure/postgres/report_querier.go
+++ b/backend/internal/infrastructure/postgres/report_querier.go
@@ -32,50 +32,82 @@ func (r *pgReportQuerier) queries(ctx context.Context) *db.Queries {
 
 func (r *pgReportQuerier) QueryCampReport(ctx context.Context, campID domain.CampID) (*usecase.CampReport, error) {
 	q := r.queries(ctx)
+	src := campReportSource{campID: campID, now: r.nowFn()}
 
-	dbCamp, err := q.GetCamp(ctx, string(campID))
+	var err error
+	src.camp, err = q.GetCamp(ctx, string(campID))
 	if err != nil {
 		return nil, errs.Wrap(ctx, err)
 	}
 
-	dbGroups, err := q.ListGroupsByCamp(ctx, string(campID))
+	src.groups, err = q.ListGroupsByCamp(ctx, string(campID))
 	if err != nil {
 		return nil, errs.Wrap(ctx, err)
 	}
 
-	dbCorners, err := q.ListCornersByCamp(ctx, string(campID))
+	src.corners, err = q.ListCornersByCamp(ctx, string(campID))
 	if err != nil {
 		return nil, errs.Wrap(ctx, err)
 	}
 
-	dbVisits, err := q.ListVisitsByCamp(ctx, string(campID))
+	src.visits, err = q.ListVisitsByCamp(ctx, string(campID))
 	if err != nil {
 		return nil, errs.Wrap(ctx, err)
 	}
 
-	dbTracks, err := q.ListTracksByCamp(ctx, string(campID))
+	src.tracks, err = q.ListTracksByCamp(ctx, string(campID))
 	if err != nil {
 		return nil, errs.Wrap(ctx, err)
 	}
 
-	dbAuditLogs, err := q.ListAuditLogsByCamp(ctx, pgtype.Text{String: string(campID), Valid: true})
+	src.auditLogs, err = q.ListAuditLogsByCamp(ctx, pgtype.Text{String: string(campID), Valid: true})
 	if err != nil {
 		return nil, errs.Wrap(ctx, err)
 	}
 
-	return calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, dbTracks, dbAuditLogs, r.nowFn())
+	return calculateCampReport(src)
 }
 
-func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Group, dbCorners []db.Corner, dbVisits []db.ListVisitsByCampRow, dbTracks []db.Track, dbAuditLogs []db.AuditLog, now time.Time) (*usecase.CampReport, error) {
-	totalGroups := len(dbGroups)
+// campReportSource는 캠프 결과 리포트 집계에 필요한 원장 로우 전체를 한데 묶는다.
+// calculateCampReport가 값 하나 넘어가는 위치 인자 8~9개를 받게 하는 대신 이 구조체 하나를
+// 받게 해, 호출부/테스트 픽스처에서 어떤 슬라이스가 무엇인지 필드명으로 드러나게 한다.
+type campReportSource struct {
+	campID    domain.CampID
+	camp      db.Camp
+	groups    []db.Group
+	corners   []db.Corner
+	visits    []db.ListVisitsByCampRow
+	tracks    []db.Track
+	auditLogs []db.AuditLog
+	now       time.Time
+}
+
+// calculateCampReport는 캠프 종료 시(또는 진행 중 조회 시) 1회성으로 도는 사후 배치 집계다
+// (analytics-model.md §0.2 "사후 지표"). 이 집계를 SQL(GROUP BY/윈도우 함수)이 아니라 Go에서
+// 계산하는 이유:
+//  1. 같은 방문 로우 집합에서 조/코너/트랙/5분 버킷이라는 서로 다른 4개 차원으로 동시에 접어야
+//     한다. sqlc는 쿼리 하나당 결과 행 모양이 고정이라, 이 다차원 집계를 SQL로 그대로 옮기면
+//     차원마다 별도 쿼리를 왕복하거나 CTE/윈도우 함수를 겹겹이 쌓아야 해서 오히려 복잡해진다.
+//  2. 캠프 규모 상한(조 20·코너 10·트랙 40 안팎, 방문 최대 수백 건)에서 O(방문 수) 완전탐색은
+//     비용이 무시할 만큼 작다 — DB 쪽 최적화로 얻을 성능 이득이 없다.
+//  3. median/표준편차/목표시간편차비율처럼 도메인이 정의한 통계(analytics-model.md §1)는 Go
+//     단위 테스트(report_querier_test.go)로 결정론적으로 검증하기가 SQL을 스냅샷 테스트하는
+//     것보다 쉽다.
+//
+// 이 함수 자체는 ctx/DB 접근이 없는 순수 함수다 — sqlc row 타입에 결합되어 있다는 점은 남는
+// 트레이드오프이지만(스키마 변경에 취약), 조회 전용 read model이 애그리거트 경계를 가로질러
+// 여러 테이블을 한 번에 다루는 것 자체는 DEVELOPER_GUIDE.md CQRS 절이 명시적으로 허용하는
+// 형태다(권한/비즈니스 로직 없는 리포트 통계는 Handler→Read-Only Outbound Port→DB 직행 허용).
+func calculateCampReport(src campReportSource) (*usecase.CampReport, error) {
+	totalGroups := len(src.groups)
 	finishedGroupsCount := 0
 
-	groupReports := make([]usecase.GroupReport, 0, len(dbGroups))
+	groupReports := make([]usecase.GroupReport, 0, len(src.groups))
 	groupCompletedVisits := make(map[string][]db.ListVisitsByCampRow)
 	cornerDurations := make(map[string][]float64)
 	trackCompletedVisits := make(map[string][]db.ListVisitsByCampRow)
 
-	for _, dbG := range dbGroups {
+	for _, dbG := range src.groups {
 		g, err := mapGroup(dbG)
 		if err != nil {
 			return nil, err
@@ -95,7 +127,7 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 		})
 	}
 
-	for _, v := range dbVisits {
+	for _, v := range src.visits {
 		if v.Status == "COMPLETED" {
 			groupCompletedVisits[v.GroupID] = append(groupCompletedVisits[v.GroupID], v)
 			trackCompletedVisits[v.TrackID] = append(trackCompletedVisits[v.TrackID], v)
@@ -107,7 +139,7 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 		}
 	}
 
-	totalVisits := len(dbVisits)
+	totalVisits := len(src.visits)
 	completedVisitsCount := 0
 	manualVisitsCount := 0
 
@@ -155,25 +187,25 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 	var timeline []usecase.TimelineBucket
 	var firstVisitStart time.Time
 	hasFirstVisit := false
-	for _, v := range dbVisits {
+	for _, v := range src.visits {
 		if v.StartedAt.Valid && (!hasFirstVisit || v.StartedAt.Time.Before(firstVisitStart)) {
 			firstVisitStart = v.StartedAt.Time
 			hasFirstVisit = true
 		}
 	}
 	if hasFirstVisit {
-		endRef := now
-		if dbCamp.EndedAt.Valid {
-			endRef = dbCamp.EndedAt.Time
+		endRef := src.now
+		if src.camp.EndedAt.Valid {
+			endRef = src.camp.EndedAt.Time
 		}
 		if endRef.After(firstVisitStart) {
 			programDurationSec = int(endRef.Sub(firstVisitStart).Seconds())
 		}
-		timeline = buildTimeline(dbVisits, firstVisitStart, endRef)
+		timeline = buildTimeline(src.visits, firstVisitStart, endRef)
 	}
 
-	cornerReports := make([]usecase.CornerReport, 0, len(dbCorners))
-	for _, dbC := range dbCorners {
+	cornerReports := make([]usecase.CornerReport, 0, len(src.corners))
+	for _, dbC := range src.corners {
 		durations := cornerDurations[dbC.ID]
 		completedCount := len(durations)
 
@@ -229,8 +261,8 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 		})
 	}
 
-	trackReports := make([]usecase.TrackReport, 0, len(dbTracks))
-	for _, dbT := range dbTracks {
+	trackReports := make([]usecase.TrackReport, 0, len(src.tracks))
+	for _, dbT := range src.tracks {
 		completedVisits := trackCompletedVisits[dbT.ID]
 		completedCount := len(completedVisits)
 
@@ -262,7 +294,7 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 	}
 
 	ruleOverrideCount, trackOperationCount := 0, 0
-	for _, log := range dbAuditLogs {
+	for _, log := range src.auditLogs {
 		if !log.Success {
 			continue
 		}
@@ -275,7 +307,7 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 	}
 
 	report := &usecase.CampReport{
-		CampID:              campID,
+		CampID:              src.campID,
 		TotalGroups:         totalGroups,
 		FinishedGroups:      finishedGroupsCount,
 		TotalVisits:         totalVisits,

--- a/backend/internal/infrastructure/postgres/report_querier.go
+++ b/backend/internal/infrastructure/postgres/report_querier.go
@@ -152,6 +152,7 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 	}
 
 	programDurationSec := 0
+	var timeline []usecase.TimelineBucket
 	var firstVisitStart time.Time
 	hasFirstVisit := false
 	for _, v := range dbVisits {
@@ -168,6 +169,7 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 		if endRef.After(firstVisitStart) {
 			programDurationSec = int(endRef.Sub(firstVisitStart).Seconds())
 		}
+		timeline = buildTimeline(dbVisits, firstVisitStart, endRef)
 	}
 
 	cornerReports := make([]usecase.CornerReport, 0, len(dbCorners))
@@ -286,7 +288,49 @@ func calculateCampReport(campID domain.CampID, dbCamp db.Camp, dbGroups []db.Gro
 		TrackReports:        trackReports,
 		RuleOverrideCount:   ruleOverrideCount,
 		TrackOperationCount: trackOperationCount,
+		Timeline:            timeline,
 	}
 
 	return report, nil
+}
+
+// buildTimeline은 5분 단위 버킷 시계열을 만든다(analytics-model.md §1.5). start를 5분 단위로
+// 내림(floor) 정렬해 첫 버킷을 잡고, end 이전까지 버킷을 채운다. 사후 배치 집계라 버킷×방문
+// 완전탐색(O(n·m))으로 충분하다(analytics-model.md §0.2).
+func buildTimeline(dbVisits []db.ListVisitsByCampRow, start, end time.Time) []usecase.TimelineBucket {
+	if !start.Before(end) {
+		return nil
+	}
+
+	const bucketSize = 5 * time.Minute
+	buckets := make([]usecase.TimelineBucket, 0)
+	for bucketStart := start.Truncate(bucketSize); bucketStart.Before(end); bucketStart = bucketStart.Add(bucketSize) {
+		bucketEnd := bucketStart.Add(bucketSize)
+
+		inProgressCount := 0
+		cumulativeCompleted := 0
+		for _, v := range dbVisits {
+			if !v.StartedAt.Valid || v.StartedAt.Time.After(bucketStart) {
+				continue
+			}
+			if v.Status == "COMPLETED" && v.EndedAt.Valid {
+				if v.EndedAt.Time.After(bucketStart) {
+					inProgressCount++
+				}
+				if !v.EndedAt.Time.After(bucketEnd) {
+					cumulativeCompleted++
+				}
+				continue
+			}
+			// ended_at이 없는(아직 진행 중이던) 방문은 버킷 시작 시각 기준 계속 진행 중이었다.
+			inProgressCount++
+		}
+
+		buckets = append(buckets, usecase.TimelineBucket{
+			BucketStart:         bucketStart,
+			InProgressCount:     inProgressCount,
+			CumulativeCompleted: cumulativeCompleted,
+		})
+	}
+	return buckets
 }

--- a/backend/internal/infrastructure/postgres/report_querier_test.go
+++ b/backend/internal/infrastructure/postgres/report_querier_test.go
@@ -89,7 +89,10 @@ func TestCalculateCampReport(t *testing.T) {
 		}
 
 		// Act
-		report, err := calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, dbTracks, dbAuditLogs, now)
+		report, err := calculateCampReport(campReportSource{
+			campID: campID, camp: dbCamp, groups: dbGroups, corners: dbCorners, visits: dbVisits,
+			tracks: dbTracks, auditLogs: dbAuditLogs, now: now,
+		})
 
 		// Assert
 		if err != nil {
@@ -240,7 +243,9 @@ func TestCalculateCampReport(t *testing.T) {
 		}
 
 		// Act
-		report, err := calculateCampReport(campID, dbCamp, dbGroups, dbCorners, dbVisits, nil, nil, now)
+		report, err := calculateCampReport(campReportSource{
+			campID: campID, camp: dbCamp, groups: dbGroups, corners: dbCorners, visits: dbVisits, now: now,
+		})
 
 		// Assert
 		if err != nil {

--- a/backend/internal/infrastructure/postgres/report_querier_test.go
+++ b/backend/internal/infrastructure/postgres/report_querier_test.go
@@ -260,3 +260,53 @@ func TestCalculateCampReport(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildTimeline(t *testing.T) {
+	t.Run("ShouldReturnNilWhenNoVisitOverlapsRange", func(t *testing.T) {
+		// Arrange
+		anchor := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+
+		// Act
+		buckets := buildTimeline(nil, anchor, anchor)
+
+		// Assert
+		if buckets != nil {
+			t.Errorf("expected nil buckets when start is not before end, got %+v", buckets)
+		}
+	})
+
+	t.Run("ShouldBucketInProgressAndCumulativeCompletedWhenVisitsSpanMultipleBuckets", func(t *testing.T) {
+		// Arrange — 5분 버킷 경계에 이미 정렬된 anchor 사용해 Truncate 부작용을 배제한다.
+		anchor := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+		dbVisits := []db.ListVisitsByCampRow{
+			{ // 10:00~10:07 COMPLETED
+				ID: "visit-a", Status: "COMPLETED",
+				StartedAt: pgtype.Timestamptz{Time: anchor, Valid: true},
+				EndedAt:   pgtype.Timestamptz{Time: anchor.Add(7 * time.Minute), Valid: true},
+			},
+			{ // 10:06~ 아직 IN_PROGRESS(EndedAt 없음)
+				ID: "visit-b", Status: "IN_PROGRESS",
+				StartedAt: pgtype.Timestamptz{Time: anchor.Add(6 * time.Minute), Valid: true},
+			},
+		}
+
+		// Act — end를 12분 뒤로 잡아 [10:00,10:05,10:10) 3개 버킷을 만든다.
+		buckets := buildTimeline(dbVisits, anchor, anchor.Add(12*time.Minute))
+
+		// Assert
+		if len(buckets) != 3 {
+			t.Fatalf("expected 3 buckets, got %d: %+v", len(buckets), buckets)
+		}
+		want := []usecase.TimelineBucket{
+			{BucketStart: anchor, InProgressCount: 1, CumulativeCompleted: 0},
+			{BucketStart: anchor.Add(5 * time.Minute), InProgressCount: 1, CumulativeCompleted: 1},
+			{BucketStart: anchor.Add(10 * time.Minute), InProgressCount: 1, CumulativeCompleted: 1},
+		}
+		for i, w := range want {
+			got := buckets[i]
+			if !got.BucketStart.Equal(w.BucketStart) || got.InProgressCount != w.InProgressCount || got.CumulativeCompleted != w.CumulativeCompleted {
+				t.Errorf("bucket[%d]: expected %+v, got %+v", i, w, got)
+			}
+		}
+	})
+}

--- a/backend/internal/infrastructure/web/report_handler.go
+++ b/backend/internal/infrastructure/web/report_handler.go
@@ -17,7 +17,15 @@ type ReportHandler struct {
 	querier       usecase.ReportQuerier
 }
 
-type TimelineStatsResponse struct{} // @name TimelineStatsResponse
+type TimelineStatsResponse struct {
+	Buckets []TimelineBucketResponse `json:"buckets"`
+} // @name TimelineStatsResponse
+
+type TimelineBucketResponse struct {
+	BucketStart         time.Time `json:"bucketStart" format:"date-time"`
+	InProgressCount     int       `json:"inProgressCount"`
+	CumulativeCompleted int       `json:"cumulativeCompleted"`
+} // @name TimelineBucketResponse
 
 type OperationalStatsResponse struct{} // @name OperationalStatsResponse
 
@@ -184,6 +192,15 @@ func mapReport(r *usecase.CampReport) CampReportResponse {
 			ManualVisitRatio:    manualVisitRatio,
 		})
 	}
+	timelineBuckets := make([]TimelineBucketResponse, 0, len(r.Timeline))
+	for _, b := range r.Timeline {
+		timelineBuckets = append(timelineBuckets, TimelineBucketResponse{
+			BucketStart:         b.BucketStart,
+			InProgressCount:     b.InProgressCount,
+			CumulativeCompleted: b.CumulativeCompleted,
+		})
+	}
+	res.Timeline = TimelineStatsResponse{Buckets: timelineBuckets}
 	return res
 }
 

--- a/backend/internal/infrastructure/web/report_handler_test.go
+++ b/backend/internal/infrastructure/web/report_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
+	"time"
 
 	"cornermon/backend/internal/domain"
 	"cornermon/backend/internal/usecase"
@@ -170,6 +171,48 @@ func TestMapReportShouldMapTrackStatsAndManualRatioWhenTrackReportsProvided(t *t
 	}
 	if got := res.TrackStats[1].ManualVisitRatio; got != 0 {
 		t.Errorf("expected track-2 ManualVisitRatio 0 (no completed visits), got %f", got)
+	}
+}
+
+func TestMapReportShouldMapTimelineBucketsWhenReportProvidesTimeline(t *testing.T) {
+	// Arrange
+	anchor := time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC)
+	report := &usecase.CampReport{
+		CampID: "camp-1",
+		Timeline: []usecase.TimelineBucket{
+			{BucketStart: anchor, InProgressCount: 2, CumulativeCompleted: 0},
+			{BucketStart: anchor.Add(5 * time.Minute), InProgressCount: 1, CumulativeCompleted: 2},
+		},
+	}
+
+	// Act
+	res := mapReport(report)
+
+	// Assert
+	if len(res.Timeline.Buckets) != 2 {
+		t.Fatalf("expected 2 timeline buckets, got %d", len(res.Timeline.Buckets))
+	}
+	if !res.Timeline.Buckets[0].BucketStart.Equal(anchor) {
+		t.Errorf("expected bucket[0].BucketStart %v, got %v", anchor, res.Timeline.Buckets[0].BucketStart)
+	}
+	if res.Timeline.Buckets[1].InProgressCount != 1 || res.Timeline.Buckets[1].CumulativeCompleted != 2 {
+		t.Errorf("expected bucket[1] {1,2}, got %+v", res.Timeline.Buckets[1])
+	}
+}
+
+func TestMapReportShouldKeepTimelineBucketsEmptyWhenNoVisitsOccurred(t *testing.T) {
+	// Arrange
+	report := &usecase.CampReport{CampID: "camp-1"}
+
+	// Act
+	res := mapReport(report)
+
+	// Assert
+	if res.Timeline.Buckets == nil {
+		t.Error("expected non-nil (possibly empty) Buckets slice for stable JSON []")
+	}
+	if len(res.Timeline.Buckets) != 0 {
+		t.Errorf("expected 0 timeline buckets, got %d", len(res.Timeline.Buckets))
 	}
 }
 

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -305,6 +305,16 @@ type CampReport struct {
 	RuleOverrideCount int
 	// TrackOperationCount는 캠프 기간 중 성공한 트랙 생성/삭제/교체 감사 로그 수입니다.
 	TrackOperationCount int
+	Timeline            []TimelineBucket
+}
+
+// TimelineBucket은 5분 단위 시계열 버킷 DTO입니다(analytics-model.md §1.5).
+type TimelineBucket struct {
+	BucketStart time.Time
+	// InProgressCount는 버킷 시작 시각 기준 IN_PROGRESS였던 방문 수입니다.
+	InProgressCount int
+	// CumulativeCompleted는 버킷 종료 시각까지 COMPLETED로 누적된 방문 수입니다.
+	CumulativeCompleted int
 }
 
 // CornerReport는 코너별 분석 집계 DTO입니다.


### PR DESCRIPTION
## 변경 사항과 이유
#172 Phase 2. `CampReportResponse.Timeline`(기존 완전히 빈 struct)에 시계열 지표를 채운다.

- 5분 버킷 단위로 "버킷 시작 시각 기준 IN_PROGRESS였던 방문 수"와 "버킷 종료 시각까지 누적
  COMPLETED 방문 수"를 계산 (analytics-model.md §1.5)
- 범위는 첫 방문 started_at ~ (캠프 종료 시각 또는 현재 시각) — `ProgramDurationSec` 계산과
  동일한 기준(`endRef`)을 재사용
- 방문이 하나도 없으면 빈 버킷 배열(`[]`, `null` 아님)
- **API 계약 변경**: `TimelineStatsResponse`가 빈 struct에서 `{ buckets: [...] }`로 바뀜.
  이슈 발행 주체가 백엔드 자신(#172)이라 프론트 사전 협의 없이 진행했고, `make swag`로
  `api/swagger.yaml` 재생성 완료 — 프론트 연동 시 필드명 피드백 있으면 반영.

**base가 `issue-172-report-stats`(Phase 1, #220)입니다** — 스택 PR이라 Phase 1이 먼저 머지되어야
diff가 Phase 2만 남습니다.

## 검증
- `go build ./...`, `go vet ./...`, `gofmt -w .` (diff 없음)
- `go test ./...` 전체 통과
- `report_querier_test.go`: `buildTimeline` 단위 테스트(경계값 없는 range → nil, 버킷 3개에
  걸친 IN_PROGRESS/COMPLETED 계산 — 결정적 anchor 시각 사용)
- `report_handler_test.go`: 버킷 매핑, 방문 0건일 때 빈(non-nil) 배열 검증
- `make swag` 재실행 → `api/swagger.yaml`/`docs.go`/`swagger.json` diff 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)