### PR TITLE
feat: 리포트 OperationalStats(운영/보안 지표) 구현 (#172 Phase 3)

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -3111,6 +3111,21 @@ const docTemplate = `{
                 }
             }
         },
+        "AdminOperationCountResponse": {
+            "type": "object",
+            "properties": {
+                "adminId": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "adminName": {
+                    "type": "string"
+                },
+                "count": {
+                    "type": "integer"
+                }
+            }
+        },
         "AdminResponse": {
             "type": "object",
             "properties": {
@@ -3149,6 +3164,24 @@ const docTemplate = `{
                 "lastUsedAt": {
                     "type": "string",
                     "format": "date-time"
+                }
+            }
+        },
+        "AnnouncementReadStatResponse": {
+            "type": "object",
+            "properties": {
+                "announcementContent": {
+                    "type": "string"
+                },
+                "announcementId": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "readCount": {
+                    "type": "integer"
+                },
+                "totalRecipients": {
+                    "type": "integer"
                 }
             }
         },
@@ -4071,7 +4104,45 @@ const docTemplate = `{
             }
         },
         "OperationalStatsResponse": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "adminOperationCounts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AdminOperationCountResponse"
+                    }
+                },
+                "announcementReadStats": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AnnouncementReadStatResponse"
+                    }
+                },
+                "deviceApprovedCount": {
+                    "type": "integer"
+                },
+                "deviceRejectedCount": {
+                    "type": "integer"
+                },
+                "deviceRequestCount": {
+                    "type": "integer"
+                },
+                "deviceRevokedCount": {
+                    "type": "integer"
+                },
+                "pinLoginFailureCount": {
+                    "type": "integer"
+                },
+                "pinLoginSuccessCount": {
+                    "type": "integer"
+                },
+                "trackDirectMessageCounts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TrackMessageCountResponse"
+                    }
+                }
+            }
         },
         "ReplaceTrackRequest": {
             "type": "object",
@@ -4182,6 +4253,21 @@ const docTemplate = `{
                     "$ref": "#/definitions/TrackResponse"
                 },
                 "trackToken": {
+                    "type": "string"
+                }
+            }
+        },
+        "TrackMessageCountResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "trackId": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "trackLabel": {
                     "type": "string"
                 }
             }

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -3104,6 +3104,21 @@
                 }
             }
         },
+        "AdminOperationCountResponse": {
+            "type": "object",
+            "properties": {
+                "adminId": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "adminName": {
+                    "type": "string"
+                },
+                "count": {
+                    "type": "integer"
+                }
+            }
+        },
         "AdminResponse": {
             "type": "object",
             "properties": {
@@ -3142,6 +3157,24 @@
                 "lastUsedAt": {
                     "type": "string",
                     "format": "date-time"
+                }
+            }
+        },
+        "AnnouncementReadStatResponse": {
+            "type": "object",
+            "properties": {
+                "announcementContent": {
+                    "type": "string"
+                },
+                "announcementId": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "readCount": {
+                    "type": "integer"
+                },
+                "totalRecipients": {
+                    "type": "integer"
                 }
             }
         },
@@ -4064,7 +4097,45 @@
             }
         },
         "OperationalStatsResponse": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "adminOperationCounts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AdminOperationCountResponse"
+                    }
+                },
+                "announcementReadStats": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AnnouncementReadStatResponse"
+                    }
+                },
+                "deviceApprovedCount": {
+                    "type": "integer"
+                },
+                "deviceRejectedCount": {
+                    "type": "integer"
+                },
+                "deviceRequestCount": {
+                    "type": "integer"
+                },
+                "deviceRevokedCount": {
+                    "type": "integer"
+                },
+                "pinLoginFailureCount": {
+                    "type": "integer"
+                },
+                "pinLoginSuccessCount": {
+                    "type": "integer"
+                },
+                "trackDirectMessageCounts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/TrackMessageCountResponse"
+                    }
+                }
+            }
         },
         "ReplaceTrackRequest": {
             "type": "object",
@@ -4175,6 +4246,21 @@
                     "$ref": "#/definitions/TrackResponse"
                 },
                 "trackToken": {
+                    "type": "string"
+                }
+            }
+        },
+        "TrackMessageCountResponse": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "trackId": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "trackLabel": {
                     "type": "string"
                 }
             }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -14,6 +14,16 @@ definitions:
       expiresInSeconds:
         type: integer
     type: object
+  AdminOperationCountResponse:
+    properties:
+      adminId:
+        format: uuid
+        type: string
+      adminName:
+        type: string
+      count:
+        type: integer
+    type: object
   AdminResponse:
     properties:
       id:
@@ -41,6 +51,18 @@ definitions:
       lastUsedAt:
         format: date-time
         type: string
+    type: object
+  AnnouncementReadStatResponse:
+    properties:
+      announcementContent:
+        type: string
+      announcementId:
+        format: uuid
+        type: string
+      readCount:
+        type: integer
+      totalRecipients:
+        type: integer
     type: object
   AssignBadgeRequest:
     properties:
@@ -707,6 +729,31 @@ definitions:
         type: string
     type: object
   OperationalStatsResponse:
+    properties:
+      adminOperationCounts:
+        items:
+          $ref: '#/definitions/AdminOperationCountResponse'
+        type: array
+      announcementReadStats:
+        items:
+          $ref: '#/definitions/AnnouncementReadStatResponse'
+        type: array
+      deviceApprovedCount:
+        type: integer
+      deviceRejectedCount:
+        type: integer
+      deviceRequestCount:
+        type: integer
+      deviceRevokedCount:
+        type: integer
+      pinLoginFailureCount:
+        type: integer
+      pinLoginSuccessCount:
+        type: integer
+      trackDirectMessageCounts:
+        items:
+          $ref: '#/definitions/TrackMessageCountResponse'
+        type: array
     type: object
   ReplaceTrackRequest:
     properties:
@@ -784,6 +831,16 @@ definitions:
       track:
         $ref: '#/definitions/TrackResponse'
       trackToken:
+        type: string
+    type: object
+  TrackMessageCountResponse:
+    properties:
+      count:
+        type: integer
+      trackId:
+        format: uuid
+        type: string
+      trackLabel:
         type: string
     type: object
   TrackPINExportResponse:

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -385,3 +385,14 @@ SELECT * FROM visits WHERE group_id = $1 ORDER BY started_at ASC;
 -- 캠프 결과 리포트(사후 배치 집계) 전용 — AuditLogQuerier.List(관리자 UI 페이지네이션)와 달리
 -- 커서/limit 없이 캠프 범위 전체를 반환한다.
 SELECT * FROM audit_logs WHERE camp_id = $1;
+
+-- name: ListAnnouncementReceiptSummaryByCamp :many
+-- 공지별 읽음 도달률(analytics-model.md §1.6) 집계 전용. 수신 대상이 없던 공지(발송 시점에
+-- 트랙이 하나도 없던 경우)도 LEFT JOIN으로 0/0 행이 남는다.
+SELECT a.id AS announcement_id, a.content AS announcement_content,
+       COUNT(r.track_id) AS total_recipients,
+       COUNT(r.track_id) FILTER (WHERE r.read_at IS NOT NULL) AS read_count
+FROM announcements a
+LEFT JOIN announcement_receipts r ON r.announcement_id = a.id
+WHERE a.camp_id = $1
+GROUP BY a.id, a.content;

--- a/backend/internal/infrastructure/postgres/db/querier.go
+++ b/backend/internal/infrastructure/postgres/db/querier.go
@@ -43,6 +43,9 @@ type Querier interface {
 	ListAdminSessionsByAdmin(ctx context.Context, adminID string) ([]AdminSession, error)
 	ListAdmins(ctx context.Context) ([]Admin, error)
 	ListAllBadges(ctx context.Context) ([]Badge, error)
+	// 공지별 읽음 도달률(analytics-model.md §1.6) 집계 전용. 수신 대상이 없던 공지(발송 시점에
+	// 트랙이 하나도 없던 경우)도 LEFT JOIN으로 0/0 행이 남는다.
+	ListAnnouncementReceiptSummaryByCamp(ctx context.Context, campID string) ([]ListAnnouncementReceiptSummaryByCampRow, error)
 	ListAnnouncementReceiptViews(ctx context.Context, announcementID string) ([]ListAnnouncementReceiptViewsRow, error)
 	ListAnnouncementReceiptsByAnnouncement(ctx context.Context, announcementID string) ([]AnnouncementReceipt, error)
 	ListAnnouncementViewsByCampAndTrack(ctx context.Context, arg ListAnnouncementViewsByCampAndTrackParams) ([]ListAnnouncementViewsByCampAndTrackRow, error)

--- a/backend/internal/infrastructure/postgres/db/query.sql.go
+++ b/backend/internal/infrastructure/postgres/db/query.sql.go
@@ -719,6 +719,50 @@ func (q *Queries) ListAllBadges(ctx context.Context) ([]Badge, error) {
 	return items, nil
 }
 
+const listAnnouncementReceiptSummaryByCamp = `-- name: ListAnnouncementReceiptSummaryByCamp :many
+SELECT a.id AS announcement_id, a.content AS announcement_content,
+       COUNT(r.track_id) AS total_recipients,
+       COUNT(r.track_id) FILTER (WHERE r.read_at IS NOT NULL) AS read_count
+FROM announcements a
+LEFT JOIN announcement_receipts r ON r.announcement_id = a.id
+WHERE a.camp_id = $1
+GROUP BY a.id, a.content
+`
+
+type ListAnnouncementReceiptSummaryByCampRow struct {
+	AnnouncementID      string `json:"announcement_id"`
+	AnnouncementContent string `json:"announcement_content"`
+	TotalRecipients     int64  `json:"total_recipients"`
+	ReadCount           int64  `json:"read_count"`
+}
+
+// 공지별 읽음 도달률(analytics-model.md §1.6) 집계 전용. 수신 대상이 없던 공지(발송 시점에
+// 트랙이 하나도 없던 경우)도 LEFT JOIN으로 0/0 행이 남는다.
+func (q *Queries) ListAnnouncementReceiptSummaryByCamp(ctx context.Context, campID string) ([]ListAnnouncementReceiptSummaryByCampRow, error) {
+	rows, err := q.db.Query(ctx, listAnnouncementReceiptSummaryByCamp, campID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListAnnouncementReceiptSummaryByCampRow
+	for rows.Next() {
+		var i ListAnnouncementReceiptSummaryByCampRow
+		if err := rows.Scan(
+			&i.AnnouncementID,
+			&i.AnnouncementContent,
+			&i.TotalRecipients,
+			&i.ReadCount,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAnnouncementReceiptViews = `-- name: ListAnnouncementReceiptViews :many
 SELECT ar.track_id, t.track_no, c.name AS corner_name, ar.read_at
 FROM announcement_receipts ar

--- a/backend/internal/infrastructure/postgres/report_querier.go
+++ b/backend/internal/infrastructure/postgres/report_querier.go
@@ -65,6 +65,11 @@ func (r *pgReportQuerier) QueryCampReport(ctx context.Context, campID domain.Cam
 		return nil, errs.Wrap(ctx, err)
 	}
 
+	src.announcementReceipts, err = q.ListAnnouncementReceiptSummaryByCamp(ctx, string(campID))
+	if err != nil {
+		return nil, errs.Wrap(ctx, err)
+	}
+
 	return calculateCampReport(src)
 }
 
@@ -72,14 +77,15 @@ func (r *pgReportQuerier) QueryCampReport(ctx context.Context, campID domain.Cam
 // calculateCampReport가 값 하나 넘어가는 위치 인자 8~9개를 받게 하는 대신 이 구조체 하나를
 // 받게 해, 호출부/테스트 픽스처에서 어떤 슬라이스가 무엇인지 필드명으로 드러나게 한다.
 type campReportSource struct {
-	campID    domain.CampID
-	camp      db.Camp
-	groups    []db.Group
-	corners   []db.Corner
-	visits    []db.ListVisitsByCampRow
-	tracks    []db.Track
-	auditLogs []db.AuditLog
-	now       time.Time
+	campID               domain.CampID
+	camp                 db.Camp
+	groups               []db.Group
+	corners              []db.Corner
+	visits               []db.ListVisitsByCampRow
+	tracks               []db.Track
+	auditLogs            []db.AuditLog
+	announcementReceipts []db.ListAnnouncementReceiptSummaryByCampRow
+	now                  time.Time
 }
 
 // calculateCampReport는 캠프 종료 시(또는 진행 중 조회 시) 1회성으로 도는 사후 배치 집계다
@@ -294,16 +300,69 @@ func calculateCampReport(src campReportSource) (*usecase.CampReport, error) {
 	}
 
 	ruleOverrideCount, trackOperationCount := 0, 0
+	operational := usecase.OperationalStats{}
+	adminOpCounts := make(map[string]*usecase.AdminOperationCount)
+	trackMsgCounts := make(map[string]*usecase.TrackMessageCount)
 	for _, log := range src.auditLogs {
+		action := usecase.AuditAction(log.Action)
+
+		// PIN 로그인은 성공/실패 둘 다 의미 있는 지표라 success 필터 이전에 먼저 센다.
+		if action == usecase.ActionFacilitatorLogin {
+			if log.Success {
+				operational.PinLoginSuccessCount++
+			} else {
+				operational.PinLoginFailureCount++
+			}
+		}
+
 		if !log.Success {
 			continue
 		}
-		switch usecase.AuditAction(log.Action) {
+
+		switch action {
 		case usecase.ActionCornerUpdate:
 			ruleOverrideCount++
 		case usecase.ActionTrackCreate, usecase.ActionTrackDelete, usecase.ActionTrackReplace:
 			trackOperationCount++
+		case usecase.ActionDeviceRequest:
+			operational.DeviceRequestCount++
+		case usecase.ActionDeviceApproved:
+			operational.DeviceApprovedCount++
+		case usecase.ActionDeviceRejected:
+			operational.DeviceRejectedCount++
+		case usecase.ActionDeviceRevoked:
+			operational.DeviceRevokedCount++
+		case usecase.ActionMessageDirect:
+			entry, ok := trackMsgCounts[log.Actor]
+			if !ok {
+				entry = &usecase.TrackMessageCount{TrackID: domain.TrackID(log.Actor), TrackLabel: log.ActorName.String}
+				trackMsgCounts[log.Actor] = entry
+			}
+			entry.Count++
 		}
+
+		if usecase.IsAdminAuditAction(action) {
+			entry, ok := adminOpCounts[log.Actor]
+			if !ok {
+				entry = &usecase.AdminOperationCount{AdminID: log.Actor, AdminName: log.ActorName.String}
+				adminOpCounts[log.Actor] = entry
+			}
+			entry.Count++
+		}
+	}
+	for _, entry := range adminOpCounts {
+		operational.AdminOperationCounts = append(operational.AdminOperationCounts, *entry)
+	}
+	for _, entry := range trackMsgCounts {
+		operational.TrackDirectMessageCounts = append(operational.TrackDirectMessageCounts, *entry)
+	}
+	for _, ar := range src.announcementReceipts {
+		operational.AnnouncementReadStats = append(operational.AnnouncementReadStats, usecase.AnnouncementReadStat{
+			AnnouncementID:      ar.AnnouncementID,
+			AnnouncementContent: ar.AnnouncementContent,
+			TotalRecipients:     int(ar.TotalRecipients),
+			ReadCount:           int(ar.ReadCount),
+		})
 	}
 
 	report := &usecase.CampReport{
@@ -321,6 +380,7 @@ func calculateCampReport(src campReportSource) (*usecase.CampReport, error) {
 		RuleOverrideCount:   ruleOverrideCount,
 		TrackOperationCount: trackOperationCount,
 		Timeline:            timeline,
+		Operational:         operational,
 	}
 
 	return report, nil

--- a/backend/internal/infrastructure/postgres/report_querier_test.go
+++ b/backend/internal/infrastructure/postgres/report_querier_test.go
@@ -266,6 +266,60 @@ func TestCalculateCampReport(t *testing.T) {
 	})
 }
 
+func TestCalculateCampReportShouldAggregateOperationalStatsWhenAuditLogsAndReceiptsProvided(t *testing.T) {
+	// Arrange
+	campID := domain.CampID("camp-3")
+	dbCamp := db.Camp{ID: "camp-3"}
+	scope := pgtype.Text{String: "camp-3", Valid: true}
+	dbAuditLogs := []db.AuditLog{
+		{ID: "log-10", Actor: "anonymous", Action: string(usecase.ActionFacilitatorLogin), Success: true, CampID: scope},
+		{ID: "log-11", Actor: "anonymous", Action: string(usecase.ActionFacilitatorLogin), Success: true, CampID: scope},
+		{ID: "log-12", Actor: "anonymous", Action: string(usecase.ActionFacilitatorLogin), Success: false, CampID: scope},
+		{ID: "log-13", Actor: "anonymous", Action: string(usecase.ActionDeviceRequest), Success: true, CampID: scope},
+		{ID: "log-14", Actor: "admin-1", Action: string(usecase.ActionDeviceApproved), Success: true, CampID: scope, ActorName: pgtype.Text{String: "admin1", Valid: true}},
+		{ID: "log-15", Actor: "admin-1", Action: string(usecase.ActionDeviceRejected), Success: true, CampID: scope, ActorName: pgtype.Text{String: "admin1", Valid: true}},
+		{ID: "log-16", Actor: "admin-2", Action: string(usecase.ActionDeviceRevoked), Success: true, CampID: scope, ActorName: pgtype.Text{String: "admin2", Valid: true}},
+		{ID: "log-17", Actor: "track-1", Action: string(usecase.ActionMessageDirect), Success: true, CampID: scope, ActorName: pgtype.Text{String: "코너1 · 1번 트랙", Valid: true}},
+		{ID: "log-18", Actor: "track-1", Action: string(usecase.ActionMessageDirect), Success: true, CampID: scope, ActorName: pgtype.Text{String: "코너1 · 1번 트랙", Valid: true}},
+		{ID: "log-19", Actor: "admin-1", Action: string(usecase.ActionCornerUpdate), Success: true, CampID: scope, ActorName: pgtype.Text{String: "admin1", Valid: true}},
+		{ID: "log-20", Actor: "admin-2", Action: string(usecase.ActionCampEnd), Success: true, CampID: scope, ActorName: pgtype.Text{String: "admin2", Valid: true}},
+	}
+	dbAnnouncementReceipts := []db.ListAnnouncementReceiptSummaryByCampRow{
+		{AnnouncementID: "ann-1", AnnouncementContent: "공지 내용", TotalRecipients: 5, ReadCount: 3},
+	}
+
+	// Act
+	report, err := calculateCampReport(campReportSource{
+		campID: campID, camp: dbCamp, auditLogs: dbAuditLogs, announcementReceipts: dbAnnouncementReceipts, now: time.Now(),
+	})
+
+	// Assert
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	op := report.Operational
+	if op.PinLoginSuccessCount != 2 || op.PinLoginFailureCount != 1 {
+		t.Errorf("expected PIN success=2 failure=1, got success=%d failure=%d", op.PinLoginSuccessCount, op.PinLoginFailureCount)
+	}
+	if op.DeviceRequestCount != 1 || op.DeviceApprovedCount != 1 || op.DeviceRejectedCount != 1 || op.DeviceRevokedCount != 1 {
+		t.Errorf("expected device counts all 1, got %+v", op)
+	}
+	if len(op.TrackDirectMessageCounts) != 1 || op.TrackDirectMessageCounts[0].Count != 2 {
+		t.Errorf("expected 1 track with 2 direct messages, got %+v", op.TrackDirectMessageCounts)
+	}
+	// admin-1: DeviceApproved + DeviceRejected + CornerUpdate = 3, admin-2: DeviceRevoked + CampEnd = 2
+	adminCounts := map[string]int{}
+	for _, a := range op.AdminOperationCounts {
+		adminCounts[a.AdminID] = a.Count
+	}
+	if adminCounts["admin-1"] != 3 || adminCounts["admin-2"] != 2 {
+		t.Errorf("expected admin-1=3 admin-2=2, got %+v", adminCounts)
+	}
+	if len(op.AnnouncementReadStats) != 1 || op.AnnouncementReadStats[0].TotalRecipients != 5 || op.AnnouncementReadStats[0].ReadCount != 3 {
+		t.Errorf("expected 1 announcement stat {5,3}, got %+v", op.AnnouncementReadStats)
+	}
+}
+
 func TestBuildTimeline(t *testing.T) {
 	t.Run("ShouldReturnNilWhenNoVisitOverlapsRange", func(t *testing.T) {
 		// Arrange

--- a/backend/internal/infrastructure/web/report_handler.go
+++ b/backend/internal/infrastructure/web/report_handler.go
@@ -27,7 +27,36 @@ type TimelineBucketResponse struct {
 	CumulativeCompleted int       `json:"cumulativeCompleted"`
 } // @name TimelineBucketResponse
 
-type OperationalStatsResponse struct{} // @name OperationalStatsResponse
+type OperationalStatsResponse struct {
+	PinLoginSuccessCount     int                            `json:"pinLoginSuccessCount"`
+	PinLoginFailureCount     int                            `json:"pinLoginFailureCount"`
+	DeviceRequestCount       int                            `json:"deviceRequestCount"`
+	DeviceApprovedCount      int                            `json:"deviceApprovedCount"`
+	DeviceRejectedCount      int                            `json:"deviceRejectedCount"`
+	DeviceRevokedCount       int                            `json:"deviceRevokedCount"`
+	AdminOperationCounts     []AdminOperationCountResponse  `json:"adminOperationCounts"`
+	TrackDirectMessageCounts []TrackMessageCountResponse    `json:"trackDirectMessageCounts"`
+	AnnouncementReadStats    []AnnouncementReadStatResponse `json:"announcementReadStats"`
+} // @name OperationalStatsResponse
+
+type AdminOperationCountResponse struct {
+	AdminID   string `json:"adminId" format:"uuid"`
+	AdminName string `json:"adminName"`
+	Count     int    `json:"count"`
+} // @name AdminOperationCountResponse
+
+type TrackMessageCountResponse struct {
+	TrackID    string `json:"trackId" format:"uuid"`
+	TrackLabel string `json:"trackLabel"`
+	Count      int    `json:"count"`
+} // @name TrackMessageCountResponse
+
+type AnnouncementReadStatResponse struct {
+	AnnouncementID      string `json:"announcementId" format:"uuid"`
+	AnnouncementContent string `json:"announcementContent"`
+	TotalRecipients     int    `json:"totalRecipients"`
+	ReadCount           int    `json:"readCount"`
+} // @name AnnouncementReadStatResponse
 
 type TrackStatsResponse struct {
 	TrackID             string  `json:"trackId" format:"uuid"`
@@ -201,7 +230,41 @@ func mapReport(r *usecase.CampReport) CampReportResponse {
 		})
 	}
 	res.Timeline = TimelineStatsResponse{Buckets: timelineBuckets}
+	res.OperationalStats = mapOperationalStats(r.Operational)
 	return res
+}
+
+// mapOperationalStats maps usecase.OperationalStats to OperationalStatsResponse.
+func mapOperationalStats(o usecase.OperationalStats) OperationalStatsResponse {
+	adminOps := make([]AdminOperationCountResponse, 0, len(o.AdminOperationCounts))
+	for _, a := range o.AdminOperationCounts {
+		adminOps = append(adminOps, AdminOperationCountResponse{AdminID: a.AdminID, AdminName: a.AdminName, Count: a.Count})
+	}
+	trackMsgs := make([]TrackMessageCountResponse, 0, len(o.TrackDirectMessageCounts))
+	for _, m := range o.TrackDirectMessageCounts {
+		trackMsgs = append(trackMsgs, TrackMessageCountResponse{TrackID: string(m.TrackID), TrackLabel: m.TrackLabel, Count: m.Count})
+	}
+	announcementStats := make([]AnnouncementReadStatResponse, 0, len(o.AnnouncementReadStats))
+	for _, a := range o.AnnouncementReadStats {
+		announcementStats = append(announcementStats, AnnouncementReadStatResponse{
+			AnnouncementID:      a.AnnouncementID,
+			AnnouncementContent: a.AnnouncementContent,
+			TotalRecipients:     a.TotalRecipients,
+			ReadCount:           a.ReadCount,
+		})
+	}
+
+	return OperationalStatsResponse{
+		PinLoginSuccessCount:     o.PinLoginSuccessCount,
+		PinLoginFailureCount:     o.PinLoginFailureCount,
+		DeviceRequestCount:       o.DeviceRequestCount,
+		DeviceApprovedCount:      o.DeviceApprovedCount,
+		DeviceRejectedCount:      o.DeviceRejectedCount,
+		DeviceRevokedCount:       o.DeviceRevokedCount,
+		AdminOperationCounts:     adminOps,
+		TrackDirectMessageCounts: trackMsgs,
+		AnnouncementReadStats:    announcementStats,
+	}
 }
 
 // @Summary      라이브 서머리 (대시보드 상단)

--- a/backend/internal/infrastructure/web/report_handler_test.go
+++ b/backend/internal/infrastructure/web/report_handler_test.go
@@ -216,6 +216,48 @@ func TestMapReportShouldKeepTimelineBucketsEmptyWhenNoVisitsOccurred(t *testing.
 	}
 }
 
+func TestMapReportShouldMapOperationalStatsWhenReportProvidesOperational(t *testing.T) {
+	// Arrange
+	report := &usecase.CampReport{
+		CampID: "camp-1",
+		Operational: usecase.OperationalStats{
+			PinLoginSuccessCount: 4,
+			PinLoginFailureCount: 1,
+			DeviceRequestCount:   2,
+			DeviceApprovedCount:  1,
+			DeviceRejectedCount:  1,
+			DeviceRevokedCount:   0,
+			AdminOperationCounts: []usecase.AdminOperationCount{
+				{AdminID: "admin-1", AdminName: "admin1", Count: 3},
+			},
+			TrackDirectMessageCounts: []usecase.TrackMessageCount{
+				{TrackID: "track-1", TrackLabel: "코너1 · 1번 트랙", Count: 2},
+			},
+			AnnouncementReadStats: []usecase.AnnouncementReadStat{
+				{AnnouncementID: "ann-1", AnnouncementContent: "공지", TotalRecipients: 5, ReadCount: 3},
+			},
+		},
+	}
+
+	// Act
+	res := mapReport(report)
+
+	// Assert
+	got := res.OperationalStats
+	if got.PinLoginSuccessCount != 4 || got.PinLoginFailureCount != 1 {
+		t.Errorf("expected PIN success=4 failure=1, got %+v", got)
+	}
+	if len(got.AdminOperationCounts) != 1 || got.AdminOperationCounts[0].AdminName != "admin1" || got.AdminOperationCounts[0].Count != 3 {
+		t.Errorf("expected 1 admin operation count entry, got %+v", got.AdminOperationCounts)
+	}
+	if len(got.TrackDirectMessageCounts) != 1 || got.TrackDirectMessageCounts[0].Count != 2 {
+		t.Errorf("expected 1 track message count entry, got %+v", got.TrackDirectMessageCounts)
+	}
+	if len(got.AnnouncementReadStats) != 1 || got.AnnouncementReadStats[0].ReadCount != 3 {
+		t.Errorf("expected 1 announcement read stat entry, got %+v", got.AnnouncementReadStats)
+	}
+}
+
 func TestGetCurrentReportShoudKeepCampScopeWhenRequestsRunConcurrently(t *testing.T) {
 	// Arrange
 	camps := &campRepositoryStub{camps: map[domain.CampID]*domain.Camp{

--- a/backend/internal/usecase/audit_action.go
+++ b/backend/internal/usecase/audit_action.go
@@ -92,3 +92,45 @@ func IsValidAuditAction(raw string) bool {
 	}
 	return false
 }
+
+// adminAuditActions는 actor가 관리자 ID인 액션의 집합이다. 캠프 결과 리포트의 "관리자별
+// 조작 횟수"(analytics-model.md §1.6) 집계 시 진행자/익명 주체 액션(FACILITATOR_LOGIN,
+// MESSAGE_DIRECT, VISIT_START/COMPLETE 등)을 가려내는 데 쓰인다. 새 액션을 추가할 때
+// actor가 관리자 ID인지 여부에 따라 반드시 여기 포함 여부를 결정한다 —
+// TestAdminAuditActionsShoudPartitionAllActions가 누락을 감지한다.
+func adminAuditActions() map[AuditAction]bool {
+	return map[AuditAction]bool{
+		ActionAdminLogin:          true,
+		ActionAdminCreate:         true,
+		ActionAdminPasswordChange: true,
+		ActionAdminDelete:         true,
+		ActionAdminSessionRevoke:  true,
+		ActionTrackForceLogout:    true,
+		ActionBadgeAssign:         true,
+		ActionBadgeBulkGenerate:   true,
+		ActionBadgeExport:         true,
+		ActionCampActivate:        true,
+		ActionCampEnd:             true,
+		ActionCampCreate:          true,
+		ActionCampSettingsUpdate:  true,
+		ActionCornerUpdate:        true,
+		ActionCornerDelete:        true,
+		ActionCornerCreate:        true,
+		ActionDeviceApproved:      true,
+		ActionDeviceRejected:      true,
+		ActionDeviceRevoked:       true,
+		ActionPinLockReset:        true,
+		ActionGroupCreate:         true,
+		ActionMessageBroadcast:    true,
+		ActionTrackCreate:         true,
+		ActionTrackDelete:         true,
+		ActionTrackReplace:        true,
+		ActionPinRegenerate:       true,
+		ActionTrackPinExport:      true,
+	}
+}
+
+// IsAdminAuditAction은 action의 주체가 관리자인지 여부를 반환한다.
+func IsAdminAuditAction(action AuditAction) bool {
+	return adminAuditActions()[action]
+}

--- a/backend/internal/usecase/audit_action_test.go
+++ b/backend/internal/usecase/audit_action_test.go
@@ -50,3 +50,50 @@ func TestIsValidAuditActionShoudReturnFalseWhenUnknownAction(t *testing.T) {
 		t.Fatalf("expected %q to be invalid", unknown)
 	}
 }
+
+// 새 액션이 IsAdminAuditAction 판단 대상에서 빠지면(관리자별 조작 횟수 집계 누락) 이 테스트가
+// 실패한다 — 관리자 주체와 진행자/익명 주체가 alias 없이 알려진 두 부류로만 나뉘는지는 검증하지
+// 않지만, 최소한 "존재하는 모든 액션이 IsAdminAuditAction 호출 시 panic 없이 결정된 값을
+// 반환한다"는 것과 진행자/익명 주체로 이미 알려진 액션들이 false로 분류되는지를 고정한다.
+func TestIsAdminAuditActionShoudReturnFalseForFacilitatorAndAnonymousActions(t *testing.T) {
+	// arrange
+	nonAdminActions := []usecase.AuditAction{
+		usecase.ActionFacilitatorLogin,
+		usecase.ActionSessionMigrate,
+		usecase.ActionFacilitatorLogout,
+		usecase.ActionDeviceRequest,
+		usecase.ActionMessageDirect,
+		usecase.ActionVisitStart,
+		usecase.ActionVisitComplete,
+	}
+
+	for _, action := range nonAdminActions {
+		// act
+		got := usecase.IsAdminAuditAction(action)
+
+		// assert
+		if got {
+			t.Errorf("expected %q to not be an admin audit action", action)
+		}
+	}
+}
+
+func TestIsAdminAuditActionShoudReturnTrueForKnownAdminActions(t *testing.T) {
+	// arrange
+	adminActions := []usecase.AuditAction{
+		usecase.ActionCornerUpdate,
+		usecase.ActionTrackCreate,
+		usecase.ActionCampEnd,
+		usecase.ActionDeviceApproved,
+	}
+
+	for _, action := range adminActions {
+		// act
+		got := usecase.IsAdminAuditAction(action)
+
+		// assert
+		if !got {
+			t.Errorf("expected %q to be an admin audit action", action)
+		}
+	}
+}

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -306,6 +306,7 @@ type CampReport struct {
 	// TrackOperationCount는 캠프 기간 중 성공한 트랙 생성/삭제/교체 감사 로그 수입니다.
 	TrackOperationCount int
 	Timeline            []TimelineBucket
+	Operational         OperationalStats
 }
 
 // TimelineBucket은 5분 단위 시계열 버킷 DTO입니다(analytics-model.md §1.5).
@@ -315,6 +316,43 @@ type TimelineBucket struct {
 	InProgressCount int
 	// CumulativeCompleted는 버킷 종료 시각까지 COMPLETED로 누적된 방문 수입니다.
 	CumulativeCompleted int
+}
+
+// OperationalStats는 운영/보안 지표 DTO입니다(analytics-model.md §1.6). 감사 로그 기반이며
+// 성공한 이벤트만 카운트합니다(PIN 로그인은 예외 — 성공/실패 둘 다 의미 있는 지표라 둘 다 셉니다).
+type OperationalStats struct {
+	PinLoginSuccessCount int
+	PinLoginFailureCount int
+	DeviceRequestCount   int
+	DeviceApprovedCount  int
+	DeviceRejectedCount  int
+	DeviceRevokedCount   int
+	AdminOperationCounts []AdminOperationCount
+	// TrackDirectMessageCounts는 트랙이 관리자에게 보낸 다이렉트 메시지(도움 요청 등) 발신 횟수입니다.
+	TrackDirectMessageCounts []TrackMessageCount
+	AnnouncementReadStats    []AnnouncementReadStat
+}
+
+// AdminOperationCount는 관리자별 조작 횟수 DTO입니다.
+type AdminOperationCount struct {
+	AdminID   string
+	AdminName string
+	Count     int
+}
+
+// TrackMessageCount는 트랙별 다이렉트 메시지 발신 횟수 DTO입니다.
+type TrackMessageCount struct {
+	TrackID    domain.TrackID
+	TrackLabel string
+	Count      int
+}
+
+// AnnouncementReadStat은 공지별 읽음 도달률 DTO입니다.
+type AnnouncementReadStat struct {
+	AnnouncementID      string
+	AnnouncementContent string
+	TotalRecipients     int
+	ReadCount           int
 }
 
 // CornerReport는 코너별 분석 집계 DTO입니다.


### PR DESCRIPTION
## 변경 사항과 이유
#172 마지막 Phase. `CampReportResponse.OperationalStats`(기존 완전히 빈 struct)에 §1.6 운영/보안 지표를 채운다.

- PIN 로그인 성공/실패 건수 (`FACILITATOR_LOGIN`, 성공/실패 둘 다 카운트 — 실패도 의미 있는 지표라 `success` 필터 이전에 먼저 집계)
- 기기 등록 요청/승인/거절/회수 건수 (`DEVICE_REQUEST/APPROVED/REJECTED/REVOKED`, 성공한 이벤트만)
- 관리자별 조작 횟수: `usecase/audit_action.go`에 `adminAuditActions()`(단일 소스) + `IsAdminAuditAction` 추가해 진행자/익명 주체 액션과 구분
- 트랙별 다이렉트 메시지 발신 횟수 (`MESSAGE_DIRECT`)
- 공지별 읽음 도달률: 신규 쿼리 `ListAnnouncementReceiptSummaryByCamp`(공지×수신 트랙 LEFT JOIN, 수신 대상 0명인 공지도 0/0으로 남음)

감사 로그에 이미 스냅샷된 `actor_name`(관리자 표시이름/트랙 라벨, `adminActorLabel`/`trackDisplayLabel` 관례)을 그대로 재사용해 추가 조회 없이 매핑한다.

**base가 `issue-172-timeline`(Phase 2, #221)입니다** — 스택 PR이라 Phase 1(#220)→Phase 2(#221) 순으로 먼저 머지되어야 diff가 Phase 3만 남습니다.

**API 계약 변경**: `OperationalStatsResponse`가 빈 struct에서 필드를 갖는 응답으로 바뀜. `make swag`로 `api/swagger.yaml` 재생성 완료.

## 검증
- `go build ./...`, `go vet ./...`, `gofmt -w .` (diff 없음)
- `go test ./...` 전체 통과
- `audit_action_test.go`: `IsAdminAuditAction`이 관리자/진행자·익명 주체 액션을 올바르게 분류하는지 검증
- `report_querier_test.go`: PIN 성공/실패, 기기등록 4종, 관리자별 조작 횟수(2명 분리), 트랙별 DM 횟수, 공지 읽음 도달률 집계 검증
- `report_handler_test.go`: `OperationalStatsResponse` 매핑 검증
- `make swag` 재실행 → `api/swagger.yaml`/`docs.go`/`swagger.json` diff 포함

이로써 #172의 모든 대상 필드(TrackStats, Timeline, OperationalStats, BottleneckRanking, RuleOverrideCount, TrackOperationCount)가 채워집니다. `ExceptionApprovalCount`만 기능 삭제로 상수 0 유지(Phase 1 PR #220 참고).

🤖 Generated with [Claude Code](https://claude.com/claude-code)