### PR TITLE
feat : 공지/다이렉트 메시지 수신 시 소리+진동 피드백 추가

### DIFF
--- a/frontend/build.yaml
+++ b/frontend/build.yaml
@@ -10,8 +10,10 @@ targets:
             - lib/shared/api/sse/*.dart
             - lib/shared/auth/*.dart
             - lib/shared/network/*.dart
+            - lib/shared/util/*.dart
             - lib/facilitator/session/*.dart
             - lib/facilitator/features/**/*.dart
             - lib/facilitator/router/*.dart
+            - lib/facilitator/realtime/*.dart
             - lib/admin/session/*.dart
             - lib/admin/features/**/*.dart

--- a/frontend/docs/artifacts/plan/20260819_issue_218_notice_message_feedback_plan_.md
+++ b/frontend/docs/artifacts/plan/20260819_issue_218_notice_message_feedback_plan_.md
@@ -1,0 +1,93 @@
+# Issue #218 — 공지/메시지 수신 소리·진동 피드백 구현 계획
+
+- 이슈: [#218](https://github.com/lsjtop10/cornermon/issues/218)
+- 작성일: 2026-08-19
+- 범위: **프런트엔드만**. 백엔드/API 계약 변경 없음(기존 `messages_changed` SSE 이벤트만 사용).
+
+## 0. 사용자 확정 사항 (질의응답 결과)
+
+- 대상 이벤트: admin은 `messages_changed`(공지+트랙 다이렉트 메시지 목록 갱신 트리거) 전체, facilitator는
+  camp scope(공지)와 자기 트랙 scope(다이렉트 메시지) 모두.
+- 구현 방식: 신규 패키지 의존성 추가하지 않음. Flutter 내장 `HapticFeedback.vibrate()` +
+  `SystemSound.play(SystemSoundType.alert)`만 사용 — 커스텀 사운드 asset을 재생하는
+  `audioplayers` 등은 무음 모드를 자동으로 존중하지 않아(미디어 카테고리) 오히려 요구사항에
+  안 맞음. 내장 API는 OS UI 사운드 채널을 쓰므로 무음/진동/소리 모드가 자동으로 반영된다.
+- 설정 토글 없음 — 항상 켜짐(운영 중 공지 놓침 방지가 이슈 목적).
+- 백그라운드/비활성 상태(앱 스위처 등) 피드백은 범위 밖 — SSE 연결 자체가 포그라운드에서만
+  유지되는 현재 구조상 자연히 포그라운드 한정. OS 푸시 알림 연동은 별도 이슈.
+
+## 1. 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+| --- | --- | --- | --- |
+| **P0** | UC-218-1: 관리자 공지/메시지 피드백 | admin이 `messages_changed`를 받으면 기존 invalidate에 더해 소리+진동 피드백을 준다. | **프로덕션 핵심 UX** |
+| **P0** | UC-218-2: 진행자 공지 피드백 | facilitator가 camp scope `messages_changed`(공지)를 받으면 피드백을 준다. | **프로덕션 핵심 UX** |
+| **P0** | UC-218-3: 진행자 다이렉트 메시지 피드백 | facilitator가 자기 트랙 scope `messages_changed`(1:1 메시지)를 받으면 피드백을 준다. | **프로덕션 핵심 UX** |
+| P1 | UC-218-4: 무음/진동 모드 자동 반영 | 기기가 무음이면 소리 없이 진동만(또는 무음), 벨소리 모드면 소리+진동 — OS 기본 동작에 위임하고 앱이 별도 판단하지 않는다. | **내장 API로 자동 충족, 별도 테스트 불필요(플랫폼 채널 동작이라 유닛 테스트 범위 밖)** |
+
+## 2. 객체 및 책임
+
+### 2.1 `NoticeFeedback` — 신규 (`lib/shared/util/notice_feedback.dart`)
+
+`AdminEventCoordinator`/`TrackEventCoordinator`가 직접 `HapticFeedback`/`SystemSound`를 호출하면
+테스트에서 플랫폼 채널 mocking이 코디네이터 테스트마다 중복된다. 얇은 인터페이스로 감싸 provider로
+주입하고, 기존 `admin_event_coordinator_test.dart`/`track_event_coordinator_test.dart`의
+override 관례(`FakeTrackSession` 등)를 그대로 따른다.
+
+```dart
+// 책임: 공지/메시지 수신 시 OS 소리+진동 피드백 트리거
+abstract class NoticeFeedback {
+  void notify();
+}
+
+class SystemNoticeFeedback implements NoticeFeedback {
+  @override
+  void notify() {
+    HapticFeedback.vibrate();
+    SystemSound.play(SystemSoundType.alert);
+  }
+}
+
+@Riverpod(keepAlive: true)
+NoticeFeedback noticeFeedback(Ref ref) => SystemNoticeFeedback();
+```
+
+- `keepAlive: true` 이유: `apiClientProvider`와 동일하게 앱 전체에서 하나만 있으면 되는
+  무상태 서비스이며, 코디네이터가 이벤트 처리 중 잠깐 `ref.read`하는 용도라 autoDispose로 두면
+  불필요한 재생성이 반복된다(§2.1 DEVELOPER_GUIDE 패턴 준용).
+- 테스트에서는 `noticeFeedbackProvider.overrideWith((ref) => fakeNoticeFeedback)`로 호출 횟수만
+  기록하는 fake로 교체한다(`FakeDeviceTrust`와 동일 패턴).
+
+### 2.2 `AdminEventCoordinator._handle` — 기존 파일 확장
+
+```dart
+case SseEventEventEnum.messagesChanged:
+  ref.invalidate(broadcastMessageListProvider(campId));
+  ref.invalidate(trackMessageListProvider);
+  ref.read(noticeFeedbackProvider).notify();
+  break;
+```
+
+### 2.3 `TrackEventCoordinator._handle` — 기존 파일 확장
+
+`messagesChanged` 분기의 camp scope(공지)/isThisTrack(다이렉트) 두 경로 모두에서 각각
+`ref.read(noticeFeedbackProvider).notify()`를 호출한다(두 경로는 서로 다른 종류의 메시지이므로
+분기 안에서 각자 호출 — 실수로 다른 트랙向 이벤트에 반응하지 않도록 기존 scope 판별 로직은
+그대로 둔다).
+
+## 3. 검증 체크리스트
+
+### 3.1 유즈케이스 검증
+
+- [x] UC-218-1: admin 코디네이터 테스트에 `messages_changed` 수신 시 `fakeNoticeFeedback.notifyCalls == 1` 확인 추가
+- [x] UC-218-2: facilitator 코디네이터 테스트에 camp scope `messages_changed` 수신 시 피드백 호출 확인 추가
+- [x] UC-218-3: facilitator 코디네이터 테스트에 자기 트랙 scope `messages_changed` 수신 시 피드백 호출 확인, 다른 트랙 scope에는 호출 안 됨을 함께 확인(기존 scope 방어 로직 회귀 검증)
+- [x] `flutter analyze` — **pre-existing** 17건 경고(자동생성 `cornermon_api_gen` unused_import 16건 + `pubspec.yaml` unnecessary_dev_dependency 1건)가 main에도 이미 있어 `docker-check`가 이 이슈와 무관하게 실패함을 main에서 직접 재현·확인함. 내 변경 파일 자체에는 analyze 이슈 없음. `docker-check`의 hard-fail 게이트를 여는 것은 이슈 #218 범위 밖이라 손대지 않음
+- [x] `make docker-build` 후 컨테이너에서 `flutter test`(변경 테스트 2개 파일 21건 전부 통과) + 전체 스위트 실행 — `end_camp_bar_button_test.dart`/`track_event_stream_test.dart` 실패 2건은 main에서도 동일하게 재현되는 기존 flaky 테스트로 확인, 내 변경과 무관 — 로컬 flutter 직접 실행 금지 지침 준수(모두 docker 컨테이너 내부에서 실행)
+
+### 3.2 아키텍처 검증
+
+- [x] 신규 패키지 의존성 추가 없음(`pubspec.yaml` 불변)
+- [x] `domain`/API 계약(`api/openapi.yaml`) 변경 없음
+- [x] 코디네이터가 플랫폼 API를 직접 호출하지 않고 `NoticeFeedback` 인터페이스에만 의존
+- [x] (계획에 없던 추가 발견) `build.yaml`의 `riverpod_generator.generate_for.include`에 `lib/facilitator/realtime/*.dart`와 `lib/shared/util/*.dart`가 누락되어 있어 `track_event_coordinator.g.dart`가 build_runner 재생성 시 삭제되는 기존 버그를 발견 — 이번 변경이 그 경로를 직접 건드리므로 함께 수정(두 glob 추가)하지 않으면 커밋 가능한 빌드를 만들 수 없어 범위에 포함시킴

--- a/frontend/lib/admin/session/admin_event_coordinator.dart
+++ b/frontend/lib/admin/session/admin_event_coordinator.dart
@@ -10,6 +10,7 @@ import 'package:cornermon/shared/api/providers/message_providers.dart';
 import 'package:cornermon/shared/api/providers/report_providers.dart';
 import 'package:cornermon/shared/api/sse/admin_event_stream.dart';
 import 'package:cornermon/shared/design_system/widgets/connection_banner.dart';
+import 'package:cornermon/shared/util/notice_feedback.dart';
 import 'admin_session_provider.dart';
 import 'selected_camp_provider.dart';
 
@@ -75,6 +76,7 @@ class AdminEventCoordinator extends _$AdminEventCoordinator {
       case SseEventEventEnum.messagesChanged:
         ref.invalidate(broadcastMessageListProvider(campId));
         ref.invalidate(trackMessageListProvider);
+        ref.read(noticeFeedbackProvider).notify();
         break;
       case SseEventEventEnum.trackDeleted:
         ref.invalidate(trackListProvider(campId));

--- a/frontend/lib/admin/session/admin_event_coordinator.g.dart
+++ b/frontend/lib/admin/session/admin_event_coordinator.g.dart
@@ -74,7 +74,7 @@ final class AdminEventCoordinatorProvider
 }
 
 String _$adminEventCoordinatorHash() =>
-    r'6817c7f6fb7eec2cbcec538e5b019c35c63096de';
+    r'5dc5f18e8427d5d303658ad88a59278a0beb29e4';
 
 /// `TrackEventCoordinator`(`facilitator/features/main_track/track_event_coordinator.dart`)와
 /// 대칭되는 admin 쪽 디스패처. 연결상태 자체는 이미 `AdminConnection`

--- a/frontend/lib/facilitator/realtime/track_event_coordinator.dart
+++ b/frontend/lib/facilitator/realtime/track_event_coordinator.dart
@@ -11,6 +11,7 @@ import 'package:cornermon/shared/api/sse/track_event_stream.dart';
 import 'package:cornermon/facilitator/session/device_trust_provider.dart';
 import 'package:cornermon/facilitator/session/facilitator_broadcast_provider.dart';
 import 'package:cornermon/facilitator/session/track_session_provider.dart';
+import 'package:cornermon/shared/util/notice_feedback.dart';
 
 part 'track_event_coordinator.g.dart';
 
@@ -70,10 +71,12 @@ class TrackEventCoordinator extends _$TrackEventCoordinator {
             // facade provider만 invalidate하면 내부 family의 HTTP 결과는 캐시된 채다.
             // 실제 목록 provider를 무효화해야 새 공지를 GET으로 다시 가져온다.
             ref.invalidate(broadcastMessageListProvider(campId));
+            ref.read(noticeFeedbackProvider).notify();
           }
         } else if (isThisTrack) {
           ref.invalidate(trackMessageListProvider(trackId, background: true));
           ref.invalidate(unreadDirectMessageCountProvider(trackId));
+          ref.read(noticeFeedbackProvider).notify();
         }
         break;
       case SseEventEventEnum.trackDeleted:

--- a/frontend/lib/facilitator/realtime/track_event_coordinator.g.dart
+++ b/frontend/lib/facilitator/realtime/track_event_coordinator.g.dart
@@ -22,18 +22,28 @@ part of 'track_event_coordinator.dart';
 @ProviderFor(TrackEventCoordinator)
 final trackEventCoordinatorProvider = TrackEventCoordinatorFamily._();
 
-/// SSE 이벤트 분기는 위젯이 아니라 이 전용 Notifier에 둔다 — 위젯 build() 안에서 스트림
-/// 값에 반응해 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가
-/// 날 수 있다. ref.listen은 provider의 build() 안에서 쓰는 게 표준 패턴이고(콜백이 프레임
-/// 이후 비동기로 실행되어 "빌드 도중 변경" 제약이 없음), 화면(위젯)은 이 결과를 watch만 해서
-/// 생명주기(자동 dispose)만 공유한다(§04 plan).
+/// 인증된 트랙 세션의 SSE 수신·재조회 경계를 한 곳에서 관리한다.
+///
+/// 메시지·공지, 방문 상태, 세션 종료는 서로 다른 도메인 관심사지만, 현재는 모두 같은 트랙
+/// 세션의 단일 SSE 연결에서 도착하고 각 provider를 재조회시키는 얇은 어댑터다. 따라서 지금은
+/// 연결·재연결·세션 수명을 한 코디네이터에 둔다. 각 이벤트에 독자적인 정책 또는 화면별 구독
+/// 수명이 생길 때에만 메시지/방문/세션 코디네이터로 분리한다.
+///
+/// 이벤트 분기는 위젯이 아니라 이 Notifier에 둔다. 위젯 build() 안에서 스트림 값에 반응해
+/// 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가 날 수 있다.
+/// 화면은 이 결과만 watch하고, 앱 루트가 인증 세션 동안의 생명주기를 소유한다.
 final class TrackEventCoordinatorProvider
     extends $NotifierProvider<TrackEventCoordinator, void> {
-  /// SSE 이벤트 분기는 위젯이 아니라 이 전용 Notifier에 둔다 — 위젯 build() 안에서 스트림
-  /// 값에 반응해 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가
-  /// 날 수 있다. ref.listen은 provider의 build() 안에서 쓰는 게 표준 패턴이고(콜백이 프레임
-  /// 이후 비동기로 실행되어 "빌드 도중 변경" 제약이 없음), 화면(위젯)은 이 결과를 watch만 해서
-  /// 생명주기(자동 dispose)만 공유한다(§04 plan).
+  /// 인증된 트랙 세션의 SSE 수신·재조회 경계를 한 곳에서 관리한다.
+  ///
+  /// 메시지·공지, 방문 상태, 세션 종료는 서로 다른 도메인 관심사지만, 현재는 모두 같은 트랙
+  /// 세션의 단일 SSE 연결에서 도착하고 각 provider를 재조회시키는 얇은 어댑터다. 따라서 지금은
+  /// 연결·재연결·세션 수명을 한 코디네이터에 둔다. 각 이벤트에 독자적인 정책 또는 화면별 구독
+  /// 수명이 생길 때에만 메시지/방문/세션 코디네이터로 분리한다.
+  ///
+  /// 이벤트 분기는 위젯이 아니라 이 Notifier에 둔다. 위젯 build() 안에서 스트림 값에 반응해
+  /// 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가 날 수 있다.
+  /// 화면은 이 결과만 watch하고, 앱 루트가 인증 세션 동안의 생명주기를 소유한다.
   TrackEventCoordinatorProvider._({
     required TrackEventCoordinatorFamily super.from,
     required TrackId super.argument,
@@ -79,13 +89,18 @@ final class TrackEventCoordinatorProvider
 }
 
 String _$trackEventCoordinatorHash() =>
-    r'8ce32258b2d8547ca0d84d484a23d7a5f23959ad';
+    r'890460af05066fcb08ee52bbc47b2b3903722ebe';
 
-/// SSE 이벤트 분기는 위젯이 아니라 이 전용 Notifier에 둔다 — 위젯 build() 안에서 스트림
-/// 값에 반응해 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가
-/// 날 수 있다. ref.listen은 provider의 build() 안에서 쓰는 게 표준 패턴이고(콜백이 프레임
-/// 이후 비동기로 실행되어 "빌드 도중 변경" 제약이 없음), 화면(위젯)은 이 결과를 watch만 해서
-/// 생명주기(자동 dispose)만 공유한다(§04 plan).
+/// 인증된 트랙 세션의 SSE 수신·재조회 경계를 한 곳에서 관리한다.
+///
+/// 메시지·공지, 방문 상태, 세션 종료는 서로 다른 도메인 관심사지만, 현재는 모두 같은 트랙
+/// 세션의 단일 SSE 연결에서 도착하고 각 provider를 재조회시키는 얇은 어댑터다. 따라서 지금은
+/// 연결·재연결·세션 수명을 한 코디네이터에 둔다. 각 이벤트에 독자적인 정책 또는 화면별 구독
+/// 수명이 생길 때에만 메시지/방문/세션 코디네이터로 분리한다.
+///
+/// 이벤트 분기는 위젯이 아니라 이 Notifier에 둔다. 위젯 build() 안에서 스트림 값에 반응해
+/// 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가 날 수 있다.
+/// 화면은 이 결과만 watch하고, 앱 루트가 인증 세션 동안의 생명주기를 소유한다.
 
 final class TrackEventCoordinatorFamily extends $Family
     with
@@ -99,11 +114,16 @@ final class TrackEventCoordinatorFamily extends $Family
         isAutoDispose: true,
       );
 
-  /// SSE 이벤트 분기는 위젯이 아니라 이 전용 Notifier에 둔다 — 위젯 build() 안에서 스트림
-  /// 값에 반응해 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가
-  /// 날 수 있다. ref.listen은 provider의 build() 안에서 쓰는 게 표준 패턴이고(콜백이 프레임
-  /// 이후 비동기로 실행되어 "빌드 도중 변경" 제약이 없음), 화면(위젯)은 이 결과를 watch만 해서
-  /// 생명주기(자동 dispose)만 공유한다(§04 plan).
+  /// 인증된 트랙 세션의 SSE 수신·재조회 경계를 한 곳에서 관리한다.
+  ///
+  /// 메시지·공지, 방문 상태, 세션 종료는 서로 다른 도메인 관심사지만, 현재는 모두 같은 트랙
+  /// 세션의 단일 SSE 연결에서 도착하고 각 provider를 재조회시키는 얇은 어댑터다. 따라서 지금은
+  /// 연결·재연결·세션 수명을 한 코디네이터에 둔다. 각 이벤트에 독자적인 정책 또는 화면별 구독
+  /// 수명이 생길 때에만 메시지/방문/세션 코디네이터로 분리한다.
+  ///
+  /// 이벤트 분기는 위젯이 아니라 이 Notifier에 둔다. 위젯 build() 안에서 스트림 값에 반응해
+  /// 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가 날 수 있다.
+  /// 화면은 이 결과만 watch하고, 앱 루트가 인증 세션 동안의 생명주기를 소유한다.
 
   TrackEventCoordinatorProvider call(TrackId trackId) =>
       TrackEventCoordinatorProvider._(argument: trackId, from: this);
@@ -112,11 +132,16 @@ final class TrackEventCoordinatorFamily extends $Family
   String toString() => r'trackEventCoordinatorProvider';
 }
 
-/// SSE 이벤트 분기는 위젯이 아니라 이 전용 Notifier에 둔다 — 위젯 build() 안에서 스트림
-/// 값에 반응해 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가
-/// 날 수 있다. ref.listen은 provider의 build() 안에서 쓰는 게 표준 패턴이고(콜백이 프레임
-/// 이후 비동기로 실행되어 "빌드 도중 변경" 제약이 없음), 화면(위젯)은 이 결과를 watch만 해서
-/// 생명주기(자동 dispose)만 공유한다(§04 plan).
+/// 인증된 트랙 세션의 SSE 수신·재조회 경계를 한 곳에서 관리한다.
+///
+/// 메시지·공지, 방문 상태, 세션 종료는 서로 다른 도메인 관심사지만, 현재는 모두 같은 트랙
+/// 세션의 단일 SSE 연결에서 도착하고 각 provider를 재조회시키는 얇은 어댑터다. 따라서 지금은
+/// 연결·재연결·세션 수명을 한 코디네이터에 둔다. 각 이벤트에 독자적인 정책 또는 화면별 구독
+/// 수명이 생길 때에만 메시지/방문/세션 코디네이터로 분리한다.
+///
+/// 이벤트 분기는 위젯이 아니라 이 Notifier에 둔다. 위젯 build() 안에서 스트림 값에 반응해
+/// 동기적으로 ref.invalidate를 호출하면 빌드 사이클 도중 provider를 바꾸다 예외가 날 수 있다.
+/// 화면은 이 결과만 watch하고, 앱 루트가 인증 세션 동안의 생명주기를 소유한다.
 
 abstract class _$TrackEventCoordinator extends $Notifier<void> {
   late final _$args = ref.$arg as TrackId;

--- a/frontend/lib/shared/util/notice_feedback.dart
+++ b/frontend/lib/shared/util/notice_feedback.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/services.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+part 'notice_feedback.g.dart';
+
+/// 공지/메시지 수신 시 사용자에게 주는 소리+진동 피드백.
+///
+/// `HapticFeedback`/`SystemSound`는 OS의 UI 알림 사운드 채널을 그대로 쓰므로, 기기가
+/// 무음/진동/벨소리 모드일 때의 동작(소리 유무)을 앱이 직접 판단하지 않고 OS에 위임한다
+/// (이슈 #218). 커스텀 사운드 asset을 재생하는 방식(예: audioplayers)은 미디어 재생
+/// 카테고리라 무음 모드를 자동으로 존중하지 않으므로 의도적으로 채택하지 않았다.
+abstract class NoticeFeedback {
+  void notify();
+}
+
+class SystemNoticeFeedback implements NoticeFeedback {
+  const SystemNoticeFeedback();
+
+  @override
+  void notify() {
+    HapticFeedback.vibrate();
+    SystemSound.play(SystemSoundType.alert);
+  }
+}
+
+/// 무상태 서비스이며 이벤트 코디네이터가 순간적으로 `ref.read`만 하므로,
+/// `apiClientProvider`와 동일하게 `keepAlive: true`로 고정한다
+/// (frontend/docs/DEVELOPER_GUIDE.md §2.1).
+@Riverpod(keepAlive: true)
+NoticeFeedback noticeFeedback(Ref ref) => const SystemNoticeFeedback();

--- a/frontend/lib/shared/util/notice_feedback.g.dart
+++ b/frontend/lib/shared/util/notice_feedback.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notice_feedback.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, type=warning
+/// 무상태 서비스이며 이벤트 코디네이터가 순간적으로 `ref.read`만 하므로,
+/// `apiClientProvider`와 동일하게 `keepAlive: true`로 고정한다
+/// (frontend/docs/DEVELOPER_GUIDE.md §2.1).
+
+@ProviderFor(noticeFeedback)
+final noticeFeedbackProvider = NoticeFeedbackProvider._();
+
+/// 무상태 서비스이며 이벤트 코디네이터가 순간적으로 `ref.read`만 하므로,
+/// `apiClientProvider`와 동일하게 `keepAlive: true`로 고정한다
+/// (frontend/docs/DEVELOPER_GUIDE.md §2.1).
+
+final class NoticeFeedbackProvider
+    extends $FunctionalProvider<NoticeFeedback, NoticeFeedback, NoticeFeedback>
+    with $Provider<NoticeFeedback> {
+  /// 무상태 서비스이며 이벤트 코디네이터가 순간적으로 `ref.read`만 하므로,
+  /// `apiClientProvider`와 동일하게 `keepAlive: true`로 고정한다
+  /// (frontend/docs/DEVELOPER_GUIDE.md §2.1).
+  NoticeFeedbackProvider._()
+    : super(
+        from: null,
+        argument: null,
+        retry: null,
+        name: r'noticeFeedbackProvider',
+        isAutoDispose: false,
+        dependencies: null,
+        $allTransitiveDependencies: null,
+      );
+
+  @override
+  String debugGetCreateSourceHash() => _$noticeFeedbackHash();
+
+  @$internal
+  @override
+  $ProviderElement<NoticeFeedback> $createElement($ProviderPointer pointer) =>
+      $ProviderElement(pointer);
+
+  @override
+  NoticeFeedback create(Ref ref) {
+    return noticeFeedback(ref);
+  }
+
+  /// {@macro riverpod.override_with_value}
+  Override overrideWithValue(NoticeFeedback value) {
+    return $ProviderOverride(
+      origin: this,
+      providerOverride: $SyncValueProvider<NoticeFeedback>(value),
+    );
+  }
+}
+
+String _$noticeFeedbackHash() => r'edb855787f35065359079bf8eb1d76678b0b9f74';

--- a/frontend/test/admin/session/admin_event_coordinator_test.dart
+++ b/frontend/test/admin/session/admin_event_coordinator_test.dart
@@ -8,8 +8,20 @@ import 'package:cornermon/shared/api/providers/corner_track_providers.dart';
 import 'package:cornermon/shared/api/providers/message_providers.dart';
 import 'package:cornermon/shared/api/sse/admin_event_stream.dart';
 import 'package:cornermon/shared/api/sse/sse_event_receipt.dart';
+import 'package:cornermon/shared/util/notice_feedback.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+/// 실제 구현은 HapticFeedback/SystemSound 플랫폼 채널을 건드리므로, 호출 횟수만
+/// 기록하는 가짜로 대체한다(FakeTrackSession 등과 동일한 관례).
+class FakeNoticeFeedback implements NoticeFeedback {
+  int notifyCalls = 0;
+
+  @override
+  void notify() {
+    notifyCalls++;
+  }
+}
 
 void main() {
   final campId = CampId('camp-1');
@@ -17,6 +29,7 @@ void main() {
 
   late StreamController<SseEventReceipt> eventController;
   late ProviderContainer container;
+  late FakeNoticeFeedback fakeNoticeFeedback;
   late int broadcastListBuildCount;
   late int threadMessageListBuildCount;
   late int previewMessageListBuildCount;
@@ -36,6 +49,7 @@ void main() {
   setUp(() {
     eventController = StreamController<SseEventReceipt>();
     eventSequence = 0;
+    fakeNoticeFeedback = FakeNoticeFeedback();
     broadcastListBuildCount = 0;
     threadMessageListBuildCount = 0;
     previewMessageListBuildCount = 0;
@@ -43,6 +57,7 @@ void main() {
     container = ProviderContainer(
       overrides: [
         adminEventsProvider(campId).overrideWith((ref) => eventController.stream),
+        noticeFeedbackProvider.overrideWithValue(fakeNoticeFeedback),
         broadcastMessageListProvider(campId).overrideWith((ref) async {
           broadcastListBuildCount++;
           return <Message>[];
@@ -167,6 +182,25 @@ void main() {
 
       // assert
       expect(broadcastListBuildCount, greaterThan(baseline));
+    },
+  );
+
+  test(
+    'ShouldTriggerNoticeFeedbackWhenMessagesChangedArrives',
+    () async {
+      // arrange
+      final event = SseEvent(
+        (b) => b
+          ..event = SseEventEventEnum.messagesChanged
+          ..scope.kind = SseScopeKind.track
+          ..scope.trackId = trackId.value,
+      );
+
+      // act
+      await pushAndSettle(event);
+
+      // assert — 이슈 #218: 공지/메시지 수신 시 소리+진동 피드백을 준다.
+      expect(fakeNoticeFeedback.notifyCalls, 1);
     },
   );
 }

--- a/frontend/test/facilitator/features/track_event_coordinator_test.dart
+++ b/frontend/test/facilitator/features/track_event_coordinator_test.dart
@@ -10,8 +10,20 @@ import 'package:cornermon/shared/api/providers/message_providers.dart';
 import 'package:cornermon/shared/api/providers/visit_providers.dart';
 import 'package:cornermon/shared/api/sse/track_event_stream.dart';
 import 'package:cornermon/shared/api/sse/sse_event_receipt.dart';
+import 'package:cornermon/shared/util/notice_feedback.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+/// 실제 구현은 HapticFeedback/SystemSound 플랫폼 채널을 건드리므로, 호출 횟수만
+/// 기록하는 가짜로 대체한다(FakeTrackSession 등과 동일한 관례).
+class FakeNoticeFeedback implements NoticeFeedback {
+  int notifyCalls = 0;
+
+  @override
+  void notify() {
+    notifyCalls++;
+  }
+}
 
 /// 실제 handleTermination은 secure storage(플랫폼 채널)를 건드리므로, 강제종료 3종 분기가
 /// 올바른 사유로 호출되는지만 기록하는 가짜 세션으로 대체한다.
@@ -58,6 +70,7 @@ void main() {
   late ProviderContainer container;
   late FakeTrackSession fakeTrackSession;
   late FakeDeviceTrust fakeDeviceTrust;
+  late FakeNoticeFeedback fakeNoticeFeedback;
   late int currentVisitBuildCount;
   late int rawBroadcastListBuildCount;
   late int trackMessageListBuildCount;
@@ -81,6 +94,7 @@ void main() {
     eventSequence = 0;
     fakeTrackSession = FakeTrackSession();
     fakeDeviceTrust = FakeDeviceTrust();
+    fakeNoticeFeedback = FakeNoticeFeedback();
     currentVisitBuildCount = 0;
     rawBroadcastListBuildCount = 0;
     trackMessageListBuildCount = 0;
@@ -94,6 +108,7 @@ void main() {
         ).overrideWith((ref) => eventController.stream),
         trackSessionProvider.overrideWith(() => fakeTrackSession),
         deviceTrustProvider.overrideWith(() => fakeDeviceTrust),
+        noticeFeedbackProvider.overrideWithValue(fakeNoticeFeedback),
         currentVisitProvider(trackId).overrideWith((ref) {
           currentVisitBuildCount++;
           return null;
@@ -245,6 +260,41 @@ void main() {
   );
 
   test(
+    'ShouldTriggerNoticeFeedbackWhenMessagesChangedScopeIsCamp',
+    () async {
+      // arrange — 이슈 #218: camp scope(공지)도 피드백 대상이다.
+      fakeTrackSession.setSession(
+        TrackSessionAuthenticated(
+          trackToken: 'token',
+          track: Track(
+            (b) => b
+              ..id = trackId.value
+              ..cornerId = 'corner-1'
+              ..trackNo = 1
+              ..status = TrackStatus.ACTIVE,
+          ),
+          corner: Corner(
+            (b) => b
+              ..id = 'corner-1'
+              ..campId = 'camp-1',
+          ),
+        ),
+      );
+      final event = SseEvent(
+        (b) => b
+          ..event = SseEventEventEnum.messagesChanged
+          ..scope.kind = SseScopeKind.camp,
+      );
+
+      // act
+      await pushAndSettle(event);
+
+      // assert
+      expect(fakeNoticeFeedback.notifyCalls, 1);
+    },
+  );
+
+  test(
     'ShouldInvalidateTrackMessageListWhenMessagesChangedScopeIsOwnTrack',
     () async {
       // arrange
@@ -305,6 +355,44 @@ void main() {
 
       // assert
       expect(unreadDirectCountBuildCount, greaterThan(baseline));
+    },
+  );
+
+  test(
+    'ShouldTriggerNoticeFeedbackWhenMessagesChangedScopeIsOwnTrack',
+    () async {
+      // arrange — 이슈 #218: 자기 트랙 앞 다이렉트 메시지도 피드백 대상이다.
+      final event = SseEvent(
+        (b) => b
+          ..event = SseEventEventEnum.messagesChanged
+          ..scope.kind = SseScopeKind.track
+          ..scope.trackId = trackId.value,
+      );
+
+      // act
+      await pushAndSettle(event);
+
+      // assert
+      expect(fakeNoticeFeedback.notifyCalls, 1);
+    },
+  );
+
+  test(
+    'ShouldNotTriggerNoticeFeedbackWhenMessagesChangedScopeIsAnotherTrack',
+    () async {
+      // arrange — 다른 트랙 앞 다이렉트 메시지에는 반응하지 않는다(기존 scope 방어 로직 회귀 검증).
+      final event = SseEvent(
+        (b) => b
+          ..event = SseEventEventEnum.messagesChanged
+          ..scope.kind = SseScopeKind.track
+          ..scope.trackId = otherTrackId.value,
+      );
+
+      // act
+      await pushAndSettle(event);
+
+      // assert
+      expect(fakeNoticeFeedback.notifyCalls, 0);
     },
   );
 


### PR DESCRIPTION
## 변경 사항과 이유
관리자·진행자 모두 공지/메시지 수신 시 아무 피드백이 없어 운영 중 놓칠 가능성이 있었습니다(#218).
기존 SSE `messages_changed` 이벤트 디스패처(`AdminEventCoordinator`, `TrackEventCoordinator`)에
`HapticFeedback.vibrate()` + `SystemSound.play(SystemSoundType.alert)`로 OS 알림 사운드 채널을
쓰는 `NoticeFeedback`을 추가 호출합니다.

- Flutter 내장 API만 사용 — 신규 패키지 의존성 없음
- OS UI 사운드 채널을 그대로 쓰므로 기기의 무음/진동/벨소리 모드가 자동으로 반영됨(사용자 요청사항)
- 대상: admin은 `messages_changed` 전체, facilitator는 camp scope(공지) + 자기 트랙 scope(다이렉트 메시지)
- 설정 토글 없음 — 항상 켜짐(운영 중 놓침 방지가 이슈 목적)
- 백그라운드/푸시 알림 연동은 범위 밖(별도 이슈)

`NoticeFeedback`은 인터페이스로 분리해 provider로 주입 — 코디네이터 테스트에서 `FakeNoticeFeedback`으로
대체해 호출 여부만 검증합니다(플랫폼 채널 mocking 불필요).

### 부수 수정
`build.yaml`의 `riverpod_generator.generate_for.include`에 `lib/facilitator/realtime/*.dart`,
`lib/shared/util/*.dart`가 누락되어 있던 기존 버그를 발견했습니다. 이번 변경이 정확히 그 경로
(`track_event_coordinator.dart`, 신규 `notice_feedback.dart`)를 건드려서, 고치지 않으면 build_runner
재생성 시 `track_event_coordinator.g.dart`가 삭제되어 커밋 가능한 빌드가 나오지 않아 함께 수정했습니다.

## 계획 문서
`frontend/docs/artifacts/plan/20260819_issue_218_notice_message_feedback_plan_.md`

## 종료 조건 검증
- `make docker-build` 후 컨테이너 내부에서 변경된 테스트 21건 전부 통과
  (`admin_event_coordinator_test.dart`, `track_event_coordinator_test.dart`)
- 전체 스위트 실행: 실패 2건(`end_camp_bar_button_test`, `track_event_stream_test`)은 main
  브랜치에서도 동일하게 재현되는 기존 flaky 테스트로 별도 확인 — 이번 변경과 무관
- `flutter analyze`의 기존 경고 17건(자동생성 `cornermon_api_gen` unused_import 등)도 main에
  이미 존재함을 확인 — 이번 변경 파일에는 analyze 이슈 없음
- 신규 패키지 의존성 추가 없음(`pubspec.yaml` 불변), API 계약 변경 없음

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)