### PR TITLE
fix : 기기 등록 코드 생성을 campId 해싱에서 랜덤 방식으로 교체

### DIFF
--- a/backend/db/migrations/20260819100000_update_registration_code_comment.down.sql
+++ b/backend/db/migrations/20260819100000_update_registration_code_comment.down.sql
@@ -1,0 +1,1 @@
+COMMENT ON COLUMN camps.registration_code IS '기기 등록 코드 (campId 해시, Crockford Base32, 진행자에게 공유)';

--- a/backend/db/migrations/20260819100000_update_registration_code_comment.up.sql
+++ b/backend/db/migrations/20260819100000_update_registration_code_comment.up.sql
@@ -1,0 +1,1 @@
+COMMENT ON COLUMN camps.registration_code IS '기기 등록 코드 (crypto/rand 무작위 생성, Crockford Base32, 진행자에게 공유)';

--- a/backend/docs/artifacts/plan/20260819_기기등록코드_랜덤생성_plan_.md
+++ b/backend/docs/artifacts/plan/20260819_기기등록코드_랜덤생성_plan_.md
@@ -1,0 +1,130 @@
+# 기기 등록 코드 생성 방식 개선: campId 해싱 → 랜덤 생성
+
+이슈: [#217](https://github.com/lsjtop10/cornermon/issues/217)
+
+## 배경 / 근본 원인
+
+현재 `domain.GenerateRegistrationCode(id CampID)`는 `campId`를 SHA-256으로 해싱한 뒤 앞
+40비트를 Crockford Base32로 인코딩해 등록 코드를 만든다
+(`backend/internal/domain/registration_code.go`, 설계 근거:
+`backend/docs/artifacts/plan/20260717_기기등록코드_campid해시_plan_.md`).
+
+`campId`는 서버가 `uuid.NewString()`으로 생성하지만 이 자체가 비밀값으로 설계된 적이 없고
+(`GET /camps` 응답에도 그대로 노출됨), 등록 코드가 `campId`의 **결정적 함수**이기만 하면
+공격자가 알아낸/추측한 `campId`로 오프라인에서 동일한 해시를 재계산해 등록 코드를 얻어낼 수
+있다. 즉 등록 코드의 비밀성이 "SHA-256의 일방향성"이 아니라 "campId의 비밀성"에 의존하게
+되는데, campId는 애초에 비밀이 아니므로 이 역참조 설계 자체가 취약점이다.
+
+## 해결 방향
+
+등록 코드를 campId의 함수로 계산하지 않고, Camp 생성 시점에 `crypto/rand`로 직접 무작위
+생성한다. 8자 Crockford Base32(40비트, 약 1.1조 조합) 길이는 기존과 동일하게 유지해 DB 컬럼
+크기(`VARCHAR(20)`)·API 계약·프론트 UX(코드 입력 UI)에 영향이 없도록 한다.
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-1: 캠프 생성 시 등록 코드 무작위 생성 | `domain.NewCamp` 호출 시 `crypto/rand`로 40비트를 뽑아 Crockford Base32 8자 코드 생성, `camps.registration_code`에 저장 | **프로덕션 핵심 로직** |
+| P1 | UC-2: 등록 코드 조회/등록 플로우 | 기존 `GetByRegistrationCode` 역참조, `POST /device-registrations` 흐름은 변경 없음(코드 생성 방식만 교체) | 회귀 방지 |
+
+## 설계
+
+### Domain Layer
+
+#### `backend/internal/domain/registration_code.go` (기존 파일 수정)
+
+```go
+package domain
+
+// 책임: crypto/rand로 40비트를 뽑아 Crockford Base32 8자 등록 코드를 생성한다.
+// 더 이상 campId를 입력으로 받지 않는다 — campId는 GET /camps 응답에 그대로 노출되는
+// 비밀 아닌 값이라, 이를 해시 입력으로 쓰면 등록 코드를 역산 가능하게 만드는 취약점이 된다
+// (이슈 #217). crypto/rand 실패는 OS 엔트로피 소스 고갈 등 프로세스 자체가 불안정한
+// 상황이므로 panic으로 즉시 드러낸다(기존 설계와 동일하게 무입력·무의존 순수 함수 유지).
+func GenerateRegistrationCode() string
+```
+
+- `crypto/rand.Read`로 5바이트(40비트)를 채운 뒤 기존과 동일한 `registrationCodeEncoding`
+  (Crockford Base32, `NoPadding`)으로 인코딩한다.
+- 문자셋·길이(8자)는 기존과 동일하게 유지 — DB 컬럼 크기, API 응답 예시, 프론트 UX 변경 불필요.
+- 시그니처에서 `CampID` 파라미터 제거(더 이상 campId를 입력받지 않음이 타입으로도 드러남).
+
+#### `backend/internal/domain/camp.go` (기존 파일 수정)
+
+- `NewCamp` 내부 호출을 `GenerateRegistrationCode(id)` → `GenerateRegistrationCode()`로 변경.
+  나머지 로직(검증 규칙, 필드 조립)은 변경 없음.
+
+### Infrastructure — Postgres
+
+- 코드/쿼리 변경 없음. 기존 `registration_code VARCHAR(20) NOT NULL UNIQUE` 제약을 그대로
+  사용한다. 40비트 무작위 값 공간(약 1.1조)에 캠프 생성 빈도(운영 도구 특성상 수백~수천
+  건/lifetime)를 고려하면 충돌 확률은 무시 가능한 수준 — 기존 해시 기반 설계도 동일한 전제
+  (해시 충돌 미대응)였으므로 이번 변경으로 새로 생기는 리스크가 아니다. 재시도 로직은 범위
+  밖(스코프 최소화, 이슈 본문의 요구사항인 "생성 방식 교체"에 집중).
+- 컬럼 코멘트 갱신: 현재 코멘트("기기 등록 코드 (campId 해시, Crockford Base32, 진행자에게
+  공유)")가 이번 변경 후 사실과 어긋나므로, `COMMENT ON COLUMN` 갱신만 담은 신규 마이그레이션을
+  추가한다(개발자 가이드 9.1 — 새 마이그레이션 파일 쌍).
+
+  `backend/db/migrations/20260819100000_update_registration_code_comment.up.sql`
+  ```sql
+  COMMENT ON COLUMN camps.registration_code IS '기기 등록 코드 (crypto/rand 무작위 생성, Crockford Base32, 진행자에게 공유)';
+  ```
+
+  `backend/db/migrations/20260819100000_update_registration_code_comment.down.sql`
+  ```sql
+  COMMENT ON COLUMN camps.registration_code IS '기기 등록 코드 (campId 해시, Crockford Base32, 진행자에게 공유)';
+  ```
+
+### API 계약
+
+- 요청/응답 스키마 변경 없음(`CampResponse.registrationCode` 필드 형태는 동일 — 여전히 8자
+  Crockford Base32 문자열). `api/swagger.yaml` 갱신 불필요.
+
+### 문서 갱신
+
+- `docs/technical-design.md`, `docs/domain-model.md`에 이전 plan(#108)이 "campId 해시" 방식으로
+  등록 코드 생성을 설명한 부분이 있다면 "무작위 생성"으로 갱신한다(그리드 서치 후 존재 시에만
+  수정, 없으면 스킵).
+
+## Phase
+
+| 순서 | 작업 | 파일 |
+| --- | --- | --- |
+| A-1 | `GenerateRegistrationCode()` 시그니처 변경(무입력, crypto/rand 사용) | `backend/internal/domain/registration_code.go` |
+| A-2 | `NewCamp` 호출부 수정 | `backend/internal/domain/camp.go` |
+| A-3 | 테스트 갱신: 결정성 테스트 제거, 무작위성(연속 호출 시 다른 값)·문자셋·길이 테스트로 교체 | `backend/internal/domain/registration_code_test.go` |
+| A-4 | `camp_test.go`의 `GenerateRegistrationCode("camp-1")` 결정성 비교 제거 → 문자셋/길이 검증으로 교체 | `backend/internal/domain/camp_test.go` |
+| B-1 | 컬럼 코멘트 갱신 마이그레이션 추가 | `backend/db/migrations/20260819100000_*.{up,down}.sql` |
+| C-1 | `docs/technical-design.md`/`docs/domain-model.md` 중 "campId 해시" 서술 검색 후 필요 시 갱신 | `docs/technical-design.md`, `docs/domain-model.md` |
+| D-1 | `gofmt -w . && go vet ./... && go test ./...` 통과 확인 | 전체 |
+
+## 검증 방법
+
+- **자동화 테스트**:
+  - `domain`: `GenerateRegistrationCode()`를 반복 호출했을 때 8자 Crockford Base32 알파벳
+    범위 내 문자만 포함하는지, 연속 호출 결과가 서로 다른지(무작위성 스모크 테스트).
+  - `NewCamp`가 여전히 8자 Crockford Base32 코드를 채워 반환하는지(`camp_test.go`).
+  - 기존 `device_trust_test.go`(등록 코드로 campId 역참조) 회귀 없이 통과하는지 재확인.
+- **수동 검증**: `make reset-postgres` → 서버 기동 → `POST /camps`로 캠프 2개 생성 → 두
+  응답의 `registrationCode`가 서로 다르고, 더 이상 campId로부터 예측 불가능한지(동일 campId를
+  다시 넣어도 같은 코드가 나오지 않음, 애초에 campId 재사용 불가하므로 참고용) 확인.
+
+## 검증 체크리스트
+
+### 아키텍처 검증
+- [x] `domain` 패키지에서 `infrastructure` import 없음 (`crypto/rand`는 표준 라이브러리)
+- [x] 신규 포트/인터페이스 추가 없음(기존 구조 그대로)
+
+### 유즈케이스 검증
+- [x] UC-1: 캠프 생성 시 등록 코드가 campId와 무관하게 무작위로 생성되어 저장됨
+- [x] UC-2: 등록 코드 기반 조회/기기 등록 플로우 회귀 없음
+
+### 종료 조건 (이슈 #217 원문 대조)
+- [x] 등록 코드 생성이 campId 기반 해싱이 아닌 랜덤 생성 방식으로 교체됨
+- [x] 등록 코드 발급/조회 로직(백엔드) 반영 완료
+- [x] 필요 시 `api/openapi.yaml` 및 관련 plan 문서 갱신(이번 변경은 API 계약 불변이라 해당 없음
+      — 이유를 PR에 명시)
+
+### 부수 확인
+- [x] `gofmt -w . && go vet ./... && go test ./...` 통과

--- a/backend/internal/domain/camp.go
+++ b/backend/internal/domain/camp.go
@@ -34,7 +34,7 @@ func NewCamp(id CampID, name string, startAt, endAt time.Time) (*Camp, error) {
 	}
 	return &Camp{
 		id:                   id,
-		registrationCode:     GenerateRegistrationCode(id),
+		registrationCode:     GenerateRegistrationCode(),
 		name:                 name,
 		startAt:              startAt,
 		endAt:                endAt,

--- a/backend/internal/domain/camp_test.go
+++ b/backend/internal/domain/camp_test.go
@@ -2,6 +2,7 @@ package domain_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -208,8 +209,14 @@ func TestNewCampShoudCreatePendingCampWhenValid(t *testing.T) {
 	if camp.Status() != domain.CampPending || camp.BottleneckMinSamples() != 3 || camp.BottleneckRatioPct() != 20 {
 		t.Fatalf("unexpected defaults: %+v", camp)
 	}
-	if camp.RegistrationCode() != domain.GenerateRegistrationCode("camp-1") {
-		t.Fatalf("expected deterministic registration code, got %q", camp.RegistrationCode())
+	const crockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+	if len(camp.RegistrationCode()) != 8 {
+		t.Fatalf("expected 8-character registration code, got %q", camp.RegistrationCode())
+	}
+	for _, r := range camp.RegistrationCode() {
+		if !strings.ContainsRune(crockfordAlphabet, r) {
+			t.Fatalf("registration code %q contains character %q outside Crockford Base32 alphabet", camp.RegistrationCode(), r)
+		}
 	}
 }
 

--- a/backend/internal/domain/registration_code.go
+++ b/backend/internal/domain/registration_code.go
@@ -1,8 +1,9 @@
 package domain
 
 import (
-	"crypto/sha256"
+	"crypto/rand"
 	"encoding/base32"
+	"fmt"
 )
 
 // crockfordAlphabet은 가독성을 위해 혼동되기 쉬운 I/L/O/U를 제외한 Crockford Base32 문자셋입니다.
@@ -10,14 +11,19 @@ const crockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 var registrationCodeEncoding = base32.NewEncoding(crockfordAlphabet).WithPadding(base32.NoPadding)
 
-// registrationCodeHashBytes는 40비트(8자 Crockford Base32)로 인코딩하기 위해 사용하는 해시 길이입니다.
-const registrationCodeHashBytes = 5
+// registrationCodeRandomBytes는 40비트(8자 Crockford Base32)로 인코딩하기 위해 사용하는
+// 난수 바이트 길이입니다.
+const registrationCodeRandomBytes = 5
 
-// GenerateRegistrationCode는 campId를 SHA-256으로 해싱한 뒤 앞 5바이트(40비트)를
-// Crockford Base32로 인코딩해 8자 등록 코드를 결정적으로 생성합니다.
-// 같은 campId는 항상 같은 코드를 반환하므로, 매 요청마다 재계산하지 않고 Camp 생성 시점에
-// 한 번 계산해 저장하는 용도로 쓰입니다.
-func GenerateRegistrationCode(id CampID) string {
-	sum := sha256.Sum256([]byte(id))
-	return registrationCodeEncoding.EncodeToString(sum[:registrationCodeHashBytes])
+// GenerateRegistrationCode는 crypto/rand로 40비트를 뽑아 Crockford Base32 8자 등록 코드를
+// 생성합니다. campId를 입력으로 받지 않습니다 — campId는 GET /camps 응답에 그대로 노출되는
+// 비밀 아닌 값이라, 과거처럼 이를 해싱해 코드를 만들면 campId를 아는 사람이 등록 코드를
+// 역산할 수 있게 됩니다(이슈 #217). crypto/rand 실패는 OS 엔트로피 소스 고갈 등 프로세스
+// 자체가 불안정한 상황이므로 즉시 panic으로 드러냅니다.
+func GenerateRegistrationCode() string {
+	buf := make([]byte, registrationCodeRandomBytes)
+	if _, err := rand.Read(buf); err != nil {
+		panic(fmt.Sprintf("domain: failed to generate registration code: %v", err))
+	}
+	return registrationCodeEncoding.EncodeToString(buf)
 }

--- a/backend/internal/domain/registration_code_test.go
+++ b/backend/internal/domain/registration_code_test.go
@@ -7,42 +7,25 @@ import (
 	"cornermon/backend/internal/domain"
 )
 
-func TestGenerateRegistrationCodeShoudReturnSameCodeWhenCalledTwiceWithSameCampID(t *testing.T) {
-	// Arrange
-	campID := domain.CampID("camp-1")
+func TestGenerateRegistrationCodeShoudReturnDifferentCodeWhenCalledTwice(t *testing.T) {
+	// Arrange (no campId input anymore — code is random, not derived from any value)
 
 	// Act
-	first := domain.GenerateRegistrationCode(campID)
-	second := domain.GenerateRegistrationCode(campID)
+	first := domain.GenerateRegistrationCode()
+	second := domain.GenerateRegistrationCode()
 
 	// Assert
-	if first != second {
-		t.Fatalf("expected deterministic code, got %q and %q", first, second)
-	}
-}
-
-func TestGenerateRegistrationCodeShoudReturnDifferentCodeWhenCampIDDiffers(t *testing.T) {
-	// Arrange
-	campA := domain.CampID("camp-1")
-	campB := domain.CampID("camp-2")
-
-	// Act
-	codeA := domain.GenerateRegistrationCode(campA)
-	codeB := domain.GenerateRegistrationCode(campB)
-
-	// Assert
-	if codeA == codeB {
-		t.Fatalf("expected different codes for different camp IDs, got %q for both", codeA)
+	if first == second {
+		t.Fatalf("expected two random calls to differ (40-bit space), got %q for both", first)
 	}
 }
 
 func TestGenerateRegistrationCodeShoudReturnEightCrockfordCharsWhenCalled(t *testing.T) {
 	// Arrange
-	campID := domain.CampID("camp-1")
 	const crockfordAlphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 	// Act
-	code := domain.GenerateRegistrationCode(campID)
+	code := domain.GenerateRegistrationCode()
 
 	// Assert
 	if len(code) != 8 {

--- a/backend/internal/infrastructure/postgres/db/models.go
+++ b/backend/internal/infrastructure/postgres/db/models.go
@@ -111,7 +111,7 @@ type Camp struct {
 	BottleneckMinSamples int32 `json:"bottleneck_min_samples"`
 	// 목표 시간 대비 지연 비율(%) 임계값
 	BottleneckRatioPct int32 `json:"bottleneck_ratio_pct"`
-	// 기기 등록 코드 (campId 해시, Crockford Base32, 진행자에게 공유)
+	// 기기 등록 코드 (crypto/rand 무작위 생성, Crockford Base32, 진행자에게 공유)
 	RegistrationCode string `json:"registration_code"`
 }
 

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -90,12 +90,13 @@
 
 #### 2.4-b 기기 신뢰 모델 (Device Trust)
 - **신뢰 장치 게이트**: 신뢰 토큰(서버 발급)이 없는 미등록 기기는 PIN 입력 화면에 도달할 수 없다.
-- **등록 코드(campId 해시)**: 진행자는 campId 원문을 알 수 없다. `Camp` 생성 시점에 campId를
-  SHA-256으로 해싱한 뒤 앞 40비트를 Crockford Base32(`0123456789ABCDEFGHJKMNPQRSTVWXYZ`, I/L/O/U
-  제외)로 인코딩한 8자 `registrationCode`를 결정적으로 생성해 캠프 레코드에 함께 저장한다.
-  관리자는 이 코드를 관리자 화면에서 확인해 진행자에게 구두/메신저 등으로 전달하고, 진행자는
-  기기 등록 시 이 코드를 입력한다. 서버는 `registrationCode`로 campId를 O(1) 역참조한다(매 요청
-  재해싱 없음).
+- **등록 코드(무작위 생성)**: 진행자는 campId 원문을 알 수 없다. `Camp` 생성 시점에
+  `crypto/rand`로 40비트를 뽑아 Crockford Base32(`0123456789ABCDEFGHJKMNPQRSTVWXYZ`, I/L/O/U
+  제외)로 인코딩한 8자 `registrationCode`를 생성해 캠프 레코드에 함께 저장한다. campId처럼
+  다른 API 응답에 노출되는 값을 해싱해 만들지 않는다 — campId는 비밀이 아니므로 그 값의
+  결정적 함수인 코드는 역산 가능해 취약점이 되기 때문이다(이슈 #217). 관리자는 이 코드를
+  관리자 화면에서 확인해 진행자에게 구두/메신저 등으로 전달하고, 진행자는 기기 등록 시 이
+  코드를 입력한다. 서버는 `registrationCode`로 campId를 O(1) 역참조한다.
 - **토큰 상태 관리**: 토큰은 `PENDING` -> `APPROVED` 또는 `REJECTED`로 상태가 관리되며, 분실 시 `REVOKED`로 신뢰를 철회할 수 있다.
 - **지연 정책**: 이미 승인된 신뢰 기기에서 PIN 입력이 연속 실패하는 경우에만 점증형 지연(스로틀링) 정책이 적용된다. (구체적 시나리오는 `scenarios.md` Feature 3-b 참고)
 

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -138,8 +138,8 @@ DB 트랜잭션 경계는 `usecase` 계층이 잡고, 위반 시 롤백한다 �
 
 **1단계: 기기 등록 요청 및 토큰 발급**
 - 클라이언트(모바일 앱)가 최초 실행 시 `POST /device-registrations`를 호출하며, 요청 body에 `registrationCode`(등록 코드), `deviceName`(기기명), `deviceModel`(기종), `displayName`(관리자 화면 표시용 이름, 진행자 입력)을 담는다.
-  - `campId` 원문은 진행자에게 노출되지 않는다(§domain-model.md 2.4-b). 대신 `Camp` 생성 시점에 campId를 SHA-256 해싱한 뒤 Crockford Base32로 인코딩해 미리 계산해 둔 `registrationCode`를 관리자가 진행자에게 구두/메신저로 공유한다.
-  - 서버는 `registrationCode` → `campId`를 `camps.registration_code` 유니크 컬럼으로 O(1) 조회해 역참조한다. 매 요청마다 해시를 재계산하지 않는다.
+  - `campId` 원문은 진행자에게 노출되지 않는다(§domain-model.md 2.4-b). 대신 `Camp` 생성 시점에 `crypto/rand`로 무작위 생성해 Crockford Base32로 인코딩한 `registrationCode`를 관리자가 진행자에게 구두/메신저로 공유한다. campId를 해싱해 만들지 않는 이유는 campId 자체가 다른 API 응답에 노출되는 비밀 아닌 값이라, 해시 입력으로 쓰면 코드를 역산할 수 있기 때문이다(이슈 #217).
+  - 서버는 `registrationCode` → `campId`를 `camps.registration_code` 유니크 컬럼으로 O(1) 조회해 역참조한다.
   - 일치하는 캠프가 없으면 404(`CAMP_NOT_FOUND`), 캠프가 `ACTIVE`가 아니면 400(`INVALID_TRANSITION`)을 반환한다.
 - 서버는 opaque token을 생성해 DB에는 **SHA256 해시만 저장**하고, **평문 토큰은 응답 body의 `deviceToken` 필드로만 한 번 전달**한다(`DeviceRegistrationCreatedResponse`).
   - 이 토큰을 "한 번만" 클라이언트에 노출하는 이유: 클라이언트가 안전하게 저장(iOS Keychain, Android Keystore)해야 하고, 이후로는 모든 요청에서 `Authorization: Bearer <토큰>`으로 사용한다. 평문은 절대 두 번째 회선을 타지 않는다.


### PR DESCRIPTION
## 변경 사항과 이유

`domain.GenerateRegistrationCode`가 `campId`를 SHA-256으로 해싱한 뒤 Crockford Base32로
인코딩해 등록 코드를 만드는 **결정적 함수**였다. `campId`는 `GET /camps` 응답에 그대로
노출되는 비밀 아닌 값이라, 이를 아는 사람은 오프라인에서 동일한 해시를 재계산해 등록 코드를
역산할 수 있었다 — 등록 코드의 비밀성이 사실상 존재하지 않는 셈이었다(이슈 #217).

`GenerateRegistrationCode()`가 더 이상 `campId`를 입력받지 않고, `crypto/rand`로 직접
40비트를 뽑아 8자 Crockford Base32 코드를 생성하도록 교체했다.

- 코드 길이(8자)·문자셋·DB 컬럼 크기(`VARCHAR(20)`)·API 응답 필드 형태는 변경 없음 →
  API 계약 불변, `api/swagger.yaml` 갱신 불필요.
- `registration_code` 컬럼의 `COMMENT`만 갱신하는 마이그레이션 추가, `sqlc generate` 반영.
- `docs/domain-model.md` §2.4-b, `docs/technical-design.md`의 "campId 해시" 서술을
  "무작위 생성"으로 갱신.
- Plan: `backend/docs/artifacts/plan/20260819_기기등록코드_랜덤생성_plan_.md`

## 종료 조건 증명

- [x] 등록 코드 생성이 campId 기반 해싱이 아닌 `crypto/rand` 랜덤 방식으로 교체됨
      (`backend/internal/domain/registration_code.go`)
- [x] `gofmt -l .` 무출력 / `go vet ./...` / `go test ./...` 전체 통과
- [x] `sqlc diff` 확인 후 생성물 반영(코멘트 텍스트만 변경, 스키마 타입 영향 없음)
- [x] 관련 설계 문서(§2.4-b, technical-design.md) 갱신

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)