### PR TITLE
fix : main에서 실패하던 flaky 테스트 2건 수정

### DIFF
--- a/frontend/test/admin/features/end_camp/end_camp_bar_button_test.dart
+++ b/frontend/test/admin/features/end_camp/end_camp_bar_button_test.dart
@@ -9,6 +9,7 @@ import 'package:cornermon/shared/api/providers/camp_providers.dart';
 import 'package:cornermon/shared/api/providers/report_providers.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon_api_gen/cornermon_api_gen.dart';
+import 'package:dio/dio.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -254,9 +255,16 @@ void main() {
           liveSummaryProvider(campId).overrideWith(
             (ref) async => _summary(finishedGroupCount: 0, totalGroups: 0),
           ),
-          endCampProvider(
-            campId,
-          ).overrideWith((ref) async => throw Exception('이미 종료된 캠프')),
+          endCampProvider(campId).overrideWith(
+            (ref) async => throw DioException(
+              requestOptions: RequestOptions(path: '/camps/camp-1/end'),
+              response: Response(
+                requestOptions: RequestOptions(path: '/camps/camp-1/end'),
+                statusCode: 409,
+                data: {'code': 'CAMP_STATE_CONFLICT', 'message': 'x'},
+              ),
+            ),
+          ),
         ],
         child: const MaterialApp(home: Scaffold(body: EndCampBarButton())),
       ),
@@ -271,9 +279,13 @@ void main() {
       await tester.pump(const Duration(seconds: 1));
     }
 
-    // assert
+    // assert — 서버 원문(ErrorResponse.code/message)이 아닌 가공된 안내 문구만 노출한다
     expect(find.text('코너학습을 종료할까요?'), findsOneWidget);
-    expect(find.textContaining('이미 종료된 캠프'), findsOneWidget);
+    expect(
+      find.textContaining('종료할 수 없는 캠프 상태이거나 정리 중인 방문이 있습니다.'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('CAMP_STATE_CONFLICT'), findsNothing);
   });
 
   testWidgets(

--- a/frontend/test/shared/api/sse/track_event_stream_test.dart
+++ b/frontend/test/shared/api/sse/track_event_stream_test.dart
@@ -34,13 +34,24 @@ class _ScriptedSseClient extends SseClient {
   }) {
     final index = callCount;
     final succeed = index < _script.length ? _script[index] : _script.last;
+    // 스크립트의 마지막 항목(그 이후는 반복되는 _script.last)인가 — 여기서 성공하면 그 뒤로도
+    // 영원히 성공이므로 "연결이 계속 유지된 채 끝난다"로 취급해 close하지 않는다. 그보다 앞의
+    // 성공은 다음 스크립트 항목을 소비할 수 있도록 연결이 끝나야(재연결 루프가 돌아야) 한다 —
+    // 그러지 않으면 스크립트 중간의 성공 이후 항목들은 영원히 connect()가 호출되지 않는다.
+    final isFinalScriptedOutcome = index >= _script.length - 1;
     final controller = StreamController<SSENotification>();
 
     if (succeed) {
       onConnected?.call();
-      // 연결을 계속 살아있게 둔다(도메인 이벤트는 이 테스트의 관심사가 아님) — controller를
-      // 절대 close/addError하지 않는다.
-      addTearDown(controller.close);
+      if (isFinalScriptedOutcome) {
+        // 연결을 계속 살아있게 둔다(도메인 이벤트는 이 테스트의 관심사가 아님) — controller를
+        // 절대 close/addError하지 않는다.
+        addTearDown(controller.close);
+      } else {
+        // 서버가 정상 종료(done)한 것처럼 에러 없이 닫아, 프로덕션 재연결 루프가 다음
+        // 스크립트 항목으로 넘어가게 한다.
+        scheduleMicrotask(controller.close);
+      }
     } else {
       onDisconnected?.call();
       scheduleMicrotask(() {


### PR DESCRIPTION
## 변경 사항

main에서 `flutter test` 실행 시 실패하던 2건을 수정했습니다.

### 1. `test/shared/api/sse/track_event_stream_test.dart` — `ShouldResetConsecutiveMissCounterOnSuccessfulReconnect`

- `_ScriptedSseClient` fake가 스크립트의 성공 항목을 마지막이 아니어도 절대 닫지 않아, 성공 뒤 실패가 다시 이어지는 시나리오에서 재연결 루프가 다음 스크립트 항목으로 넘어가지 못하고 30초 타임아웃으로 실패했습니다.
- fake를 "마지막 스크립트 항목이 아닌 성공은 정상 종료(done)로 처리"하도록 고쳐, 재연결이 이어지도록 수정했습니다.
- 프로덕션 코드(`trackEvents()`)는 문제가 없었고, fake의 설계와 테스트 시나리오 간 불일치가 원인이었습니다.

### 2. `test/admin/features/end_camp/end_camp_bar_button_test.dart` — `ShoudKeepDialogOpenAndShowServerMessageWhenEndFails`

- 테스트가 `endCampProvider`에 순수 `Exception('이미 종료된 캠프')`를 던지게 하고 그 원문이 화면에 그대로 노출되길 기대했으나, `end_camp_confirm_dialog.dart`의 `_describeEndError`는 `DioException` + `code == 'CAMP_STATE_CONFLICT'`인 경우만 하드코딩된 한국어 문구로 매핑하고 그 외는 고정 문구로 대체합니다(원시 서버 에러 노출 방지 정책, `df6d2be`).
- 백엔드도 `ErrorResponse.message`에 로컬라이즈 안 된 진단용 문구만 주고 `code`로만 프론트가 문구를 만들도록 설계돼 있습니다(`camp_handler.go`의 `campHTTPError`).
- `start_camp_button_test.dart`와 동일한 패턴으로 `DioException` + `code: 'CAMP_STATE_CONFLICT'` 응답을 시뮬레이션하도록 테스트를 수정했습니다.

## 검증

`make docker-check` (flutter analyze + flutter test) 324개 전체 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)