### PR TITLE
feat: 로깅 코어(AppLogger/LogRingBuffer) 추가 (#131 Phase A)

### DIFF
--- a/frontend/lib/shared/logging/app_logger.dart
+++ b/frontend/lib/shared/logging/app_logger.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:cornermon/shared/logging/log_level.dart';
+import 'package:cornermon/shared/logging/log_record.dart';
+import 'package:cornermon/shared/logging/log_ring_buffer.dart';
+
+/// 화면·프로바이더·네트워크 계층이 각자 `debugPrint`를 재구현하던 것(#131)을 대체하는
+/// 단일 진입점. `debug`/`info`는 `kDebugMode`에서만 콘솔에 출력하고 링버퍼에는 남기지
+/// 않는다. `warn`/`error`는 빌드 모드와 무관하게 항상 [LogRingBuffer]에 적재해, release
+/// 빌드에서 실기기 필드 이슈가 나도 사후에 최근 이력을 확인할 수 있게 한다(§목표①).
+///
+/// `main()`의 `runZonedGuarded`/`FlutterError.onError`(§UC-3)처럼 `ProviderScope` 밖에서도
+/// 써야 하는 지점이 있어 전역 싱글턴 [appLogger]로 두고, Riverpod 경계 안에서는
+/// [appLoggerProvider]로 접근해 테스트에서 override할 수 있게 한다.
+class AppLogger {
+  AppLogger({LogRingBuffer? buffer}) : _buffer = buffer ?? LogRingBuffer();
+
+  final LogRingBuffer _buffer;
+
+  void debug(String tag, String message) => _console(LogLevel.debug, tag, message);
+
+  void info(String tag, String message) => _console(LogLevel.info, tag, message);
+
+  void warn(
+    String tag,
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    String? traceId,
+  }) => _record(LogLevel.warn, tag, message, error, stackTrace, traceId);
+
+  void error(
+    String tag,
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    String? traceId,
+  }) => _record(LogLevel.error, tag, message, error, stackTrace, traceId);
+
+  List<LogRecord> exportSnapshot() => _buffer.snapshot();
+
+  void _console(LogLevel level, String tag, String message) {
+    if (!kDebugMode) return;
+    debugPrint(
+      LogRecord(
+        level: level,
+        tag: tag,
+        message: message,
+        timestamp: DateTime.now(),
+      ).toLine(),
+    );
+  }
+
+  void _record(
+    LogLevel level,
+    String tag,
+    String message,
+    Object? error,
+    StackTrace? stackTrace,
+    String? traceId,
+  ) {
+    final record = LogRecord(
+      level: level,
+      tag: tag,
+      message: message,
+      timestamp: DateTime.now(),
+      traceId: traceId,
+      error: error,
+      stackTrace: stackTrace,
+    );
+    _buffer.add(record);
+    debugPrint(record.toLine());
+  }
+}
+
+/// `main()`의 zone/전역 예외 핸들러(§UC-3)처럼 `ProviderScope` 밖에서 로깅해야 하는
+/// 지점을 위한 전역 인스턴스. 앱 전체에서 이 인스턴스 하나만 존재해야 하므로
+/// [appLoggerProvider]도 항상 이 인스턴스를 반환한다.
+final appLogger = AppLogger();
+
+/// Riverpod 경계 안(인터셉터, 화면, 컨트롤러)에서는 이 provider로 접근한다 — 테스트에서
+/// override해 링버퍼를 검증할 수 있다.
+final appLoggerProvider = Provider<AppLogger>((ref) => appLogger);

--- a/frontend/lib/shared/logging/log_level.dart
+++ b/frontend/lib/shared/logging/log_level.dart
@@ -1,0 +1,4 @@
+/// 로그 레벨. `debug`/`info`는 개발 중 진단용이라 release 빌드 콘솔·링버퍼 어디에도
+/// 남기지 않는다. `warn`/`error`는 필드 사후진단(#131)의 대상이라 release에서도
+/// [LogRingBuffer]에 항상 적재된다 — 자세한 정책은 §레벨 정책(2026-07-22 플랜 문서) 참고.
+enum LogLevel { debug, info, warn, error }

--- a/frontend/lib/shared/logging/log_record.dart
+++ b/frontend/lib/shared/logging/log_record.dart
@@ -1,0 +1,42 @@
+import 'package:cornermon/shared/logging/log_level.dart';
+
+/// 로그 한 건. [LogRingBuffer] 적재 및 진단 내보내기(#131 UC-4, 별도 이슈) 시
+/// 텍스트 직렬화의 단위다.
+class LogRecord {
+  const LogRecord({
+    required this.level,
+    required this.tag,
+    required this.message,
+    required this.timestamp,
+    this.traceId,
+    this.error,
+    this.stackTrace,
+  });
+
+  final LogLevel level;
+
+  /// 로그 발생 지점 식별자. 화면/프로바이더 태그(`login`, `setup_wizard` 등) 또는
+  /// 네트워크 계층 태그(`network`)로 쓴다.
+  final String tag;
+  final String message;
+  final DateTime timestamp;
+
+  /// 백엔드 구조화 로그(`trace_id`)와 이 사건을 상관관계 매칭하기 위한 값
+  /// (`backend/internal/infrastructure/web/logger_middleware.go`의 `X-Trace-ID` echo와 대칭).
+  /// 네트워크 계층을 거치지 않은 로그(전역 예외 등)는 null.
+  final String? traceId;
+  final Object? error;
+  final StackTrace? stackTrace;
+
+  /// 콘솔 출력·내보내기 텍스트 모두가 공유하는 한 줄(+스택트레이스) 포맷.
+  String toLine() {
+    final levelTag = level.name.toUpperCase();
+    final traceSuffix = traceId == null ? '' : ' trace_id=$traceId';
+    final buffer = StringBuffer(
+      '${timestamp.toIso8601String()} [$levelTag][$tag] $message$traceSuffix',
+    );
+    if (error != null) buffer.write('\n$error');
+    if (stackTrace != null) buffer.write('\n$stackTrace');
+    return buffer.toString();
+  }
+}

--- a/frontend/lib/shared/logging/log_ring_buffer.dart
+++ b/frontend/lib/shared/logging/log_ring_buffer.dart
@@ -1,0 +1,24 @@
+import 'dart:collection';
+
+import 'package:cornermon/shared/logging/log_record.dart';
+
+/// 최근 [capacity]건의 [LogRecord]를 FIFO로 보관한다 — 진단 내보내기(#131 UC-4, 별도
+/// 이슈)의 데이터 소스. `warn`/`error`만 적재 대상이며 그 판단은 [AppLogger]의 책임이다.
+class LogRingBuffer {
+  LogRingBuffer({this.capacity = 500}) : assert(capacity > 0);
+
+  final int capacity;
+  final Queue<LogRecord> _records = Queue<LogRecord>();
+
+  void add(LogRecord record) {
+    _records.addLast(record);
+    while (_records.length > capacity) {
+      _records.removeFirst();
+    }
+  }
+
+  List<LogRecord> snapshot() => List.unmodifiable(_records);
+
+  String exportAsText() =>
+      _records.map((record) => record.toLine()).join('\n\n');
+}

--- a/frontend/test/shared/logging/app_logger_test.dart
+++ b/frontend/test/shared/logging/app_logger_test.dart
@@ -1,0 +1,51 @@
+import 'package:cornermon/shared/logging/app_logger.dart';
+import 'package:cornermon/shared/logging/log_level.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppLogger', () {
+    test('ShoudNotAppendToBufferWhenLevelIsDebugOrInfo', () {
+      // arrange
+      final logger = AppLogger();
+
+      // act
+      logger.debug('tag', 'debug message');
+      logger.info('tag', 'info message');
+
+      // assert
+      expect(logger.exportSnapshot(), isEmpty);
+    });
+
+    test('ShoudAppendToBufferWhenLevelIsWarnOrError', () {
+      // arrange
+      final logger = AppLogger();
+
+      // act
+      logger.warn('tag', 'warn message');
+      logger.error('tag', 'error message');
+
+      // assert
+      final snapshot = logger.exportSnapshot();
+      expect(snapshot.map((record) => record.level), [
+        LogLevel.warn,
+        LogLevel.error,
+      ]);
+    });
+
+    test('ShoudKeepErrorAndStackTraceWhenProvided', () {
+      // arrange
+      final logger = AppLogger();
+      final error = StateError('boom');
+      final stackTrace = StackTrace.current;
+
+      // act
+      logger.error('tag', 'failed', error: error, stackTrace: stackTrace, traceId: 'trace-1');
+
+      // assert
+      final record = logger.exportSnapshot().single;
+      expect(record.error, error);
+      expect(record.stackTrace, stackTrace);
+      expect(record.traceId, 'trace-1');
+    });
+  });
+}

--- a/frontend/test/shared/logging/log_ring_buffer_test.dart
+++ b/frontend/test/shared/logging/log_ring_buffer_test.dart
@@ -1,0 +1,61 @@
+import 'package:cornermon/shared/logging/log_level.dart';
+import 'package:cornermon/shared/logging/log_record.dart';
+import 'package:cornermon/shared/logging/log_ring_buffer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+LogRecord _record(String message) => LogRecord(
+  level: LogLevel.error,
+  tag: 'test',
+  message: message,
+  timestamp: DateTime.utc(2026, 1, 1),
+);
+
+void main() {
+  group('LogRingBuffer', () {
+    test('ShoudEvictOldestWhenCapacityExceeded', () {
+      // arrange
+      final buffer = LogRingBuffer(capacity: 2);
+
+      // act
+      buffer.add(_record('a'));
+      buffer.add(_record('b'));
+      buffer.add(_record('c'));
+
+      // assert
+      expect(
+        buffer.snapshot().map((record) => record.message),
+        ['b', 'c'],
+      );
+    });
+
+    test('ShoudPreserveInsertionOrderWhenWithinCapacity', () {
+      // arrange
+      final buffer = LogRingBuffer();
+
+      // act
+      buffer.add(_record('first'));
+      buffer.add(_record('second'));
+
+      // assert
+      expect(
+        buffer.snapshot().map((record) => record.message),
+        ['first', 'second'],
+      );
+    });
+
+    test('ShoudJoinRecordLinesWhenExportingAsText', () {
+      // arrange
+      final buffer = LogRingBuffer()
+        ..add(_record('first'))
+        ..add(_record('second'));
+
+      // act
+      final text = buffer.exportAsText();
+
+      // assert
+      expect(text, contains('first'));
+      expect(text, contains('second'));
+      expect(text.indexOf('first'), lessThan(text.indexOf('second')));
+    });
+  });
+}


### PR DESCRIPTION
## 요약
이슈 #131(에러 로깅 중복/불일치)의 3단계 PR 중 첫 번째. `20260722_issue131_frontend_logging_policy_plan_.md` Phase A.

화면/프로바이더마다 debugPrint를 재구현하던 것을 대체할 공통 로깅 유틸리티의 코어(`LogLevel`/`LogRecord`/`LogRingBuffer`/`AppLogger`)를 `frontend/lib/shared/logging/`에 추가한다. `warn`/`error`는 release 빌드에서도 링버퍼(기본 500건 FIFO)에 남고, `debug`/`info`는 `kDebugMode`에서만 콘솔에 출력된다.

이 PR만으로는 아직 아무 화면도 마이그레이션하지 않는다 — 이어지는 두 PR(네트워크 인터셉터, 기존 호출부 이관)에서 실제로 소비한다. 순서대로 머지되어야 한다:
1. **이 PR** — 로깅 코어
2. #(다음 PR) — Dio 인터셉터(TraceIdInterceptor/LoggingInterceptor)
3. #(다음 PR) — 전역 예외 포착 + 기존 14곳 이관

## 종료 조건
- [x] `LogRingBuffer` capacity 초과 시 FIFO 동작 단위테스트
- [x] `AppLogger` 레벨별 콘솔 출력/버퍼 적재 분기 단위테스트
- [x] `flutter analyze lib/` 이슈 없음
- [x] `flutter test` 신규 6개 전부 통과 (`log_ring_buffer_test.dart`, `app_logger_test.dart`)

Refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)