### PR TITLE
feat: trace_id 자체 생성 fallback을 UUIDv7로 변경

### DIFF
--- a/backend/internal/infrastructure/web/logger_middleware.go
+++ b/backend/internal/infrastructure/web/logger_middleware.go
@@ -21,10 +21,19 @@ func Logger() echo.MiddlewareFunc {
 			start := time.Now()
 			c.Set(requestStartKey, start)
 
-			// Trace ID 추출 또는 생성
+			// Trace ID 추출 또는 생성. 프론트가 항상 UUIDv7로 선생성해서 보내므로
+			// (frontend/lib/shared/api/client/trace_id_interceptor.dart) 여기서 새로
+			// 만드는 경우(#131) — 헤더가 아예 없는 요청 — 도 v7로 맞춘다: 문자열 정렬이
+			// 생성 시각 순서에 가까워져 로그를 훑어볼 때 도움이 된다.
 			traceID := c.Request().Header.Get("X-Trace-ID")
 			if traceID == "" {
-				traceID = uuid.New().String()
+				if generated, err := uuid.NewV7(); err == nil {
+					traceID = generated.String()
+				} else {
+					// crypto/rand 실패 등 극히 드문 경우에만 v4로 대체 — trace_id
+					// 생성 실패로 요청 자체를 막지 않는다.
+					traceID = uuid.New().String()
+				}
 			}
 
 			// Context에 trace_id 바인딩

--- a/backend/internal/infrastructure/web/logger_middleware_test.go
+++ b/backend/internal/infrastructure/web/logger_middleware_test.go
@@ -12,6 +12,7 @@ import (
 	"cornermon/backend/internal/errs"
 	"cornermon/backend/internal/infrastructure/web"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
 
@@ -46,6 +47,52 @@ func TestLoggerShouldLogTraceIDExactlyOnceWhenRequestSucceeds(t *testing.T) {
 	logLine := buf.String()
 	if count := strings.Count(logLine, `"trace_id"`); count != 1 {
 		t.Errorf("expected trace_id to appear exactly once, got %d in: %s", count, logLine)
+	}
+}
+
+func TestLoggerShouldGenerateUuidV7TraceIDWhenHeaderIsAbsent(t *testing.T) {
+	// arrange — 헤더가 없어 미들웨어가 자체 생성하는 경로(#131): 프론트가 이미 매
+	// 요청 X-Trace-ID를 보내므로 실제로는 프론트 없는 클라이언트(curl 등)에서만 탄다.
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/camps", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	next := func(c echo.Context) error { return c.NoContent(http.StatusOK) }
+
+	// act
+	if err := web.Logger()(next)(c); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// assert — 문자열 정렬이 생성 시각 순서에 가깝도록 v4(완전 랜덤)가 아닌 v7이어야 한다.
+	traceID := rec.Header().Get("X-Trace-ID")
+	parsed, err := uuid.Parse(traceID)
+	if err != nil {
+		t.Fatalf("expected X-Trace-ID to be a valid UUID, got %q: %v", traceID, err)
+	}
+	if parsed.Version() != 7 {
+		t.Errorf("expected UUID version 7, got version %d (%q)", parsed.Version(), traceID)
+	}
+}
+
+func TestLoggerShouldReuseClientProvidedTraceIDWhenHeaderIsPresent(t *testing.T) {
+	// arrange — 프론트의 TraceIdInterceptor가 이미 v7로 선생성해 보내는 일반적인
+	// 경로(#131): 클라이언트가 보낸 값은 형식과 무관하게 그대로 재사용해야 한다.
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/camps", nil)
+	req.Header.Set("X-Trace-ID", "client-provided-id")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	next := func(c echo.Context) error { return c.NoContent(http.StatusOK) }
+
+	// act
+	if err := web.Logger()(next)(c); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// assert
+	if got := rec.Header().Get("X-Trace-ID"); got != "client-provided-id" {
+		t.Errorf("expected X-Trace-ID to be echoed back unchanged, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## 요약
#224 (프론트 `TraceIdInterceptor`, #131 Phase B) 리뷰 중 나온 제안 반영. 프론트가 매 요청 `X-Trace-ID`를 UUIDv7로 선생성해 보내도록 바뀌면서, 헤더가 없어 백엔드가 자체 생성하는 fallback 경로(`logger_middleware.go`)도 형식을 맞춘다.

- v4(완전 랜덤) → v7: 문자열 정렬이 생성 시각 순서에 가까워져 로그를 훑어볼 때 도움이 됨
- `crypto/rand` 실패 등 극히 드문 에러 경로만 v4로 폴백 — trace_id 생성 실패로 요청 자체가 막히지 않도록 함
- 클라이언트가 이미 값을 보낸 경우(프론트 앱의 대다수 트래픽)는 형식과 무관하게 그대로 재사용하는 기존 동작 그대로 — 이 PR은 fallback 경로에만 영향을 줌

## 종료 조건
- [x] `TestLoggerShouldGenerateUuidV7TraceIDWhenHeaderIsAbsent`: 헤더 없을 때 응답 `X-Trace-ID`가 유효한 UUID이고 버전이 7인지 검증
- [x] `TestLoggerShouldReuseClientProvidedTraceIDWhenHeaderIsPresent`: 클라이언트 제공 값은 형식과 무관하게 그대로 echo되는 기존 동작 회귀 확인
- [x] 기존 `TestLoggerShouldLogTraceIDExactlyOnceWhenRequestSucceeds`/`...DurationMs...` 무수정 통과
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` 클린
- [x] `go test ./...` 전체 통과

Refs #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)