### PR TITLE
fix : 관리자 로그인 실패 원인에 따라 401/500 응답 분리

### DIFF
--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -37,6 +37,7 @@ var (
 	ErrAdminInvalidRole         = errors.New("admin: invalid role")
 	ErrAdminSelfDeleteForbidden = errors.New("admin: cannot delete self")
 	ErrAdminLastSystemAdmin     = errors.New("admin: cannot delete last system admin")
+	ErrAdminInvalidCredentials  = errors.New("admin: invalid username or password")
 )
 
 type DeviceLockedError struct {

--- a/backend/internal/infrastructure/web/auth_handler.go
+++ b/backend/internal/infrastructure/web/auth_handler.go
@@ -94,13 +94,23 @@ func (h *AuthHandler) AdminLogin(c echo.Context) error {
 	deviceInfo := c.Request().UserAgent()
 	access, _, err := h.adminAuth.Login(c.Request().Context(), req.ID, req.Password, deviceInfo)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: CodeUnauthorized, Message: err.Error()}).SetInternal(err)
+		return adminLoginHTTPError(err)
 	}
 
 	return c.JSON(http.StatusOK, AdminLoginResponse{
 		AccessToken:      access,
 		ExpiresInSeconds: int(usecase.AdminAccessTokenTTL.Seconds()),
 	})
+}
+
+// adminLoginHTTPError는 잘못된 아이디/비밀번호(도메인 검증 실패)만 401로 매핑한다.
+// 그 외 에러(DB 커넥션 끊김 등 인프라 실패)는 echo.HTTPError로 감싸지 않고 그대로 반환해
+// ErrorHandler가 500으로 처리하도록 한다 (trackLoginHTTPError와 동일한 패턴).
+func adminLoginHTTPError(err error) error {
+	if errors.Is(err, domain.ErrAdminInvalidCredentials) {
+		return echo.NewHTTPError(http.StatusUnauthorized, ErrorResponse{Code: CodeUnauthorized, Message: "invalid username or password"}).SetInternal(err)
+	}
+	return err
 }
 
 // @Summary      관리자 로그아웃

--- a/backend/internal/infrastructure/web/auth_handler_test.go
+++ b/backend/internal/infrastructure/web/auth_handler_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,61 @@ import (
 
 	"github.com/labstack/echo/v4"
 )
+
+type adminLoginUsecaseStub struct{ err error }
+
+func (s adminLoginUsecaseStub) Login(context.Context, string, string, string) (string, *domain.AdminSession, error) {
+	return "", nil, s.err
+}
+func (adminLoginUsecaseStub) RevokeSession(context.Context, domain.AdminSessionID, domain.AdminID) error {
+	return nil
+}
+func (adminLoginUsecaseStub) ListSessions(context.Context, domain.AdminID) ([]*domain.AdminSession, error) {
+	return nil, nil
+}
+func (adminLoginUsecaseStub) ForceTrackLogout(context.Context, domain.TrackID, domain.AdminID) error {
+	return nil
+}
+
+// TestAdminLoginShouldMapExpectedErrorsToHTTPStatus는 로그인 실패 원인에 따라 상태 코드가
+// 갈려야 함을 검증한다: 아이디/비밀번호 오류(domain.ErrAdminInvalidCredentials)만 401이고,
+// 그 외(DB 커넥션 끊김 등 인프라 실패)는 500으로 떨어져야 한다. 과거에는 원인과 무관하게
+// 무조건 401을 반환해 DB 장애가 "로그인 실패"로 오인되는 문제가 있었다.
+func TestAdminLoginShouldMapExpectedErrorsToHTTPStatus(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		wantCode int
+		wantBody string
+	}{
+		{name: "invalid credentials", err: domain.ErrAdminInvalidCredentials, wantCode: http.StatusUnauthorized, wantBody: "UNAUTHORIZED"},
+		{name: "wrapped invalid credentials", err: fmt.Errorf("login failed: %w", domain.ErrAdminInvalidCredentials), wantCode: http.StatusUnauthorized, wantBody: "UNAUTHORIZED"},
+		{name: "infra failure (e.g. db down)", err: errors.New("context canceled"), wantCode: http.StatusInternalServerError, wantBody: "INTERNAL_SERVER_ERROR"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// arrange
+			e := echo.New()
+			e.HTTPErrorHandler = ErrorHandler()
+			e.POST("/api/v1/auth/admin/login", NewAuthHandler(adminLoginUsecaseStub{err: tt.err}, nil, nil).AdminLogin)
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/admin/login", strings.NewReader(`{"id":"orca","password":"pw"}`))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+
+			// act
+			e.ServeHTTP(rec, req)
+
+			// assert
+			if rec.Code != tt.wantCode {
+				t.Fatalf("expected status %d, got %d: %s", tt.wantCode, rec.Code, rec.Body.String())
+			}
+			if !strings.Contains(rec.Body.String(), tt.wantBody) {
+				t.Fatalf("expected response body to contain %q, got %s", tt.wantBody, rec.Body.String())
+			}
+		})
+	}
+}
 
 type trackLoginUsecaseStub struct{ err error }
 

--- a/backend/internal/usecase/auth_admin.go
+++ b/backend/internal/usecase/auth_admin.go
@@ -66,13 +66,13 @@ func (s *AdminAuthService) Login(
 		return "", nil, withErrorContext("auth_admin.login", "repository.get_admin", err, map[string]any{"username": username})
 	}
 	if admin == nil {
-		err = withErrorContext("auth_admin.login", "validate_admin", errors.New("invalid username or password"), map[string]any{"username": username, "admin_found": false})
+		err = withErrorContext("auth_admin.login", "validate_admin", domain.ErrAdminInvalidCredentials, map[string]any{"username": username, "admin_found": false})
 		s.recordAuditLog(ctx, domain.None[domain.CampID](), "anonymous", "anonymous", ActionAdminLogin, username, username, false, errorAuditMetadata(err, nil))
 		return "", nil, err
 	}
 
 	if err := verifyPassword(admin.PasswordHash(), password); err != nil {
-		err = withErrorContext("auth_admin.login", "validate_password", errors.New("invalid username or password"), map[string]any{"username": username})
+		err = withErrorContext("auth_admin.login", "validate_password", domain.ErrAdminInvalidCredentials, map[string]any{"username": username})
 		s.recordAuditLog(ctx, domain.None[domain.CampID](), "anonymous", "anonymous", ActionAdminLogin, username, username, false, errorAuditMetadata(err, nil))
 		return "", nil, err
 	}

--- a/backend/internal/usecase/auth_admin_test.go
+++ b/backend/internal/usecase/auth_admin_test.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -113,6 +114,33 @@ func TestAdminAuthService_Login(t *testing.T) {
 		// Assert
 		if err == nil {
 			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, domain.ErrAdminInvalidCredentials) {
+			t.Errorf("expected errors.Is(err, domain.ErrAdminInvalidCredentials) to be true, got %v", err)
+		}
+	})
+
+	t.Run("ShouldFailLoginAdminWithInvalidCredentialsErrorWhenUsernameNotFound", func(t *testing.T) {
+		// Arrange
+		admins := NewMockAdminRepository()
+		sessions := NewMockAdminSessionRepository()
+		auditLogs := &MockAuditLogRepository{}
+		tx := &MockTxManager{}
+		facSessions := NewMockFacilitatorSessionRepository()
+		tracks := NewMockTrackRepository()
+		corners := NewMockCornerRepository()
+		broadcaster := &MockBroadcaster{}
+
+		s := NewAdminAuthService(admins, sessions, facSessions, tracks, corners, broadcaster, auditLogs, tx)
+
+		// Act
+		_, _, err := s.Login(context.Background(), "no-such-admin", "any-password", "PC")
+
+		// Assert
+		// 아이디가 존재하지 않는 경우와 비밀번호가 틀린 경우를 호출부에서 같은 sentinel로
+		// 구분 없이 401 처리할 수 있어야 하므로 동일한 에러여야 한다.
+		if !errors.Is(err, domain.ErrAdminInvalidCredentials) {
+			t.Errorf("expected errors.Is(err, domain.ErrAdminInvalidCredentials) to be true, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## 변경 사항 및 이유

`AdminLogin` 핸들러(`backend/internal/infrastructure/web/auth_handler.go`)가
`usecase.Login()`에서 나오는 모든 에러를 구분 없이 401로 응답했다.
아이디/비밀번호 오류뿐 아니라 DB 커넥션 끊김·타임아웃 같은 인프라 실패까지
전부 401로 뭉개져서, 실제 운영 중 발생한 `context canceled` DB 장애가
"로그인 실패"로 오인되고 WARN 레벨로 로깅되어 심각도가 드러나지 않는
문제가 있었다.

같은 파일의 facilitator 트랙 로그인(`TrackLogin` / `trackLoginHTTPError`)은
알려진 도메인 sentinel 에러만 명시적으로 상태 코드를 매핑하고 나머지는
그대로 흘려보내 500으로 떨어지게 하는 패턴을 이미 쓰고 있는데, admin
로그인만 이 패턴을 따르지 않고 있었다.

## 변경 내용

- `domain.ErrAdminInvalidCredentials` sentinel 추가, `usecase.AdminAuthService.Login()`의
  두 실패 경로(계정 없음 / 비밀번호 불일치)가 이 sentinel을 반환하도록 변경
  (기존엔 `errors.New("invalid username or password")` 인라인이라 `errors.Is`로 구분 불가했음)
- `auth_handler.go`에 `adminLoginHTTPError` 추가: 이 sentinel만 401로 매핑하고,
  그 외 에러(인프라 실패)는 `echo.HTTPError`로 감싸지 않고 그대로 반환해
  `ErrorHandler` 미들웨어가 500 + ERROR 레벨로 처리하도록 함
- API 응답 계약 변경 없음 (여전히 잘못된 자격증명은 401) — `openapi.yaml` 수정 불필요

## 종료 조건 검증

- `go build ./...`, `go vet ./...`, `gofmt -l .` 통과
- `go test ./...` 전체 통과
- 신규 회귀 테스트:
  - `internal/usecase/auth_admin_test.go`: 계정 없음/비밀번호 불일치 모두
    `errors.Is(err, domain.ErrAdminInvalidCredentials)`가 true임을 검증
  - `internal/infrastructure/web/auth_handler_test.go`:
    `TestAdminLoginShouldMapExpectedErrorsToHTTPStatus` — 자격증명 오류는 401,
    임의의 인프라 에러(예: `context canceled`)는 500으로 응답함을 검증
- 실제 테스트 로그로 이전 동작(모두 401 WARN) → 수정 후 동작(자격증명만 401 WARN,
  인프라 에러는 500 ERROR) 전환 확인