### PR TITLE
refactor: 전역 예외 포착 + 기존 14곳 debugPrint를 AppLogger로 이관 (#131 Phase C)

### DIFF
--- a/frontend/docs/artifacts/plan/20260722_issue131_frontend_logging_policy_plan_.md
+++ b/frontend/docs/artifacts/plan/20260722_issue131_frontend_logging_policy_plan_.md
@@ -297,35 +297,46 @@ class DiagnosticsExportController extends AsyncNotifier<void> {
 
 ---
 
+## 진행 현황 (2026-08-07)
+
+P0(UC-1~3, Phase A~C)까지 구현 완료, 3개 PR로 분할(각 500 LOC 이내, 순서대로 스택):
+
+- [x] Phase A — 로깅 코어 (#223)
+- [x] Phase B — 네트워크 계층 통합 (#224)
+- [x] Phase C — 전역 예외 포착 + 기존 14곳 이관 (#225, 이슈 본문 4곳 + 조사로 확인된 10곳 전부)
+
+P1(UC-4 진단 내보내기, UC-5 레벨 재분류 화면 노출)은 사용자와 협의해 이번 범위에서 제외 —
+필요 시 별도 이슈로 진행한다.
+
 ## 검증 체크리스트
 
 ### 아키텍처 검증
 
-- [ ] `lib/shared/logging/`가 `lib/admin/**`, `lib/facilitator/**`를 import하지 않음
-- [ ] `lib/shared/api/gen/**` 무수정
-- [ ] `LoggingInterceptor`/`TraceIdInterceptor`가 `AuthInterceptor`와 동일하게 `SessionTokenSource` 등 추상 인터페이스만 참조(admin/facilitator 세션 직접 참조 금지)
-- [ ] 로그 어디에도 `Authorization` 헤더 원문, PIN/등록코드 원문이 포함되지 않음(§목표⑦) — 코드 리뷰 시 `LoggingInterceptor` 구현에서 헤더/민감 필드 제외 여부 확인
+- [x] `lib/shared/logging/`가 `lib/admin/**`, `lib/facilitator/**`를 import하지 않음
+- [x] `lib/shared/api/gen/**` 무수정
+- [x] `LoggingInterceptor`/`TraceIdInterceptor`가 `AuthInterceptor`와 동일하게 `Ref`만 참조(admin/facilitator 세션 직접 참조 금지)
+- [x] 로그 어디에도 `Authorization` 헤더 원문, PIN/등록코드 원문이 포함되지 않음(§목표⑦) — `LoggingInterceptor`는 `describeDioError()`(type/statusCode/message/error)만 기록하고 헤더를 다루지 않음
 
 ### 유즈케이스 검증
 
-- [ ] UC-1: `device_manage_screen.dart`, `pin_login_error_provider.dart`처럼 기존에 로깅이 없던 화면에서도 API 실패 시 로그가 자동으로 남는지 확인(수동 재현: 네트워크 차단 후 액션 수행)
-- [ ] UC-2: 실패 요청의 프론트 로그와 백엔드 `trace_id` 로그가 동일 값으로 매칭되는지 확인(백엔드 로그 tail + 프론트 로그 export 비교)
-- [ ] UC-3: `FlutterError.onError`를 유발하는 위젯 빌드 예외를 의도적으로 발생시켜 `AppLogger`에 기록되는지 단위/위젯 테스트로 확인
-- [ ] UC-4: release 모드 빌드에서 API 실패 재현 → 진단 내보내기 실행 → 공유된 텍스트에 해당 에러 라인이 포함되는지 실기기 확인
-- [ ] UC-5: `debug`/`info` 레벨 로그가 release 빌드의 `exportSnapshot()` 결과에 포함되지 않는지 단위테스트로 확인
+- [x] UC-1: `LoggingInterceptor`가 `apiClient`의 모든 `DioException`을 자동 기록하므로 `device_manage_screen.dart` 등 기존에 로깅이 없던 화면도 구조적으로 커버됨(단위테스트로 확인). 실기기 수동 재현은 미실시.
+- [ ] UC-2: 실패 요청의 프론트 로그와 백엔드 `trace_id` 로그가 동일 값으로 매칭되는지 실기기/실서버로 확인 — 후속 필요
+- [x] UC-3: `main_admin.dart`/`main_facilitator.dart`에 `runZonedGuarded`+`FlutterError.onError`+`PlatformDispatcher.onError` 연결 완료(정적 리뷰로 확인, 위젯 예외 유발 테스트는 미작성)
+- [ ] UC-4: 범위 밖(P1)으로 이연
+- [x] UC-5: `AppLogger` 단위테스트로 `debug`/`info`가 `exportSnapshot()`에서 빠짐을 확인
 
 ### 자동화 테스트
 
-- `LogRingBuffer`: capacity 초과 시 FIFO 정상 동작, `exportAsText()` 포맷
-- `AppLogger`: 레벨별 콘솔 출력/버퍼 적재 분기(`kDebugMode` 모킹 또는 조건 주입)
-- `describeDioError`/`traceIdOf`: 커넥션 타임아웃/4xx/5xx/헤더 없음 등 케이스별 단위테스트(`dio_error_test.dart`류 기존 패턴 참고)
-- `LoggingInterceptor`/`TraceIdInterceptor`: 기존 `AuthInterceptor` 테스트 패턴(Dio `MockAdapter` 또는 `DioAdapter`) 참고해 요청/에러 흐름 검증
-- 기존 10개 파일의 화면/컨트롤러 테스트: 로깅 제거 후에도 사용자 피드백(SnackBar/배너) 분기가 기존과 동일하게 동작하는지 회귀 확인(`flutter test` 전체)
+- [x] `LogRingBuffer`: capacity 초과 시 FIFO 정상 동작, `exportAsText()` 포맷
+- [x] `AppLogger`: 레벨별 콘솔 출력/버퍼 적재 분기
+- [x] `describeDioError`/`traceIdOf`: 커넥션 타임아웃/4xx/5xx/헤더 없음 등 케이스별 단위테스트
+- [x] `LoggingInterceptor`/`TraceIdInterceptor`: Dio + fake `HttpClientAdapter`(기존 `sse_client_test.dart` 패턴)로 요청/에러 흐름 검증
+- [x] 기존 14개 파일 회귀: `flutter test` 전체 314 passed / 2 failed(둘 다 main에도 있던 사전 실패, 이 변경과 무관함을 baseline 비교로 확인)
 
-### 실기기 테스트
+### 실기기 테스트 (미실시 — 후속 필요)
 
-- facilitator 실기기에서 Tailscale/네트워크 차단으로 connectionTimeout 재현 → 로그 export로 원인이 명확히 드러나는지 확인(#131의 원 계기였던 시나리오 재현)
-- admin(iPad)에서 동일 절차 확인
+- [ ] facilitator 실기기에서 Tailscale/네트워크 차단으로 connectionTimeout 재현 → 로그가 warn으로 남는지 확인(#131의 원 계기였던 시나리오 재현)
+- [ ] admin(iPad)에서 동일 절차 확인
 
 ---
 

--- a/frontend/lib/admin/features/admin_management/_admin_list_tile.dart
+++ b/frontend/lib/admin/features/admin_management/_admin_list_tile.dart
@@ -10,6 +10,7 @@ import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/app_tag.dart';
 import 'package:cornermon/shared/design_system/widgets/confirm_modal.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 import '_admin_management_connection_state.dart';
 
 /// SYSTEM_ADMIN 전용 관리자 목록의 행. 본인 행은 삭제 버튼을 노출하지 않는다 — 본인
@@ -46,11 +47,8 @@ class _AdminListTileState extends ConsumerState<AdminListTile> {
       await container.read(provider.future).whenComplete(sub.close);
       ref.invalidate(adminListProvider);
       ref.read(adminManagementConnectionLostProvider.notifier).set(false);
-    } on DioException catch (error, stackTrace) {
-      debugPrint(
-        '[admin_management] delete admin failed: type=${error.type} '
-        'statusCode=${error.response?.statusCode}\n$stackTrace',
-      );
+    } on DioException catch (error) {
+      // DioException은 LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록한다.
       if (isConnectionLost(error)) {
         ref.read(adminManagementConnectionLostProvider.notifier).set(true);
       } else if (mounted) {
@@ -59,7 +57,12 @@ class _AdminListTileState extends ConsumerState<AdminListTile> {
         ).showSnackBar(const SnackBar(content: Text('삭제에 실패했습니다. 잠시 후 다시 시도해주세요.')));
       }
     } catch (error, stackTrace) {
-      debugPrint('[admin_management] delete admin failed: $error\n$stackTrace');
+      ref.read(appLoggerProvider).error(
+        'admin_management',
+        'delete admin failed',
+        error: error,
+        stackTrace: stackTrace,
+      );
       if (mounted) {
         ScaffoldMessenger.of(
           context,

--- a/frontend/lib/admin/features/admin_management/_my_account_card.dart
+++ b/frontend/lib/admin/features/admin_management/_my_account_card.dart
@@ -12,6 +12,7 @@ import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/confirm_modal.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 import '_admin_management_connection_state.dart';
 
 /// 로그인한 관리자 본인의 비밀번호 변경과, CORNER_OPERATOR인 경우의 본인 탈퇴를
@@ -46,11 +47,8 @@ class _MyAccountCardState extends ConsumerState<MyAccountCard> {
       await action();
       ref.read(adminManagementConnectionLostProvider.notifier).set(false);
       return true;
-    } on DioException catch (error, stackTrace) {
-      debugPrint(
-        '[admin_management] my account action failed: type=${error.type} '
-        'statusCode=${error.response?.statusCode}\n$stackTrace',
-      );
+    } on DioException catch (error) {
+      // DioException은 LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록한다.
       if (isConnectionLost(error)) {
         ref.read(adminManagementConnectionLostProvider.notifier).set(true);
       } else {
@@ -58,7 +56,12 @@ class _MyAccountCardState extends ConsumerState<MyAccountCard> {
       }
       return false;
     } catch (error, stackTrace) {
-      debugPrint('[admin_management] my account action failed: $error\n$stackTrace');
+      ref.read(appLoggerProvider).error(
+        'admin_management',
+        'my account action failed',
+        error: error,
+        stackTrace: stackTrace,
+      );
       _showSnackBar('요청이 실패했습니다. 잠시 후 다시 시도해주세요.');
       return false;
     } finally {

--- a/frontend/lib/admin/features/camp_list/camp_list_screen.dart
+++ b/frontend/lib/admin/features/camp_list/camp_list_screen.dart
@@ -109,11 +109,8 @@ Future<void> _confirmLogout(BuildContext context, WidgetRef ref) async {
 
   try {
     await ref.read(adminSessionProvider.notifier).logout();
-  } on DioException catch (error, stackTrace) {
-    debugPrint(
-      '[camp_list] logout failed: type=${error.type} '
-      'statusCode=${error.response?.statusCode}\n$stackTrace',
-    );
+  } on DioException catch (error) {
+    // DioException은 LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록한다.
     if (isConnectionLost(error)) return;
     if (!context.mounted) return;
     ScaffoldMessenger.of(

--- a/frontend/lib/admin/features/device_manage/_device_registration_row.dart
+++ b/frontend/lib/admin/features/device_manage/_device_registration_row.dart
@@ -12,6 +12,7 @@ import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/confirm_modal.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 import 'package:cornermon/shared/widgets/local_time_label.dart';
 import '_device_manage_connection_state.dart';
 
@@ -48,19 +49,20 @@ class _DeviceRegistrationRowState extends ConsumerState<DeviceRegistrationRow> {
       await action();
       ref.invalidate(deviceRegistrationListProvider(widget.campId));
       ref.read(deviceManageConnectionLostProvider.notifier).set(false);
-    } on DioException catch (error, stackTrace) {
-      debugPrint(
-        '[device_manage] action failed: type=${error.type} '
-        'statusCode=${error.response?.statusCode} '
-        'body=${error.response?.data}\n$stackTrace',
-      );
+    } on DioException catch (error) {
+      // DioException은 LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록한다.
       if (isConnectionLost(error)) {
         ref.read(deviceManageConnectionLostProvider.notifier).set(true);
       } else {
         _showSnackBar('요청이 실패했습니다. 잠시 후 다시 시도해주세요.');
       }
     } catch (error, stackTrace) {
-      debugPrint('[device_manage] action failed: $error\n$stackTrace');
+      ref.read(appLoggerProvider).error(
+        'device_manage',
+        'action failed',
+        error: error,
+        stackTrace: stackTrace,
+      );
       _showSnackBar('요청이 실패했습니다. 잠시 후 다시 시도해주세요.');
     } finally {
       if (mounted) setState(() => _isBusy = false);

--- a/frontend/lib/admin/features/end_camp/end_camp_confirm_dialog.dart
+++ b/frontend/lib/admin/features/end_camp/end_camp_confirm_dialog.dart
@@ -11,16 +11,14 @@ import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 
 /// POST end-camp 실패를 사용자 문구로 변환한다(camp_handler.go EndCamp 참고).
-/// 인식 못한 코드(네트워크 오류, 5xx 등)는 원문을 로그로만 남기고 일반 문구로 대체한다.
+/// 인식 못한 코드(네트워크 오류, 5xx 등)는 일반 문구로 대체한다. DioException은
+/// LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록하므로, 그 외 에러만
+/// 여기서 직접 로깅한다.
 String _describeEndError(Object error, StackTrace stackTrace) {
   if (error is DioException) {
-    debugPrint(
-      '[end_camp] failed: type=${error.type} '
-      'statusCode=${error.response?.statusCode} '
-      'body=${error.response?.data}\n$stackTrace',
-    );
     final code = (error.response?.data is Map)
         ? (error.response?.data as Map)['code'] as String?
         : null;
@@ -28,7 +26,7 @@ String _describeEndError(Object error, StackTrace stackTrace) {
       return '종료할 수 없는 캠프 상태이거나 정리 중인 방문이 있습니다.';
     }
   } else {
-    debugPrint('[end_camp] failed: $error\n$stackTrace');
+    appLogger.error('end_camp', 'failed', error: error, stackTrace: stackTrace);
   }
   return '종료 처리에 실패했습니다. 잠시 후 다시 시도해주세요.';
 }

--- a/frontend/lib/admin/features/login/login_error_provider.dart
+++ b/frontend/lib/admin/features/login/login_error_provider.dart
@@ -1,8 +1,9 @@
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:cornermon/admin/session/admin_session_provider.dart';
+import 'package:cornermon/shared/api/dio_error.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 
 part 'login_error_provider.g.dart';
 
@@ -29,18 +30,18 @@ class LoginError extends _$LoginError {
     state = null;
     try {
       await ref.read(adminSessionProvider.notifier).login(loginId, password);
-    } on DioException catch (error, stackTrace) {
-      final detail =
-          'DioException type=${error.type} statusCode=${error.response?.statusCode} '
-          'message=${error.message} error=${error.error}';
-      debugPrint('[login] $detail\n$stackTrace');
+    } on DioException catch (error) {
+      // DioException은 LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록한다.
+      final detail = describeDioError(error);
       state = error.response?.statusCode == 401
           ? const AdminLoginInvalidCredentials()
           : AdminLoginServerError(detail);
       rethrow;
     } catch (error, stackTrace) {
       final detail = '${error.runtimeType} $error';
-      debugPrint('[login] non-Dio error $detail\n$stackTrace');
+      ref
+          .read(appLoggerProvider)
+          .error('login', 'non-Dio error', error: error, stackTrace: stackTrace);
       state = AdminLoginServerError(detail);
       rethrow;
     }

--- a/frontend/lib/admin/features/login/login_screen.dart
+++ b/frontend/lib/admin/features/login/login_screen.dart
@@ -27,11 +27,6 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
   }
 
   Future<void> _submit() async {
-    debugPrint(
-      '[login] _submit tapped: isSubmitting=$_isSubmitting '
-      'idEmpty=${_idController.text.trim().isEmpty} '
-      'passwordEmpty=${_passwordController.text.isEmpty}',
-    );
     if (_isSubmitting) return;
     if (_idController.text.trim().isEmpty || _passwordController.text.isEmpty) {
       setState(() {});
@@ -42,11 +37,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
       await ref
           .read(loginErrorProvider.notifier)
           .submit(_idController.text.trim(), _passwordController.text);
-      debugPrint('[login] submit() completed without throwing');
-    } catch (error, stackTrace) {
-      debugPrint(
-        '[login] _submit caught: ${error.runtimeType} $error\n$stackTrace',
-      );
+    } catch (_) {
+      // loginErrorProvider가 화면에 보여줄 상태(errorText)와 로그를 이미 남겼다
+      // (#131) — 여기서는 finally의 _isSubmitting 해제만 필요해 별도 처리 없이 삼킨다.
     } finally {
       if (mounted) setState(() => _isSubmitting = false);
     }

--- a/frontend/lib/admin/features/settings/update_camp_controller.dart
+++ b/frontend/lib/admin/features/settings/update_camp_controller.dart
@@ -3,19 +3,16 @@ import 'dart:async';
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/camp_providers.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// PATCH camp 실패를 사용자 문구로 변환한다(camp_handler.go UpdateCampSettings 참고).
-/// 인식 못한 코드(네트워크 오류, 5xx 등)는 원문을 로그로만 남기고 일반 문구로 대체한다.
+/// 인식 못한 코드(네트워크 오류, 5xx 등)는 일반 문구로 대체한다. DioException은
+/// LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록하므로, 그 외 에러만
+/// 여기서 직접 로깅한다.
 String describeUpdateCampError(Object error, StackTrace stackTrace) {
   if (error is DioException) {
-    debugPrint(
-      '[update_camp] failed: type=${error.type} '
-      'statusCode=${error.response?.statusCode} '
-      'body=${error.response?.data}\n$stackTrace',
-    );
     final code = (error.response?.data is Map)
         ? (error.response?.data as Map)['code'] as String?
         : null;
@@ -28,7 +25,7 @@ String describeUpdateCampError(Object error, StackTrace stackTrace) {
         return '종료된 캠프는 설정을 수정할 수 없습니다.';
     }
   } else {
-    debugPrint('[update_camp] failed: $error\n$stackTrace');
+    appLogger.error('update_camp', 'failed', error: error, stackTrace: stackTrace);
   }
   return '저장에 실패했습니다. 잠시 후 다시 시도해주세요.';
 }

--- a/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
+++ b/frontend/lib/admin/features/setup_wizard/setup_wizard_provider.dart
@@ -1,5 +1,4 @@
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:cornermon/admin/features/setup_wizard/setup_wizard_state.dart';
@@ -8,6 +7,7 @@ import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/camp_providers.dart';
 import 'package:cornermon/shared/api/providers/corner_track_providers.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 
 part 'setup_wizard_provider.g.dart';
 
@@ -98,11 +98,13 @@ class SetupWizard extends _$SetupWizard {
         state = state.copyWith(createdCampId: campId);
       }
     } catch (error, stackTrace) {
-      debugPrint(
-        '[setup_wizard] _createCamp failed: '
-        '${error is DioException ? 'DioException type=${error.type} statusCode=${error.response?.statusCode} message=${error.message} error=${error.error}' : '${error.runtimeType} $error'}'
-        '\n$stackTrace',
-      );
+      // DioException은 LoggingInterceptor(#131)가 이미 기록한다 — 여기서 로깅이
+      // 필요한 건 네트워크 계층을 거치지 않는 에러(_createCamp의 StateError 등)뿐이다.
+      if (error is! DioException) {
+        ref
+            .read(appLoggerProvider)
+            .error('setup_wizard', '_createCamp failed', error: error, stackTrace: stackTrace);
+      }
       state = state.copyWith(
         isSubmitting: false,
         submitError: '캠프를 만들지 못했습니다. 다시 시도해주세요.',
@@ -146,11 +148,14 @@ class SetupWizard extends _$SetupWizard {
           ),
         );
       } catch (error, stackTrace) {
-        debugPrint(
-          '[setup_wizard] corner "${row.name}" failed: '
-          '${error is DioException ? 'DioException type=${error.type} statusCode=${error.response?.statusCode} message=${error.message} error=${error.error}' : '${error.runtimeType} $error'}'
-          '\n$stackTrace',
-        );
+        if (error is! DioException) {
+          ref.read(appLoggerProvider).error(
+            'setup_wizard',
+            'corner "${row.name}" failed',
+            error: error,
+            stackTrace: stackTrace,
+          );
+        }
         _replaceRow(
           index,
           row.copyWith(

--- a/frontend/lib/admin/features/start_camp/start_camp_button.dart
+++ b/frontend/lib/admin/features/start_camp/start_camp_button.dart
@@ -7,6 +7,7 @@ import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 
 class StartCampButton extends ConsumerWidget {
   const StartCampButton({super.key});
@@ -25,14 +26,11 @@ class StartCampButton extends ConsumerWidget {
 }
 
 /// POST start-camp 실패를 사용자 문구로 변환한다(camp_handler.go StartCamp 참고).
-/// 인식 못한 코드(네트워크 오류, 5xx 등)는 원문을 로그로만 남기고 일반 문구로 대체한다.
+/// 인식 못한 코드(네트워크 오류, 5xx 등)는 일반 문구로 대체한다. DioException은
+/// LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록하므로, 그 외 에러만
+/// 여기서 직접 로깅한다.
 String _describeStartError(Object error, StackTrace stackTrace) {
   if (error is DioException) {
-    debugPrint(
-      '[start_camp] failed: type=${error.type} '
-      'statusCode=${error.response?.statusCode} '
-      'body=${error.response?.data}\n$stackTrace',
-    );
     final code = (error.response?.data is Map)
         ? (error.response?.data as Map)['code'] as String?
         : null;
@@ -40,7 +38,7 @@ String _describeStartError(Object error, StackTrace stackTrace) {
       return '이미 시작되었거나 시작할 수 없는 캠프 상태입니다.';
     }
   } else {
-    debugPrint('[start_camp] failed: $error\n$stackTrace');
+    appLogger.error('start_camp', 'failed', error: error, stackTrace: stackTrace);
   }
   return '시작 확정에 실패했습니다. 잠시 후 다시 시도해주세요.';
 }

--- a/frontend/lib/facilitator/features/broadcast_inbox/broadcast_inbox_screen.dart
+++ b/frontend/lib/facilitator/features/broadcast_inbox/broadcast_inbox_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -11,6 +12,7 @@ import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/empty_state.dart';
 import 'package:cornermon/facilitator/session/facilitator_broadcast_provider.dart';
 import 'package:cornermon/facilitator/session/track_session_provider.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 import 'package:cornermon/shared/widgets/local_time_label.dart';
 
 /// B6 공지함 — 진입 시 안읽은 공지를 자동 읽음 처리한다(screen-spec-facilitator.md B6).
@@ -120,7 +122,15 @@ class _BroadcastInboxScreenState extends ConsumerState<BroadcastInboxScreen> {
       }
     } catch (error, stackTrace) {
       _readRequestedIds.removeAll(targets.map((m) => m.id!));
-      debugPrint('broadcast read request failed: $error\n$stackTrace');
+      // DioException은 LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록한다.
+      if (error is! DioException) {
+        ref.read(appLoggerProvider).error(
+          'broadcast_inbox',
+          'read request failed',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
       if (!mounted) return;
       ScaffoldMessenger.of(
         context,

--- a/frontend/lib/facilitator/features/device_pending/device_pending_screen.dart
+++ b/frontend/lib/facilitator/features/device_pending/device_pending_screen.dart
@@ -8,6 +8,7 @@ import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 import '../../session/device_trust_provider.dart';
 
 /// B0. 신뢰되지 않은 기기는 이 화면만 볼 수 있고 PIN 화면(B1)에 도달하지 못한다.
@@ -131,12 +132,8 @@ class _RegistrationFormState extends ConsumerState<_RegistrationForm> {
       await ref
           .read(deviceTrustProvider.notifier)
           .requestRegistration(code, displayName: displayName);
-    } on DioException catch (error, stackTrace) {
-      debugPrint(
-        '[device_pending] registration failed: type=${error.type} '
-        'statusCode=${error.response?.statusCode} '
-        'body=${error.response?.data}\n$stackTrace',
-      );
+    } on DioException catch (error) {
+      // DioException은 LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록한다.
       if (!mounted) return;
       // 등록 코드로 캠프를 찾지 못한 경우에만 404를 반환한다(device_handler.go
       // RegisterDevice: CampNotFound → 404). 그 외(네트워크 오류, 5xx 등)를 같은
@@ -147,7 +144,9 @@ class _RegistrationFormState extends ConsumerState<_RegistrationForm> {
             : '등록 요청에 실패했습니다. 잠시 후 다시 시도해주세요.',
       );
     } catch (error, stackTrace) {
-      debugPrint('[device_pending] registration failed: $error\n$stackTrace');
+      ref
+          .read(appLoggerProvider)
+          .error('device_pending', 'registration failed', error: error, stackTrace: stackTrace);
       if (!mounted) return;
       setState(() => _errorText = '등록 요청에 실패했습니다. 잠시 후 다시 시도해주세요.');
     } finally {

--- a/frontend/lib/facilitator/features/main_track/_main_track_header.dart
+++ b/frontend/lib/facilitator/features/main_track/_main_track_header.dart
@@ -113,11 +113,8 @@ Future<void> _confirmLogout(BuildContext context, WidgetRef ref) async {
 
   try {
     await ref.read(trackSessionProvider.notifier).logout();
-  } on DioException catch (error, stackTrace) {
-    debugPrint(
-      '[main_track_header] logout failed: type=${error.type} '
-      'statusCode=${error.response?.statusCode}\n$stackTrace',
-    );
+  } on DioException catch (error) {
+    // DioException은 LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록한다.
     if (isConnectionLost(error)) return; // 상단 ConnectionBanner가 이미 알린다
     if (!context.mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(

--- a/frontend/lib/facilitator/session/device_trust_provider.dart
+++ b/frontend/lib/facilitator/session/device_trust_provider.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:dio/dio.dart';
-import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:cornermon/shared/api/domain_aliases.dart';
@@ -105,12 +104,9 @@ class DeviceTrust extends _$DeviceTrust {
       _pollTimer?.cancel();
       await store.write(_deviceStatusKey, newStatus.name);
       state = AsyncData(newStatus);
-    } on DioException catch (error, stackTrace) {
+    } on DioException {
       // 일시적 네트워크 오류로 폴링 자체를 멈추지 않는다 — 다음 tick에 재시도.
-      debugPrint(
-        '[device_trust] polling failed: type=${error.type} '
-        'statusCode=${error.response?.statusCode}\n$stackTrace',
-      );
+      // LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록한다.
     }
   }
 
@@ -156,11 +152,8 @@ class DeviceTrust extends _$DeviceTrust {
       // 등록된 기기로 취급하지 않는다. 응답이 불완전한 경우만 위에서 보존한다.
       await clearRegistration();
       return DeviceTrustRecovery.cleared;
-    } on DioException catch (error, stackTrace) {
-      debugPrint(
-        '[device_trust] unauthorized recovery failed: '
-        'type=${error.type} statusCode=${error.response?.statusCode}\n$stackTrace',
-      );
+    } on DioException {
+      // LoggingInterceptor(#131)가 네트워크 계층에서 이미 기록한다.
       return DeviceTrustRecovery.unresolved;
     }
   }

--- a/frontend/lib/main_admin.dart
+++ b/frontend/lib/main_admin.dart
@@ -1,19 +1,44 @@
+import 'dart:async';
+import 'dart:ui';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'package:cornermon/admin/app.dart';
 import 'package:cornermon/admin/session/admin_session_token_source.dart';
 import 'package:cornermon/shared/auth/session_token_source.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
 
 void main() {
-  runApp(
-    ProviderScope(
-      overrides: [
-        sessionTokenSourceProvider.overrideWith(
-          (ref) => AdminSessionTokenSource(ref),
+  // 지금까지 캐치 안 된 예외는 어디에도 남지 않았다(#131 UC-3) — 세 소스
+  // (Flutter 프레임워크/위젯 빌드, 플랫폼 채널, 그 외 비동기 zone)를 전부 [appLogger]로
+  // 연결해 최소한 release 링버퍼에는 남게 한다.
+  runZonedGuarded(
+    () {
+      FlutterError.onError = (details) {
+        appLogger.error(
+          'flutter',
+          details.exceptionAsString(),
+          error: details.exception,
+          stackTrace: details.stack,
+        );
+      };
+      PlatformDispatcher.instance.onError = (error, stackTrace) {
+        appLogger.error('platform', '$error', error: error, stackTrace: stackTrace);
+        return true;
+      };
+      runApp(
+        ProviderScope(
+          overrides: [
+            sessionTokenSourceProvider.overrideWith(
+              (ref) => AdminSessionTokenSource(ref),
+            ),
+          ],
+          child: const AdminApp(),
         ),
-      ],
-      child: const AdminApp(),
-    ),
+      );
+    },
+    (error, stackTrace) =>
+        appLogger.error('zone', '$error', error: error, stackTrace: stackTrace),
   );
 }

--- a/frontend/lib/main_facilitator.dart
+++ b/frontend/lib/main_facilitator.dart
@@ -1,17 +1,42 @@
+import 'dart:async';
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'facilitator/app.dart';
 import 'facilitator/session/track_session_token_source.dart';
 import 'shared/auth/session_token_source.dart';
+import 'shared/logging/app_logger.dart';
 
 void main() {
-  runApp(
-    ProviderScope(
-      overrides: [
-        sessionTokenSourceProvider.overrideWith((ref) => TrackSessionTokenSource(ref)),
-      ],
-      child: const FacilitatorApp(),
-    ),
+  // 지금까지 캐치 안 된 예외는 어디에도 남지 않았다(#131 UC-3) — 세 소스
+  // (Flutter 프레임워크/위젯 빌드, 플랫폼 채널, 그 외 비동기 zone)를 전부 [appLogger]로
+  // 연결해 최소한 release 링버퍼에는 남게 한다.
+  runZonedGuarded(
+    () {
+      FlutterError.onError = (details) {
+        appLogger.error(
+          'flutter',
+          details.exceptionAsString(),
+          error: details.exception,
+          stackTrace: details.stack,
+        );
+      };
+      PlatformDispatcher.instance.onError = (error, stackTrace) {
+        appLogger.error('platform', '$error', error: error, stackTrace: stackTrace);
+        return true;
+      };
+      runApp(
+        ProviderScope(
+          overrides: [
+            sessionTokenSourceProvider.overrideWith((ref) => TrackSessionTokenSource(ref)),
+          ],
+          child: const FacilitatorApp(),
+        ),
+      );
+    },
+    (error, stackTrace) =>
+        appLogger.error('zone', '$error', error: error, stackTrace: stackTrace),
   );
 }

--- a/frontend/lib/shared/api/client/api_client.dart
+++ b/frontend/lib/shared/api/client/api_client.dart
@@ -3,7 +3,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import '../../config/app_env.dart';
 import 'auth_interceptor.dart';
+import 'logging_interceptor.dart';
 import 'status_fallback_interceptor.dart';
+import 'trace_id_interceptor.dart';
 
 part 'api_client.g.dart';
 
@@ -16,8 +18,13 @@ Dio apiClient(Ref ref) {
       receiveTimeout: const Duration(milliseconds: AppEnv.apiReceiveTimeoutMs),
     ),
   );
+  // 등록 순서 = 요청이 실제로 거치는 순서. LoggingInterceptor를 가장 마지막에 둬서
+  // AuthInterceptor의 401/409 재시도가 끝난 뒤 호출부로 나가는 최종 에러만 기록한다
+  // (#131 UC-1/UC-2).
+  dio.interceptors.add(const TraceIdInterceptor());
   dio.interceptors.add(AuthInterceptor(ref));
   dio.interceptors.add(StatusFallbackInterceptor());
+  dio.interceptors.add(LoggingInterceptor(ref));
 
   return dio;
 }

--- a/frontend/lib/shared/api/client/logging_interceptor.dart
+++ b/frontend/lib/shared/api/client/logging_interceptor.dart
@@ -1,0 +1,48 @@
+import 'package:dio/dio.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'package:cornermon/shared/api/dio_error.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
+
+/// 모든 Dio 에러를 [AppLogger]로 통일 기록한다(#131 UC-1) — 화면/프로바이더가 각자
+/// `debugPrint`를 재구현하지 않아도 API를 거치는 실패는 예외 없이 로그가 남는다.
+/// `AuthInterceptor`와 동일하게 `Ref`만 참조하며 admin/facilitator를 알지 못한다
+/// (00_overview.md §4-a). `Authorization` 헤더는 로그에 남기지 않는다(§목표⑦).
+///
+/// 태그는 요청 경로에서 파생한다(예: `/camps/{id}` → `camps`) — 화면 코드가 로깅
+/// 자체를 신경 쓸 필요가 없게 하는 것이 목적이라 화면별 커스텀 태그는 두지 않는다.
+class LoggingInterceptor extends Interceptor {
+  LoggingInterceptor(this.ref);
+
+  final Ref ref;
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    final logger = ref.read(appLoggerProvider);
+    final tag = _tagFor(err.requestOptions.path);
+    final traceId = traceIdOf(err);
+    if (isConnectionLost(err)) {
+      logger.warn(
+        tag,
+        describeDioError(err),
+        error: err,
+        stackTrace: err.stackTrace,
+        traceId: traceId,
+      );
+    } else {
+      logger.error(
+        tag,
+        describeDioError(err),
+        error: err,
+        stackTrace: err.stackTrace,
+        traceId: traceId,
+      );
+    }
+    handler.next(err);
+  }
+
+  String _tagFor(String path) {
+    final segments = path.split('/').where((segment) => segment.isNotEmpty);
+    return segments.isEmpty ? 'network' : segments.first;
+  }
+}

--- a/frontend/lib/shared/api/client/trace_id_interceptor.dart
+++ b/frontend/lib/shared/api/client/trace_id_interceptor.dart
@@ -1,6 +1,5 @@
-import 'dart:math';
-
 import 'package:dio/dio.dart';
+import 'package:uuid/uuid.dart';
 
 /// 매 요청에 `X-Trace-ID`를 선(先)생성해 부착한다(#131 UC-2). 백엔드가 헤더를 이미
 /// 받으면 그대로 재사용하고 없으면 새로 만들어 echo하므로
@@ -8,24 +7,18 @@ import 'package:dio/dio.dart';
 /// 먼저 값을 채워두면 커넥션 자체가 실패해 응답을 못 받는 극단적 상황에서도 프론트가
 /// 자기 생성 ID로 로그를 남길 수 있다. `AuthInterceptor`보다 먼저 등록해야 한다.
 ///
-/// 백엔드는 이 값의 형식을 검증하지 않고 그대로 echo/로깅만 하므로(§조사 사실), 새 pub
-/// 의존성(uuid 등) 없이 `dart:math`만으로 충분히 유일한 32자리 hex 문자열을 만든다.
+/// UUIDv4(완전 랜덤)가 아니라 v7을 쓴다 — v7은 앞부분에 밀리초 타임스탬프를 담아
+/// 문자열을 그대로 정렬하면 생성 시각 순서에 가까워진다. 진단 로그 export(#131 P1,
+/// 별도 이슈)나 여러 요청을 한꺼번에 훑어볼 때 시간순 정렬 이점이 있어서다. 백엔드도
+/// 같은 이유로 자체 생성 fallback을 v7로 맞췄다(logger_middleware.go).
 class TraceIdInterceptor extends Interceptor {
-  const TraceIdInterceptor({this.random});
+  const TraceIdInterceptor({this.uuid = const Uuid()});
 
-  final Random? random;
+  final Uuid uuid;
 
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    options.headers.putIfAbsent('X-Trace-ID', () => _generate());
+    options.headers.putIfAbsent('X-Trace-ID', uuid.v7);
     handler.next(options);
-  }
-
-  String _generate() {
-    final source = random ?? Random.secure();
-    return List.generate(
-      32,
-      (_) => source.nextInt(16).toRadixString(16),
-    ).join();
   }
 }

--- a/frontend/lib/shared/api/client/trace_id_interceptor.dart
+++ b/frontend/lib/shared/api/client/trace_id_interceptor.dart
@@ -1,0 +1,31 @@
+import 'dart:math';
+
+import 'package:dio/dio.dart';
+
+/// 매 요청에 `X-Trace-ID`를 선(先)생성해 부착한다(#131 UC-2). 백엔드가 헤더를 이미
+/// 받으면 그대로 재사용하고 없으면 새로 만들어 echo하므로
+/// (`backend/internal/infrastructure/web/logger_middleware.go:25-28`), 이 인터셉터가 항상
+/// 먼저 값을 채워두면 커넥션 자체가 실패해 응답을 못 받는 극단적 상황에서도 프론트가
+/// 자기 생성 ID로 로그를 남길 수 있다. `AuthInterceptor`보다 먼저 등록해야 한다.
+///
+/// 백엔드는 이 값의 형식을 검증하지 않고 그대로 echo/로깅만 하므로(§조사 사실), 새 pub
+/// 의존성(uuid 등) 없이 `dart:math`만으로 충분히 유일한 32자리 hex 문자열을 만든다.
+class TraceIdInterceptor extends Interceptor {
+  const TraceIdInterceptor({this.random});
+
+  final Random? random;
+
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    options.headers.putIfAbsent('X-Trace-ID', () => _generate());
+    handler.next(options);
+  }
+
+  String _generate() {
+    final source = random ?? Random.secure();
+    return List.generate(
+      32,
+      (_) => source.nextInt(16).toRadixString(16),
+    ).join();
+  }
+}

--- a/frontend/lib/shared/api/dio_error.dart
+++ b/frontend/lib/shared/api/dio_error.dart
@@ -21,6 +21,19 @@ bool isConnectionLost(DioException error) => switch (error.type) {
 /// 코드를 없애거나 이름을 바꿨을 때 이 switch의 case가 컴파일 경고 없이 죽지 않는다.
 /// 클라이언트가 재생성 전이라 모르는 코드(백엔드가 새로 추가한 값 등)는 null로 취급해
 /// 호출부의 기본 분기를 타게 한다.
+/// DioException을 사람이 읽을 수 있는 단일 진단 문자열로 통일 포맷팅한다(#131).
+/// `login_error_provider.dart`/`setup_wizard_provider.dart`/`device_pending_screen.dart`
+/// 등이 각자 재구현하던 `type/statusCode/message/error` 추출을 대체한다.
+String describeDioError(DioException error) =>
+    'DioException type=${error.type} statusCode=${error.response?.statusCode} '
+    'message=${error.message} error=${error.error}';
+
+/// 응답 헤더의 `X-Trace-ID`를 추출한다(#131) — 백엔드가 요청에 실려온 값을 그대로
+/// echo하므로(`logger_middleware.go`) 성공/실패 모두에 남는다. 커넥션 자체가 실패해
+/// 응답을 못 받은 경우(`error.response == null`)는 null.
+String? traceIdOf(DioException error) =>
+    error.response?.headers.value('X-Trace-ID');
+
 ErrorCode? errorCodeOf(DioException error) {
   final data = error.response?.data;
   final body = data is Map ? data : null;

--- a/frontend/lib/shared/logging/app_logger.dart
+++ b/frontend/lib/shared/logging/app_logger.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:cornermon/shared/logging/log_level.dart';
+import 'package:cornermon/shared/logging/log_record.dart';
+import 'package:cornermon/shared/logging/log_ring_buffer.dart';
+
+/// 화면·프로바이더·네트워크 계층이 각자 `debugPrint`를 재구현하던 것(#131)을 대체하는
+/// 단일 진입점. `debug`/`info`는 `kDebugMode`에서만 콘솔에 출력하고 링버퍼에는 남기지
+/// 않는다. `warn`/`error`는 빌드 모드와 무관하게 항상 [LogRingBuffer]에 적재해, release
+/// 빌드에서 실기기 필드 이슈가 나도 사후에 최근 이력을 확인할 수 있게 한다(§목표①).
+///
+/// `main()`의 `runZonedGuarded`/`FlutterError.onError`(§UC-3)처럼 `ProviderScope` 밖에서도
+/// 써야 하는 지점이 있어 전역 싱글턴 [appLogger]로 두고, Riverpod 경계 안에서는
+/// [appLoggerProvider]로 접근해 테스트에서 override할 수 있게 한다.
+class AppLogger {
+  AppLogger({LogRingBuffer? buffer}) : _buffer = buffer ?? LogRingBuffer();
+
+  final LogRingBuffer _buffer;
+
+  void debug(String tag, String message) => _console(LogLevel.debug, tag, message);
+
+  void info(String tag, String message) => _console(LogLevel.info, tag, message);
+
+  void warn(
+    String tag,
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    String? traceId,
+  }) => _record(LogLevel.warn, tag, message, error, stackTrace, traceId);
+
+  void error(
+    String tag,
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    String? traceId,
+  }) => _record(LogLevel.error, tag, message, error, stackTrace, traceId);
+
+  List<LogRecord> exportSnapshot() => _buffer.snapshot();
+
+  void _console(LogLevel level, String tag, String message) {
+    if (!kDebugMode) return;
+    debugPrint(
+      LogRecord(
+        level: level,
+        tag: tag,
+        message: message,
+        timestamp: DateTime.now(),
+      ).toLine(),
+    );
+  }
+
+  void _record(
+    LogLevel level,
+    String tag,
+    String message,
+    Object? error,
+    StackTrace? stackTrace,
+    String? traceId,
+  ) {
+    final record = LogRecord(
+      level: level,
+      tag: tag,
+      message: message,
+      timestamp: DateTime.now(),
+      traceId: traceId,
+      error: error,
+      stackTrace: stackTrace,
+    );
+    _buffer.add(record);
+    debugPrint(record.toLine());
+  }
+}
+
+/// `main()`의 zone/전역 예외 핸들러(§UC-3)처럼 `ProviderScope` 밖에서 로깅해야 하는
+/// 지점을 위한 전역 인스턴스. 앱 전체에서 이 인스턴스 하나만 존재해야 하므로
+/// [appLoggerProvider]도 항상 이 인스턴스를 반환한다.
+final appLogger = AppLogger();
+
+/// Riverpod 경계 안(인터셉터, 화면, 컨트롤러)에서는 이 provider로 접근한다 — 테스트에서
+/// override해 링버퍼를 검증할 수 있다.
+final appLoggerProvider = Provider<AppLogger>((ref) => appLogger);

--- a/frontend/lib/shared/logging/log_level.dart
+++ b/frontend/lib/shared/logging/log_level.dart
@@ -1,0 +1,4 @@
+/// 로그 레벨. `debug`/`info`는 개발 중 진단용이라 release 빌드 콘솔·링버퍼 어디에도
+/// 남기지 않는다. `warn`/`error`는 필드 사후진단(#131)의 대상이라 release에서도
+/// [LogRingBuffer]에 항상 적재된다 — 자세한 정책은 §레벨 정책(2026-07-22 플랜 문서) 참고.
+enum LogLevel { debug, info, warn, error }

--- a/frontend/lib/shared/logging/log_record.dart
+++ b/frontend/lib/shared/logging/log_record.dart
@@ -1,0 +1,42 @@
+import 'package:cornermon/shared/logging/log_level.dart';
+
+/// 로그 한 건. [LogRingBuffer] 적재 및 진단 내보내기(#131 UC-4, 별도 이슈) 시
+/// 텍스트 직렬화의 단위다.
+class LogRecord {
+  const LogRecord({
+    required this.level,
+    required this.tag,
+    required this.message,
+    required this.timestamp,
+    this.traceId,
+    this.error,
+    this.stackTrace,
+  });
+
+  final LogLevel level;
+
+  /// 로그 발생 지점 식별자. 화면/프로바이더 태그(`login`, `setup_wizard` 등) 또는
+  /// 네트워크 계층 태그(`network`)로 쓴다.
+  final String tag;
+  final String message;
+  final DateTime timestamp;
+
+  /// 백엔드 구조화 로그(`trace_id`)와 이 사건을 상관관계 매칭하기 위한 값
+  /// (`backend/internal/infrastructure/web/logger_middleware.go`의 `X-Trace-ID` echo와 대칭).
+  /// 네트워크 계층을 거치지 않은 로그(전역 예외 등)는 null.
+  final String? traceId;
+  final Object? error;
+  final StackTrace? stackTrace;
+
+  /// 콘솔 출력·내보내기 텍스트 모두가 공유하는 한 줄(+스택트레이스) 포맷.
+  String toLine() {
+    final levelTag = level.name.toUpperCase();
+    final traceSuffix = traceId == null ? '' : ' trace_id=$traceId';
+    final buffer = StringBuffer(
+      '${timestamp.toIso8601String()} [$levelTag][$tag] $message$traceSuffix',
+    );
+    if (error != null) buffer.write('\n$error');
+    if (stackTrace != null) buffer.write('\n$stackTrace');
+    return buffer.toString();
+  }
+}

--- a/frontend/lib/shared/logging/log_ring_buffer.dart
+++ b/frontend/lib/shared/logging/log_ring_buffer.dart
@@ -1,0 +1,24 @@
+import 'dart:collection';
+
+import 'package:cornermon/shared/logging/log_record.dart';
+
+/// 최근 [capacity]건의 [LogRecord]를 FIFO로 보관한다 — 진단 내보내기(#131 UC-4, 별도
+/// 이슈)의 데이터 소스. `warn`/`error`만 적재 대상이며 그 판단은 [AppLogger]의 책임이다.
+class LogRingBuffer {
+  LogRingBuffer({this.capacity = 500}) : assert(capacity > 0);
+
+  final int capacity;
+  final Queue<LogRecord> _records = Queue<LogRecord>();
+
+  void add(LogRecord record) {
+    _records.addLast(record);
+    while (_records.length > capacity) {
+      _records.removeFirst();
+    }
+  }
+
+  List<LogRecord> snapshot() => List.unmodifiable(_records);
+
+  String exportAsText() =>
+      _records.map((record) => record.toLine()).join('\n\n');
+}

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -1098,7 +1098,7 @@ packages:
     source: hosted
     version: "3.1.5"
   uuid:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: uuid
       sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   go_router: ^17.3.0
   flutter_secure_storage: ^10.3.1
   dio: ^5.5.0
+  uuid: ^4.5.0 # TraceIdInterceptor에서 요청별 trace_id(UUIDv7) 생성에 직접 사용 — 기존엔 전이 의존성이었음
   mobile_scanner: ^7.4.0
   collection: ^1.19.0 # B3 QR 스캔 onDetect에서 barcodes.firstOrNull 직접 사용 — 기존엔 전이 의존성이었음
   one_of: '>=1.5.0 <2.0.0' # cornermon_api_gen이 이미 이 버전으로 고정 — oneOf 요청 바디(방문 시작) 구성에 직접 필요

--- a/frontend/test/shared/api/client/logging_interceptor_test.dart
+++ b/frontend/test/shared/api/client/logging_interceptor_test.dart
@@ -1,0 +1,117 @@
+import 'dart:typed_data';
+
+import 'package:cornermon/shared/api/client/logging_interceptor.dart';
+import 'package:cornermon/shared/logging/app_logger.dart';
+import 'package:cornermon/shared/logging/log_level.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// LoggingInterceptor는 riverpod_annotation의 Ref만 받는다 — ProviderContainer 자체는
+// Ref가 아니므로, 컨테이너 안에서 자신의 Ref를 그대로 노출하는 provider를 거쳐 얻는다.
+final _refProvider = Provider<Ref>((ref) => ref);
+
+/// 실제 요청을 보내지 않고 항상 주어진 [DioException]으로 실패하는 어댑터.
+/// SseClient 테스트(`sse_client_test.dart`)의 `_ThrowingAdapter`와 같은 패턴이다 — Dio가
+/// 인터셉터 체인/핸들러의 Future 완료를 정상적으로 관리해 주므로, `ErrorInterceptorHandler`를
+/// 직접 만들어 호출할 때 생기는 "완료된 핸들러의 Future를 아무도 기다리지 않는" 부작용이 없다.
+class _ThrowingAdapter implements HttpClientAdapter {
+  _ThrowingAdapter(this._build);
+
+  final DioException Function(RequestOptions options) _build;
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    throw _build(options);
+  }
+}
+
+Dio _buildDio(DioException Function(RequestOptions options) build, Ref ref) {
+  return Dio(BaseOptions(baseUrl: 'http://test.local'))
+    ..httpClientAdapter = _ThrowingAdapter(build)
+    ..interceptors.add(LoggingInterceptor(ref));
+}
+
+void main() {
+  group('LoggingInterceptor', () {
+    late AppLogger logger;
+    late ProviderContainer container;
+    late Ref ref;
+
+    setUp(() {
+      logger = AppLogger();
+      container = ProviderContainer(
+        overrides: [appLoggerProvider.overrideWithValue(logger)],
+      );
+      ref = container.read(_refProvider);
+    });
+
+    tearDown(() => container.dispose());
+
+    test('ShoudLogAsWarnWhenConnectionIsLost', () async {
+      // arrange
+      final dio = _buildDio(
+        (options) => DioException(
+          requestOptions: options,
+          type: DioExceptionType.connectionTimeout,
+        ),
+        ref,
+      );
+
+      // act
+      await expectLater(dio.get<void>('/camps/1'), throwsA(isA<DioException>()));
+
+      // assert
+      final record = logger.exportSnapshot().single;
+      expect(record.level, LogLevel.warn);
+      expect(record.tag, 'camps');
+    });
+
+    test('ShoudLogAsErrorWhenServerRespondsWithFailureStatus', () async {
+      // arrange
+      final dio = _buildDio(
+        (options) => DioException(
+          requestOptions: options,
+          type: DioExceptionType.badResponse,
+          response: Response(
+            requestOptions: options,
+            statusCode: 404,
+            headers: Headers.fromMap({
+              'X-Trace-ID': ['trace-abc'],
+            }),
+          ),
+        ),
+        ref,
+      );
+
+      // act
+      await expectLater(dio.get<void>('/corners/5'), throwsA(isA<DioException>()));
+
+      // assert
+      final record = logger.exportSnapshot().single;
+      expect(record.level, LogLevel.error);
+      expect(record.tag, 'corners');
+      expect(record.traceId, 'trace-abc');
+      expect(record.message, contains('statusCode=404'));
+    });
+
+    test('ShoudForwardErrorToNextInterceptorAfterLogging', () async {
+      // arrange
+      final dio = _buildDio(
+        (options) => DioException(requestOptions: options),
+        ref,
+      );
+
+      // act / assert — 로깅 후에도 호출부까지 원래 DioException이 전파되어야 한다.
+      await expectLater(dio.get<void>('/camps'), throwsA(isA<DioException>()));
+      expect(logger.exportSnapshot(), hasLength(1));
+    });
+  });
+}

--- a/frontend/test/shared/api/client/trace_id_interceptor_test.dart
+++ b/frontend/test/shared/api/client/trace_id_interceptor_test.dart
@@ -1,12 +1,11 @@
-import 'dart:math';
-
 import 'package:cornermon/shared/api/client/trace_id_interceptor.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:uuid/uuid.dart';
 
 void main() {
   group('TraceIdInterceptor', () {
-    test('ShoudAttachTraceIdHeaderWhenRequestHasNone', () {
+    test('ShoudAttachValidUuidV7WhenRequestHasNone', () {
       // arrange
       final interceptor = const TraceIdInterceptor();
       final options = RequestOptions(path: '/camps');
@@ -16,13 +15,14 @@ void main() {
       interceptor.onRequest(options, handler);
 
       // assert
-      expect(options.headers['X-Trace-ID'], isA<String>());
-      expect((options.headers['X-Trace-ID'] as String).length, 32);
+      final traceId = options.headers['X-Trace-ID'] as String;
+      expect(Uuid.isValidUUID(fromString: traceId), isTrue);
+      expect(traceId[14], '7'); // version nibble — RFC9562 UUIDv7
     });
 
     test('ShoudKeepExistingTraceIdWhenAlreadySet', () {
       // arrange
-      final interceptor = TraceIdInterceptor(random: Random(1));
+      final interceptor = const TraceIdInterceptor();
       final options = RequestOptions(
         path: '/camps',
         headers: {'X-Trace-ID': 'caller-provided'},
@@ -49,5 +49,27 @@ void main() {
       // assert
       expect(first.headers['X-Trace-ID'], isNot(second.headers['X-Trace-ID']));
     });
+
+    test(
+      'ShoudGenerateLexicographicallyIncreasingIdsWhenCalledAcrossMilliseconds',
+      () async {
+        // arrange — v7의 핵심 이점: 밀리초 타임스탬프가 앞부분에 있어 서로 다른
+        // 밀리초에 생성된 값끼리는 문자열 정렬이 생성 순서와 일치한다(같은 밀리초
+        // 안에서는 무작위 하위 비트라 순서를 보장하지 않는다 — RFC9562).
+        final interceptor = const TraceIdInterceptor();
+        final ids = <String>[];
+
+        // act
+        for (var i = 0; i < 3; i++) {
+          final options = RequestOptions(path: '/camps');
+          interceptor.onRequest(options, RequestInterceptorHandler());
+          ids.add(options.headers['X-Trace-ID'] as String);
+          await Future<void>.delayed(const Duration(milliseconds: 2));
+        }
+
+        // assert
+        expect(ids, orderedEquals([...ids]..sort()));
+      },
+    );
   });
 }

--- a/frontend/test/shared/api/client/trace_id_interceptor_test.dart
+++ b/frontend/test/shared/api/client/trace_id_interceptor_test.dart
@@ -1,0 +1,53 @@
+import 'dart:math';
+
+import 'package:cornermon/shared/api/client/trace_id_interceptor.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('TraceIdInterceptor', () {
+    test('ShoudAttachTraceIdHeaderWhenRequestHasNone', () {
+      // arrange
+      final interceptor = const TraceIdInterceptor();
+      final options = RequestOptions(path: '/camps');
+      final handler = RequestInterceptorHandler();
+
+      // act
+      interceptor.onRequest(options, handler);
+
+      // assert
+      expect(options.headers['X-Trace-ID'], isA<String>());
+      expect((options.headers['X-Trace-ID'] as String).length, 32);
+    });
+
+    test('ShoudKeepExistingTraceIdWhenAlreadySet', () {
+      // arrange
+      final interceptor = TraceIdInterceptor(random: Random(1));
+      final options = RequestOptions(
+        path: '/camps',
+        headers: {'X-Trace-ID': 'caller-provided'},
+      );
+      final handler = RequestInterceptorHandler();
+
+      // act
+      interceptor.onRequest(options, handler);
+
+      // assert
+      expect(options.headers['X-Trace-ID'], 'caller-provided');
+    });
+
+    test('ShoudGenerateDifferentTraceIdsWhenCalledTwice', () {
+      // arrange
+      final interceptor = const TraceIdInterceptor();
+      final first = RequestOptions(path: '/camps');
+      final second = RequestOptions(path: '/corners');
+
+      // act
+      interceptor.onRequest(first, RequestInterceptorHandler());
+      interceptor.onRequest(second, RequestInterceptorHandler());
+
+      // assert
+      expect(first.headers['X-Trace-ID'], isNot(second.headers['X-Trace-ID']));
+    });
+  });
+}

--- a/frontend/test/shared/api/dio_error_test.dart
+++ b/frontend/test/shared/api/dio_error_test.dart
@@ -1,0 +1,71 @@
+import 'package:cornermon/shared/api/dio_error.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('describeDioError', () {
+    test('ShoudIncludeTypeStatusCodeAndMessageWhenResponseExists', () {
+      // arrange
+      final requestOptions = RequestOptions(path: '/camps');
+      final error = DioException(
+        requestOptions: requestOptions,
+        type: DioExceptionType.badResponse,
+        message: 'Http status error [404]',
+        response: Response(requestOptions: requestOptions, statusCode: 404),
+      );
+
+      // act
+      final description = describeDioError(error);
+
+      // assert
+      expect(description, contains('type=DioExceptionType.badResponse'));
+      expect(description, contains('statusCode=404'));
+      expect(description, contains('message=Http status error [404]'));
+    });
+
+    test('ShoudOmitStatusCodeWhenResponseIsAbsent', () {
+      // arrange
+      final requestOptions = RequestOptions(path: '/camps');
+      final error = DioException(
+        requestOptions: requestOptions,
+        type: DioExceptionType.connectionTimeout,
+      );
+
+      // act
+      final description = describeDioError(error);
+
+      // assert
+      expect(description, contains('statusCode=null'));
+    });
+  });
+
+  group('traceIdOf', () {
+    test('ShoudReturnHeaderValueWhenResponseHasTraceId', () {
+      // arrange
+      final requestOptions = RequestOptions(path: '/camps');
+      final error = DioException(
+        requestOptions: requestOptions,
+        response: Response(
+          requestOptions: requestOptions,
+          headers: Headers.fromMap({
+            'X-Trace-ID': ['trace-xyz'],
+          }),
+        ),
+      );
+
+      // act / assert
+      expect(traceIdOf(error), 'trace-xyz');
+    });
+
+    test('ShoudReturnNullWhenNoResponseWasReceived', () {
+      // arrange
+      final error = DioException(
+        requestOptions: RequestOptions(path: '/camps'),
+        type: DioExceptionType.connectionError,
+      );
+
+      // act / assert
+      expect(traceIdOf(error), isNull);
+    });
+  });
+}

--- a/frontend/test/shared/logging/app_logger_test.dart
+++ b/frontend/test/shared/logging/app_logger_test.dart
@@ -1,0 +1,51 @@
+import 'package:cornermon/shared/logging/app_logger.dart';
+import 'package:cornermon/shared/logging/log_level.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppLogger', () {
+    test('ShoudNotAppendToBufferWhenLevelIsDebugOrInfo', () {
+      // arrange
+      final logger = AppLogger();
+
+      // act
+      logger.debug('tag', 'debug message');
+      logger.info('tag', 'info message');
+
+      // assert
+      expect(logger.exportSnapshot(), isEmpty);
+    });
+
+    test('ShoudAppendToBufferWhenLevelIsWarnOrError', () {
+      // arrange
+      final logger = AppLogger();
+
+      // act
+      logger.warn('tag', 'warn message');
+      logger.error('tag', 'error message');
+
+      // assert
+      final snapshot = logger.exportSnapshot();
+      expect(snapshot.map((record) => record.level), [
+        LogLevel.warn,
+        LogLevel.error,
+      ]);
+    });
+
+    test('ShoudKeepErrorAndStackTraceWhenProvided', () {
+      // arrange
+      final logger = AppLogger();
+      final error = StateError('boom');
+      final stackTrace = StackTrace.current;
+
+      // act
+      logger.error('tag', 'failed', error: error, stackTrace: stackTrace, traceId: 'trace-1');
+
+      // assert
+      final record = logger.exportSnapshot().single;
+      expect(record.error, error);
+      expect(record.stackTrace, stackTrace);
+      expect(record.traceId, 'trace-1');
+    });
+  });
+}

--- a/frontend/test/shared/logging/log_ring_buffer_test.dart
+++ b/frontend/test/shared/logging/log_ring_buffer_test.dart
@@ -1,0 +1,61 @@
+import 'package:cornermon/shared/logging/log_level.dart';
+import 'package:cornermon/shared/logging/log_record.dart';
+import 'package:cornermon/shared/logging/log_ring_buffer.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+LogRecord _record(String message) => LogRecord(
+  level: LogLevel.error,
+  tag: 'test',
+  message: message,
+  timestamp: DateTime.utc(2026, 1, 1),
+);
+
+void main() {
+  group('LogRingBuffer', () {
+    test('ShoudEvictOldestWhenCapacityExceeded', () {
+      // arrange
+      final buffer = LogRingBuffer(capacity: 2);
+
+      // act
+      buffer.add(_record('a'));
+      buffer.add(_record('b'));
+      buffer.add(_record('c'));
+
+      // assert
+      expect(
+        buffer.snapshot().map((record) => record.message),
+        ['b', 'c'],
+      );
+    });
+
+    test('ShoudPreserveInsertionOrderWhenWithinCapacity', () {
+      // arrange
+      final buffer = LogRingBuffer();
+
+      // act
+      buffer.add(_record('first'));
+      buffer.add(_record('second'));
+
+      // assert
+      expect(
+        buffer.snapshot().map((record) => record.message),
+        ['first', 'second'],
+      );
+    });
+
+    test('ShoudJoinRecordLinesWhenExportingAsText', () {
+      // arrange
+      final buffer = LogRingBuffer()
+        ..add(_record('first'))
+        ..add(_record('second'));
+
+      // act
+      final text = buffer.exportAsText();
+
+      // assert
+      expect(text, contains('first'));
+      expect(text, contains('second'));
+      expect(text.indexOf('first'), lessThan(text.indexOf('second')));
+    });
+  });
+}


### PR DESCRIPTION
## 요약
#224 (Phase B) 위에 쌓는 세 번째 PR. `20260722_issue131_frontend_logging_policy_plan_.md` Phase C — 이슈 #131의 마지막 P0 단계.

- `main_admin.dart`/`main_facilitator.dart`: `runZonedGuarded` + `FlutterError.onError` + `PlatformDispatcher.onError`로, 지금까지 어디에도 남지 않던 미처리 예외(위젯 빌드 예외, 플랫폼 채널 예외, 그 외 비동기 zone 예외)를 `appLogger`로 연결한다.
- 이슈 본문이 지목한 4곳(`login_screen`/`login_error_provider`/`setup_wizard_provider`/`device_pending_screen`)과, 원 플랜 조사에서 확인된 동일 패턴의 나머지 10곳(`admin_management`×2, `device_manage`, `camp_list`, `start_camp`, `end_camp`, `update_camp`, `main_track_header`, `device_trust`×2, `broadcast_inbox`) 전부 정리:
  - `DioException` 분기의 `debugPrint`는 Phase B의 `LoggingInterceptor`가 네트워크 계층에서 이미 기록하므로 전부 제거.
  - `DioException`이 아닌 에러(예: `setup_wizard`의 `StateError` — 인터셉터를 거치지 않는 로컬 에러)만 `ref.read(appLoggerProvider)` 또는(ref가 없는 순수 함수는) 전역 `appLogger`로 직접 기록.
  - 사용자에게 보여주는 SnackBar/상단 배너 분기 로직(`DEVELOPER_GUIDE.md` §4 규칙)은 전부 그대로 유지 — 로깅만 걷어냈다.

## 범위 밖 (P1, 별도 이슈)
플랜의 UC-4(진단 로그 내보내기, `share_plus` 기반 화면)는 이번 P0 범위에서 제외했다 — 사용자와 협의된 범위.

## 종료 조건
- [x] `flutter analyze lib/` 이슈 없음 — `packages/cornermon_api_gen`의 기존 17개 warning은 이 변경과 무관(main에도 이미 있음, 의존성 버전 드리프트)
- [x] `flutter test` 전체 314 passed, 2 failed — 두 실패(`end_camp_bar_button_test.dart`, `track_event_stream_test.dart`) 모두 main에도 이미 있는 사전 실패로 이 변경과 무관함을 baseline 비교로 확인
- [x] 승인/거절/회수, 로그인, 로그아웃, 등록 등 기존 사용자 피드백(SnackBar/배너) 코드 경로 무수정 확인(diff 리뷰)

## 실기기 테스트 (후속)
- facilitator 실기기에서 네트워크 차단으로 connectionTimeout 재현 → 이제 `LoggingInterceptor`가 warn으로 남기는지 확인 필요(#131의 원 계기였던 시나리오)

Refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)