### PR TITLE
fix : 콘솔 로그 스택트레이스 축약 + flutter analyze 경고 정리

### DIFF
--- a/frontend/analysis_options.yaml
+++ b/frontend/analysis_options.yaml
@@ -18,6 +18,9 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
+    # openapi-generator 산출물(자체 "DO NOT MODIFY" 표기) — unused_import 등은
+    # 생성기 템플릿 이슈라 여기서 고치는 대신 analyze 대상에서 제외한다.
+    - packages/cornermon_api_gen/**
   plugins:
     - import_lint
 

--- a/frontend/lib/shared/logging/app_logger.dart
+++ b/frontend/lib/shared/logging/app_logger.dart
@@ -70,7 +70,7 @@ class AppLogger {
       stackTrace: stackTrace,
     );
     _buffer.add(record);
-    debugPrint(record.toLine());
+    debugPrint(record.toConsoleLine());
   }
 }
 

--- a/frontend/lib/shared/logging/log_record.dart
+++ b/frontend/lib/shared/logging/log_record.dart
@@ -28,7 +28,8 @@ class LogRecord {
   final Object? error;
   final StackTrace? stackTrace;
 
-  /// 콘솔 출력·내보내기 텍스트 모두가 공유하는 한 줄(+스택트레이스) 포맷.
+  /// 내보내기(진단 export, #131 UC-4) 텍스트 포맷 — 스택트레이스를 잘라내지 않고
+  /// 전체를 담는다. 사후 필드 이슈 분석이 목적이라 여기서는 장황함이 곧 목표다.
   String toLine() {
     final levelTag = level.name.toUpperCase();
     final traceSuffix = traceId == null ? '' : ' trace_id=$traceId';
@@ -37,6 +38,27 @@ class LogRecord {
     );
     if (error != null) buffer.write('\n$error');
     if (stackTrace != null) buffer.write('\n$stackTrace');
+    return buffer.toString();
+  }
+
+  /// 콘솔 출력 전용 포맷. [toLine]과 내용은 같지만 스택트레이스를 앞부분
+  /// [maxStackLines]줄로 잘라낸다 — 전체 스택은 이미 링버퍼(및 export)에 남으므로,
+  /// 개발 중 터미널을 매 요청마다 수십 줄로 채우지 않기 위함이다.
+  String toConsoleLine({int maxStackLines = 4}) {
+    final levelTag = level.name.toUpperCase();
+    final traceSuffix = traceId == null ? '' : ' trace_id=$traceId';
+    final buffer = StringBuffer(
+      '${timestamp.toIso8601String()} [$levelTag][$tag] $message$traceSuffix',
+    );
+    if (error != null) buffer.write('\n$error');
+    if (stackTrace != null) {
+      final lines = stackTrace.toString().trimRight().split('\n');
+      final shown = lines.take(maxStackLines).join('\n');
+      buffer.write('\n$shown');
+      if (lines.length > maxStackLines) {
+        buffer.write('\n  ... (${lines.length - maxStackLines} more, see exportSnapshot)');
+      }
+    }
     return buffer.toString();
   }
 }

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -64,7 +64,6 @@ dev_dependencies:
   build_runner: ^2.4.9
   riverpod_generator: ^4.0.4
   import_lint: any
-  built_collection: ^5.1.1 # main_track_test에서 CornerProgress 리스트 픽스처 구성에 직접 사용 — 기존엔 전이 의존성이었음
   fake_async: ^1.3.3 # device_trust_provider_test의 폴링 타이머 테스트에서 직접 사용 — 기존엔 전이 의존성이었음
 
 flutter_launcher_icons:

--- a/frontend/test/shared/logging/log_record_test.dart
+++ b/frontend/test/shared/logging/log_record_test.dart
@@ -1,0 +1,65 @@
+import 'package:cornermon/shared/logging/log_level.dart';
+import 'package:cornermon/shared/logging/log_record.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LogRecord', () {
+    test('ToLineShouldKeepFullStackTrace', () {
+      // arrange
+      final stackTrace = StackTrace.fromString('#0 a\n#1 b\n#2 c\n#3 d\n#4 e');
+      final record = LogRecord(
+        level: LogLevel.error,
+        tag: 'tag',
+        message: 'boom',
+        timestamp: DateTime(2026, 1, 1),
+        stackTrace: stackTrace,
+      );
+
+      // act
+      final line = record.toLine();
+
+      // assert
+      expect(line, contains('#4 e'));
+      expect(line, isNot(contains('more, see exportSnapshot')));
+    });
+
+    test('ToConsoleLineShouldTruncateStackTraceBeyondMaxLines', () {
+      // arrange
+      final stackTrace = StackTrace.fromString('#0 a\n#1 b\n#2 c\n#3 d\n#4 e');
+      final record = LogRecord(
+        level: LogLevel.error,
+        tag: 'tag',
+        message: 'boom',
+        timestamp: DateTime(2026, 1, 1),
+        stackTrace: stackTrace,
+      );
+
+      // act
+      final line = record.toConsoleLine(maxStackLines: 2);
+
+      // assert
+      expect(line, contains('#0 a'));
+      expect(line, contains('#1 b'));
+      expect(line, isNot(contains('#2 c')));
+      expect(line, contains('3 more, see exportSnapshot'));
+    });
+
+    test('ToConsoleLineShouldNotAddTruncationNoteWhenStackFitsWithinMax', () {
+      // arrange
+      final stackTrace = StackTrace.fromString('#0 a\n#1 b');
+      final record = LogRecord(
+        level: LogLevel.warn,
+        tag: 'tag',
+        message: 'boom',
+        timestamp: DateTime(2026, 1, 1),
+        stackTrace: stackTrace,
+      );
+
+      // act
+      final line = record.toConsoleLine(maxStackLines: 4);
+
+      // assert
+      expect(line, isNot(contains('more, see exportSnapshot')));
+    });
+  });
+}


### PR DESCRIPTION
## 변경 사항

### 1. 콘솔 로그 스택트레이스 축약
`AppLogger`의 warn/error 로그가 콘솔 출력에도 링버퍼/export 저장용과 동일한
`LogRecord.toLine()`을 그대로 써서, DioException 하나에도 30줄 넘는 전체 스택트레이스가
터미널에 그대로 찍히던 문제를 고쳤습니다.

- `LogRecord.toConsoleLine()` 추가: 콘솔엔 스택트레이스 앞 4줄만 출력하고
  `... (N more, see exportSnapshot)`로 축약 표시
- `LogRecord.toLine()`(export/링버퍼 저장용)은 기존과 동일하게 전체 스택 유지 —
  release 빌드 필드 이슈를 사후 진단하려는 원래 설계 목적은 그대로 보존
- `AppLogger._record`는 콘솔 출력만 `toConsoleLine()`으로 교체

### 2. flutter analyze 경고 17건 정리
- `analysis_options.yaml`: openapi-generator 산출물(`packages/cornermon_api_gen`,
  자체 "DO NOT MODIFY" 표기)의 unused_import 경고 16건을 analyze 대상에서 제외.
  생성 코드를 직접 고치는 대신 exclude 처리
- `pubspec.yaml`: `built_collection`이 dependencies/dev_dependencies 양쪽에
  중복 선언돼 있던 것 정리 (unnecessary_dev_dependency 경고 해소)

## 검증
- `test/shared/logging/log_record_test.dart` 신규 3개 테스트 추가
  (export는 전체 유지 / 콘솔은 잘림 / 스택이 max 이내면 안내문 없음)
- Docker 컨테이너에서 `flutter analyze` 경고 0건 확인
- `flutter test` 전체 실행 결과 이번 변경과 무관한 기존 실패 2건
  (`end_camp_bar_button_test.dart`, `track_event_stream_test.dart`)만 남음 —
  이 변경 전 `main`에서도 동일하게 재현되는 것을 확인해 pre-existing 이슈로 판단

🤖 Generated with [Claude Code](https://claude.com/claude-code)