### PR TITLE
feat : App Store 심사용 데모 모드 백엔드 (진행자 앱 기기등록 자동승인)

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -2059,6 +2059,46 @@ const docTemplate = `{
                 }
             }
         },
+        "/demo/device-registrations": {
+            "post": {
+                "description": "이 엔드포인트는 DEMO_CAMP_NAME 환경변수가 설정된 배포(App Store 리뷰 전용)에서만 존재한다. 등록과 동시에 즉시 승인 상태로 저장되므로 관리자 승인 대기가 없다. 운영 배포에는 이 라우트 자체가 등록되지 않는다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "App Store 심사용 데모 기기 등록",
+                "parameters": [
+                    {
+                        "description": "등록 정보",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/DemoDeviceRegistrationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/DeviceRegistrationCreatedResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "NOT_FOUND: 데모 모드가 비활성화되었거나 데모 캠프를 찾을 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/device-registrations": {
             "post": {
                 "description": "기기가 서버에 등록을 요청한다. 이후 관리자의 승인 대기.",
@@ -3693,6 +3733,22 @@ const docTemplate = `{
                 },
                 "count": {
                     "type": "integer"
+                }
+            }
+        },
+        "DemoDeviceRegistrationRequest": {
+            "type": "object",
+            "properties": {
+                "deviceModel": {
+                    "type": "string",
+                    "example": "iPad Pro 11 2022"
+                },
+                "deviceName": {
+                    "type": "string"
+                },
+                "displayName": {
+                    "type": "string",
+                    "example": "1번 태블릿"
                 }
             }
         },

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -2052,6 +2052,46 @@
                 }
             }
         },
+        "/demo/device-registrations": {
+            "post": {
+                "description": "이 엔드포인트는 DEMO_CAMP_NAME 환경변수가 설정된 배포(App Store 리뷰 전용)에서만 존재한다. 등록과 동시에 즉시 승인 상태로 저장되므로 관리자 승인 대기가 없다. 운영 배포에는 이 라우트 자체가 등록되지 않는다.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "A. Auth \u0026 Device Trust"
+                ],
+                "summary": "App Store 심사용 데모 기기 등록",
+                "parameters": [
+                    {
+                        "description": "등록 정보",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/DemoDeviceRegistrationRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/DeviceRegistrationCreatedResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "NOT_FOUND: 데모 모드가 비활성화되었거나 데모 캠프를 찾을 수 없음",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/device-registrations": {
             "post": {
                 "description": "기기가 서버에 등록을 요청한다. 이후 관리자의 승인 대기.",
@@ -3686,6 +3726,22 @@
                 },
                 "count": {
                     "type": "integer"
+                }
+            }
+        },
+        "DemoDeviceRegistrationRequest": {
+            "type": "object",
+            "properties": {
+                "deviceModel": {
+                    "type": "string",
+                    "example": "iPad Pro 11 2022"
+                },
+                "deviceName": {
+                    "type": "string"
+                },
+                "displayName": {
+                    "type": "string",
+                    "example": "1번 태블릿"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -420,6 +420,17 @@ definitions:
       count:
         type: integer
     type: object
+  DemoDeviceRegistrationRequest:
+    properties:
+      deviceModel:
+        example: iPad Pro 11 2022
+        type: string
+      deviceName:
+        type: string
+      displayName:
+        example: 1번 태블릿
+        type: string
+    type: object
   DeviceRegistrationCreatedResponse:
     properties:
       approvedAt:
@@ -2313,6 +2324,33 @@ paths:
       summary: 코너 대량 수정
       tags:
       - B. Resource Management (Admin)
+  /demo/device-registrations:
+    post:
+      consumes:
+      - application/json
+      description: 이 엔드포인트는 DEMO_CAMP_NAME 환경변수가 설정된 배포(App Store 리뷰 전용)에서만 존재한다.
+        등록과 동시에 즉시 승인 상태로 저장되므로 관리자 승인 대기가 없다. 운영 배포에는 이 라우트 자체가 등록되지 않는다.
+      parameters:
+      - description: 등록 정보
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/DemoDeviceRegistrationRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/DeviceRegistrationCreatedResponse'
+        "404":
+          description: 'NOT_FOUND: 데모 모드가 비활성화되었거나 데모 캠프를 찾을 수 없음'
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+      summary: App Store 심사용 데모 기기 등록
+      tags:
+      - A. Auth & Device Trust
   /device-registrations:
     post:
       consumes:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -17,6 +17,13 @@ ADMIN_BOOTSTRAP_PASSWORD=
 # Controls behavior like DB query parameter logging
 APP_ENV=production
 
+# App Store review demo mode (leave unset in production).
+# When set, POST /demo/device-registrations auto-approves registrations against the camp
+# whose name matches this value exactly. When unset, that route is not registered at all
+# (behaves as if it doesn't exist). Set this on a dedicated review deployment only, never
+# on production, and only after manually creating a camp with this exact name.
+DEMO_CAMP_NAME=
+
 # Log Level (e.g., debug, info, warn, error)
 LOGLEVEL=info
 

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -157,7 +157,11 @@ func main() {
 	// Initialize Usecases
 	authAdminService := usecase.NewAdminAuthService(adminRepo, adminSessionRepo, facilitatorSessionRepo, trackRepo, cornerRepo, broadcaster, auditLogRepo, txManager)
 
-	deviceTrustService := usecase.NewDeviceTrustService(campRepo, deviceRepo, adminRepo, auditLogRepo, broadcaster, txManager)
+	// DEMO_CAMP_NAME은 App Store 심사용 review 배포에서만 설정한다. 운영에서는 빈 문자열로
+	// 두므로 RequestDemoRegistration이 항상 실패하고, 아래에서 demoHandler도 nil로 남아
+	// /demo/device-registrations 라우트 자체가 등록되지 않는다.
+	demoCampName := os.Getenv("DEMO_CAMP_NAME")
+	deviceTrustService := usecase.NewDeviceTrustService(campRepo, deviceRepo, adminRepo, auditLogRepo, broadcaster, txManager, demoCampName)
 	cornerService := usecase.NewCornerService(campRepo, cornerRepo, trackRepo, groupRepo, adminRepo, auditLogRepo, broadcaster, txManager)
 	cornerViewQuerier := postgres.NewCornerViewQuerier(pool)
 	groupService := usecase.NewGroupService(campRepo, cornerRepo, trackRepo, groupRepo, badgeRepo, visitRepo, adminRepo, auditLogRepo, txManager)
@@ -174,6 +178,10 @@ func main() {
 	// Initialize Handlers
 	authHandler := web.NewAuthHandler(authAdminService, authFacilitatorService, deviceTrustService)
 	deviceHandler := web.NewDeviceHandler(deviceTrustService)
+	var demoHandler *web.DemoHandler
+	if demoCampName != "" {
+		demoHandler = web.NewDemoHandler(deviceTrustService)
+	}
 	campHandler := web.NewCampHandler(campService)
 	cornerHandler := web.NewCornerHandler(cornerService, cornerViewQuerier)
 	trackHandler := web.NewTrackHandler(trackService)
@@ -192,6 +200,7 @@ func main() {
 	handlers := &web.Handlers{
 		Auth:            authHandler,
 		Device:          deviceHandler,
+		Demo:            demoHandler,
 		Camp:            campHandler,
 		Corner:          cornerHandler,
 		Track:           trackHandler,

--- a/backend/db/query.sql
+++ b/backend/db/query.sql
@@ -4,6 +4,11 @@ SELECT * FROM camps WHERE id = $1;
 -- name: GetCampByRegistrationCode :one
 SELECT * FROM camps WHERE registration_code = $1;
 
+-- name: GetCampByName :one
+-- App Store 심사용 데모 캠프를 이름으로 조회하기 위한 전용 쿼리 (DEMO_CAMP_NAME).
+-- name은 UNIQUE 제약이 없으므로 여러 행이 일치할 수 있어 LIMIT 1로 첫 번째만 취한다.
+SELECT * FROM camps WHERE name = $1 LIMIT 1;
+
 -- name: SaveCamp :exec
 INSERT INTO camps (id, name, start_at, end_at, activated_at, ended_at, status, bottleneck_min_samples, bottleneck_ratio_pct, registration_code)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)

--- a/backend/docs/artifacts/plan/20260820_앱스토어_심사용_데모환경_plan_.md
+++ b/backend/docs/artifacts/plan/20260820_앱스토어_심사용_데모환경_plan_.md
@@ -82,18 +82,29 @@ down` 시에도 volume을 지우지 않으면 데이터가 유지되므로, 한 
   `GetByRegistrationCode`와 완전히 동일한 패턴(sqlc 쿼리 1개 + 리포지토리 메서드 1개)으로
   추가했다.
 
-## 구현 중 발견한 사실 (설계 문서 대비 정정)
+## 구현 중 발견한 기존 버그 — Phase A' (별도 수정)
 
-echo v4 라우터는 같은 prefix(`/api/v1`)를 공유하는 여러 `Group`(`v1` 자신 + `admin`/`track`/
-`message` 서브그룹)이 있을 때, 그 prefix 아래 **미등록 경로 전부**를 마지막에 등록된
-서브그룹의 미들웨어(이 코드베이스에서는 `AdminAuthMiddleware`)로 흘려보낸다. 그래서
-`Handlers.Demo == nil`일 때 `/demo/device-registrations`를 두드리면 echo 표준 404가 아니라
-`401 {"code":"UNAUTHORIZED","message":"missing token"}`이 나온다 — 이건 이번 변경과 무관한
-기존 라우터 동작이며(`/api/v1/그-어떤-존재하지-않는-경로`도 전부 동일한 401을 반환), 오히려
-목적엔 더 잘 맞는다: `/demo/device-registrations`를 두드려도 아무 존재하지 않는 다른 경로와
-**완전히 동일한 응답**이 나와서, 이 경로가 특별한 의미를 가진다는 신호 자체가 없다. 검증
-체크리스트와 아래 라우팅 테스트도 이 사실에 맞춰 "echo 표준 404"가 아니라 "임의의 미등록
-경로와 동일한 응답"으로 정정했다.
+라우팅 테스트를 작성하다가, 이번 변경과 무관한 **기존 버그**를 발견해 별도로 고쳤다.
+
+**증상**: echo v4에서 `Group.Use(middleware)`를 호출하면, echo가 그 그룹의 prefix에 404
+폴백 라우트를 자동 등록하고 그 폴백에도 그룹 미들웨어를 그대로 씌운다
+(`echo/group.go`의 `Use()` 구현 — `g.RouteNotFound("", ...)` / `g.RouteNotFound("/*", ...)`).
+이 코드베이스의 `admin`/`track`/`message` 서브그룹이 전부 `v1.Group("")`으로 만들어져 `v1`
+자신과 **완전히 같은 prefix**(`/api/v1`)를 공유하기 때문에, 이 자동 등록들이 라우팅 트리의
+같은 노드에서 서로 덮어쓴다. 그 결과 `/api/v1` 아래 **실제로 등록된 적 없는 모든 경로**가
+`404 Not Found`가 아니라 `401 {"code":"UNAUTHORIZED","message":"missing token"}`을 반환하고
+있었다 — `/demo/device-registrations`뿐 아니라 아무 오타 URL을 넣어도 마찬가지였다.
+
+**수정**: `RegisterRoutes` 마지막에 `v1.RouteNotFound("/*", ...)`으로 순수 404 핸들러(인증
+미들웨어 없음)를 명시적으로 등록해, 서브그룹들이 자동 등록한 폴백을 덮어쓴다(같은 노드의
+`notFoundHandler`는 마지막 등록이 이긴다 — `echo/router.go`의 `addMethod`에서 확인).
+`internal/infrastructure/web/router.go` 변경, `TestUndefinedRouteShouldReturnPlain404...`/
+`TestRealProtectedRoutesShouldStillRequireAuthAfter404Fix`로 회귀(진짜 보호된 라우트가
+인증 없이 열리지 않는지)까지 검증했다.
+
+이 발견 이후 `/demo/device-registrations`도 `Handlers.Demo == nil`일 때 진짜 순수 404를
+반환한다 — 애초 설계 의도("엔드포인트가 존재하지 않는 것처럼 보인다")를 문자 그대로
+만족한다.
 
 ## Phase A: 데모 전용 기기 등록 엔드포인트 — ✅ 구현 완료
 
@@ -235,8 +246,12 @@ registrations` 요청부터 바로 그 캠프가 조회된다.
       기존 테스트가 그대로 통과 — 회귀 없음 확인 (`go test ./...` 전체 통과)
 - [x] `go test ./...`, `gofmt -w . && go vet ./...` 통과
 - [x] `internal/infrastructure/web/router_test.go`에 라우팅 테스트 추가 — `Handlers.Demo ==
-      nil`일 때 `/demo/device-registrations`가 임의의 미등록 경로와 완전히 동일한 응답을
-      반환하는지, `Handlers.Demo != nil`일 때 라우트가 실제 등록되는지 확인
+      nil`일 때 `/demo/device-registrations`가 순수 404(`CodeNotFound`, 인증 미들웨어를
+      거치지 않음)를 반환하는지, `Handlers.Demo != nil`일 때 라우트가 실제 등록되는지 확인
+- [x] echo 그룹 prefix 공유로 인한 기존 404/401 오반환 버그를 `v1.RouteNotFound("/*", ...)`
+      명시적 등록으로 수정, `TestUndefinedRouteShouldReturnPlain404RegardlessOfHowManyAuth
+      GroupsSharePrefix`/`TestRealProtectedRoutesShouldStillRequireAuthAfter404Fix`로
+      회귀(진짜 보호된 라우트는 여전히 401) 검증
 - [x] `make swag`로 `api/swagger.yaml`/`api/swagger.json`/`api/docs.go` 재생성,
       `/demo/device-registrations` 경로 포함 확인 (API 스키마 우선 원칙)
 - [ ] review 배포에서 실제로 `POST /demo/device-registrations` 호출 → 응답에 담긴

--- a/backend/docs/artifacts/plan/20260820_앱스토어_심사용_데모환경_plan_.md
+++ b/backend/docs/artifacts/plan/20260820_앱스토어_심사용_데모환경_plan_.md
@@ -1,0 +1,256 @@
+# 앱스토어 심사용 데모 백엔드 환경 구축 계획
+
+## 배경 (Context)
+
+진행자 앱과 관리자 앱 모두 Apple App Store 심사 제출을 앞두고 있다. 두 앱 모두 현재
+설계상 데모 개념이 전혀 없다:
+
+- 진행자 앱: 기기 등록(`POST /device-registrations`) 후 **관리자가 수동으로 승인**해야만
+  PIN 로그인이 가능하다. 심사관은 관리자 접근 권한이 없어 이 단계에서 막힌다.
+- 관리자 앱: `GET /camps`가 로그인한 관리자가 누구든 **DB의 전체 캠프를 그대로 반환**한다
+  (`internal/usecase/camp.go` `ListCamps`, camp_id 필터/actor 인자 없음). 심사관에게 아무
+  관리자 계정이나 쥐어주면 운영 중인 실캠프 데이터가 그대로 노출된다.
+
+### 검토했다가 기각한 방향
+
+**캠프 단위 `is_demo` DB 플래그**: 향후 관리자 콘솔에 캠프 설정 UI가 생기면 실캠프에 실수로
+켜질 수 있고, 켜지는 순간 그 캠프의 기기 등록이 전부 자동승인되는 조용한 보안 사고로
+이어진다. 기각.
+
+(과정 중 "심사용 빌드는 배포되는 바이너리와 달라선 안 된다"는 이유로 별도 배포 자체를 한 번
+기각했었으나, 이는 오해였다 — 바이너리를 review 전용으로 따로 만드는 게 문제였을 뿐, **같은
+바이너리가 API base URL 두 개를 다 갖고 상황에 따라 스위칭**하는 건 아무 문제가 없다. 그
+전제로 별도 배포 방향을 되살린다.)
+
+### 최종 방향
+
+**심사용 backend를 별도 배포(별도 DB)로 완전히 분리한다.** 그 배포 안에는 실캠프가 애초에
+존재하지 않으므로:
+- 기기 등록을 자동승인해도 안전하다 (자동승인 대상이 될 실캠프가 없음)
+- 관리자 앱에 실제 데모 계정을 발급해도 그 DB에 데모 캠프 하나만 있으므로 안전하다 —
+  `GET /camps`가 데모 캠프만 반환한다. 별도 RBAC 구현이 필요 없다.
+
+프론트는 **같은 바이너리 안에 운영/데모 두 API base URL을 모두 갖고, 앱 내에서 스위칭**하는
+방식으로 대응한다 (예: 설정 화면의 서버 선택, 또는 별도 진입점). 이 부분은 프론트 작업이라
+이 계획서 범위 밖이다.
+
+배포 인프라(별도 DB/컨테이너 구성)는 사용자가 직접 설정하므로 이 계획서의 유스케이스에서
+제외한다. 데모 캠프/코너/트랙도 시드 배치 없이 **review 배포에 뜬 관리자 앱으로 직접 수동
+생성**한다 — 기존 관리자 UI/API를 그대로 쓰면 되므로 새 코드가 필요 없다. `docker compose
+down` 시에도 volume을 지우지 않으면 데이터가 유지되므로, 한 번만 수동으로 채워두면 이후
+재배포마다 다시 만들 필요도 없다.
+
+캠프-스코프 관리자 RBAC 자체는 이번 데모 문제와는 무관하게 존재하던 진짜 설계 부채이므로
+(GitHub Issue #236), 이 계획에서 다루지 않는다 — 별도 review DB로 분리하는 이번 방향은 그
+부채를 메우는 게 아니라 우회하는 것일 뿐이라는 점에 유의.
+
+## 유즈케이스
+
+| 우선순위 | 유즈케이스 | 설명 | 용도 |
+|---|---|---|---|
+| **P0** | UC-D1: 데모 전용 기기 등록 엔드포인트 | 기존 `/device-registrations`와 별개인 새 엔드포인트. 환경변수로 지정된 **캠프 이름**과 일치하는 캠프를 찾아 등록과 동시에 자동 `Approve`. **환경변수가 비어 있으면 라우터에 아예 등록되지 않아, 외부에서 보면 다른 어떤 미등록 경로와도 구분되지 않는 응답이 나온다** (아래 "구현 중 발견한 사실" 참고) | **review 배포 전용** |
+| **P0** | UC-D2: 리뷰용 관리자 계정 | 기존 `BootstrapAdmin`을 그대로 재사용, review 배포에만 별도 `ADMIN_BOOTSTRAP_USERNAME/PASSWORD` 설정 | review 배포 초기화용 (신규 코드 없음) |
+
+## 아키텍처 원칙
+
+- **기존 `POST /device-registrations`(운영 경로)는 단 한 줄도 건드리지 않는다.** 자동승인은
+  완전히 별도의 새 엔드포인트로만 존재한다 — 실제 진행자가 쓰는 등록 흐름과 코드 경로가
+  섞이지 않으므로 회귀 위험이 0에 가깝다.
+- **엔드포인트 존재 자체가 환경변수에 종속된다.** `internal/infrastructure/web/router.go`에
+  이미 있는 nil-핸들러 옵션 등록 관례(`if h.Camp != nil { ... }`, DEVELOPER_GUIDE §4.2 —
+  원래는 통합 테스트에서 일부 핸들러만 wiring할 때 쓰던 패턴)를 그대로 재사용한다.
+  `cmd/server/main.go`가 환경변수를 읽어 값이 있을 때만 `DemoHandler`를 생성해 넘기고, 없으면
+  `nil`을 넘긴다 — `nil`이면 라우트 자체가 등록되지 않는다.
+  도메인 에러를 4xx로 매핑하는 게 아니라 **라우팅 테이블에 그 경로가 물리적으로 없다** —
+  이게 "외부에서 존재하지 않는 것처럼 보인다"는 요구를 가장 문자 그대로 만족한다.
+- **자동승인 대상 캠프를 "캠프 이름"으로 식별한다 — 등록코드가 아니다.** 등록코드는
+  `GenerateRegistrationCode()`로 캠프 생성 시점에 서버가 무작위 생성하는 값이라(#233),
+  "캠프를 먼저 만들고 → 생성된 코드를 읽어서 → env var에 넣고 → 재배포"라는 불필요한 왕복이
+  생긴다. 캠프 **이름**은 관리자가 캠프 생성 화면에 직접 타이핑하는 값이라 운영자가 배포
+  *이전에* 미리 정해서 env var에 넣어둘 수 있다 — 캠프를 그 이름으로 만들기만 하면 재배포
+  없이 바로 다음 요청부터 인식된다 (조회는 매 요청마다 DB에서 하므로 캐시/재시작 이슈 없음).
+  review DB에 나중에 다른 목적의 캠프가 추가되더라도, 이름이 다르면 자동승인 대상이 아니라는
+  점은 등록코드 매칭과 동일하게 유지된다.
+- **기존 포트/유스케이스 전부 재사용.** `DeviceTrustService`에 새 메서드 하나만 추가하고,
+  등록+승인 각각의 기존 로직(`RequestRegistration`/`ApproveDevice` 내부 흐름)을 그대로
+  참고한다 — 상태 전이 자체는 `domain.DeviceRegistration.Approve()`를 그대로 쓴다.
+  `CampService.OpenNewCamp/ActivateCamp`, `CornerService.AddLearningCorner`,
+  `TrackService.CreateTrack`, `usecase.BootstrapAdmin`도 데모 데이터 준비에 그대로 재사용한다.
+- **캠프 조회는 `List` 전체 스캔이 아니라 전용 인덱스 조회로 한다.** DEVELOPER_GUIDE §5가
+  명시하는 기존 관례("리포지토리 조회는 항상 `GetByTokenHash`/`GetByAccessTokenHash` 형태") —
+  `GetByRegistrationCode`가 이미 같은 자리에 있는 전례다. `CampRepository.GetByName`을
+  `GetByRegistrationCode`와 완전히 동일한 패턴(sqlc 쿼리 1개 + 리포지토리 메서드 1개)으로
+  추가했다.
+
+## 구현 중 발견한 사실 (설계 문서 대비 정정)
+
+echo v4 라우터는 같은 prefix(`/api/v1`)를 공유하는 여러 `Group`(`v1` 자신 + `admin`/`track`/
+`message` 서브그룹)이 있을 때, 그 prefix 아래 **미등록 경로 전부**를 마지막에 등록된
+서브그룹의 미들웨어(이 코드베이스에서는 `AdminAuthMiddleware`)로 흘려보낸다. 그래서
+`Handlers.Demo == nil`일 때 `/demo/device-registrations`를 두드리면 echo 표준 404가 아니라
+`401 {"code":"UNAUTHORIZED","message":"missing token"}`이 나온다 — 이건 이번 변경과 무관한
+기존 라우터 동작이며(`/api/v1/그-어떤-존재하지-않는-경로`도 전부 동일한 401을 반환), 오히려
+목적엔 더 잘 맞는다: `/demo/device-registrations`를 두드려도 아무 존재하지 않는 다른 경로와
+**완전히 동일한 응답**이 나와서, 이 경로가 특별한 의미를 가진다는 신호 자체가 없다. 검증
+체크리스트와 아래 라우팅 테스트도 이 사실에 맞춰 "echo 표준 404"가 아니라 "임의의 미등록
+경로와 동일한 응답"으로 정정했다.
+
+## Phase A: 데모 전용 기기 등록 엔드포인트 — ✅ 구현 완료
+
+**파일**: `db/query.sql`, `internal/usecase/port.go`, `internal/infrastructure/postgres/camp_repo.go`,
+`internal/usecase/device_trust.go`, `internal/infrastructure/web/demo_handler.go`(신규),
+`internal/infrastructure/web/device_handler.go`, `internal/infrastructure/web/router.go`,
+`cmd/server/main.go`, `.env.example`
+
+실제 구현은 아래 최초 설계와 거의 동일하며, 다음만 차이가 있다:
+- `mapCamp` 헬퍼로 `Get`/`GetByRegistrationCode`/`GetByName` 세 조회 경로의 매핑 로직을
+  통합했다 (기존 `Get`/`GetByRegistrationCode`가 매핑 블록을 중복 보유하고 있던 걸, 세 번째
+  중복이 생기는 시점에 정리).
+- 인터페이스 변경(`CampRepository.GetByName`, `DeviceTrustUsecase.RequestDemoRegistration`
+  추가)으로 깨진 기존 목/스텁(`MockCampRepository`, `campRepositoryStub`,
+  `listDeviceTrustStub`)에 각각 메서드를 추가했다.
+- `RequestDemoRegistration`이 저장 전 메모리상에서 바로 `Approve()`를 호출해 1회만 저장하는
+  방식으로 구현됐다(설계 문서의 "토큰 생성 → 저장 → 재저장" 2단계 대신, 아직 영속화 전이라
+  1단계로 충분함).
+
+```sql
+-- db/query.sql, GetCampByRegistrationCode 바로 아래
+-- name: GetCampByName :one
+SELECT * FROM camps WHERE name = $1 LIMIT 1;
+```
+
+```go
+// internal/usecase/port.go — CampRepository
+GetByName(ctx context.Context, name string) (*domain.Camp, error)
+```
+
+```go
+// internal/infrastructure/postgres/camp_repo.go
+func mapCamp(row db.Camp) *domain.Camp { /* Get/GetByRegistrationCode/GetByName 공유 */ }
+func (r *pgCampRepository) GetByName(ctx context.Context, name string) (*domain.Camp, error) {
+    row, err := r.queries(ctx).GetCampByName(ctx, name)
+    if err != nil {
+        if err == pgx.ErrNoRows {
+            return nil, nil
+        }
+        return nil, errs.Wrap(ctx, err)
+    }
+    return mapCamp(row), nil
+}
+```
+
+```go
+// internal/usecase/device_trust.go
+type DeviceTrustService struct {
+    // ...기존 필드...
+    demoCampName string // review 배포 전용. 운영에서는 항상 빈 문자열.
+}
+
+func (s *DeviceTrustService) RequestDemoRegistration(
+    ctx context.Context,
+    deviceName, deviceModel, displayName string,
+) (string, *domain.DeviceRegistration, error) {
+    if s.demoCampName == "" {
+        return "", nil, withErrorContext(..., domain.ErrCampNotFound, nil)
+    }
+    camp, err := s.camps.GetByName(ctx, s.demoCampName)
+    // nil 체크 → ErrCampNotFound
+    campID := camp.ID()
+    // 토큰 생성 → DeviceRegistrationProps{Status: DevicePending, ...} 구성
+    // → reg.Approve(now) (저장 전, 메모리상에서) → 1회 Save (tx 안)
+    // → 감사로그 ActionDeviceRequest + ActionDeviceApproved (actor="system",
+    //   actorName="system:demo_auto_approve") → Broadcast
+}
+```
+
+```go
+// internal/infrastructure/web/demo_handler.go (신규)
+type DemoHandler struct { deviceTrust DeviceTrustUsecase } // 기존 인터페이스 재사용
+
+type DemoDeviceRegistrationRequest struct { // registrationCode 없음
+    DeviceName, DeviceModel, DisplayName string
+} // @name DemoDeviceRegistrationRequest
+
+func (h *DemoHandler) RequestDemoRegistration(c echo.Context) error {
+    // 요청 바인딩 → deviceTrust.RequestDemoRegistration 호출
+    // → 에러는 기존 deviceRegistrationHTTPError(err) 재사용
+    // → 성공 시 기존 DeviceRegistrationCreatedResponse로 응답 (mapDeviceRegistration 재사용)
+}
+```
+
+```go
+// internal/infrastructure/web/router.go
+type Handlers struct {
+    // ...
+    Demo *DemoHandler // nil이면 이 라우트 자체가 등록되지 않음
+}
+
+if h.Demo != nil {
+    v1.POST("/demo/device-registrations", h.Demo.RequestDemoRegistration)
+}
+```
+
+```go
+// cmd/server/main.go
+demoCampName := os.Getenv("DEMO_CAMP_NAME") // review 배포에서만 값이 설정됨
+deviceTrustService := usecase.NewDeviceTrustService(
+    campRepo, deviceRepo, adminRepo, auditLogRepo, broadcaster, txManager, demoCampName,
+)
+var demoHandler *web.DemoHandler
+if demoCampName != "" {
+    demoHandler = web.NewDemoHandler(deviceTrustService)
+}
+// handlers := &web.Handlers{ ..., Demo: demoHandler }
+```
+
+review 배포가 애플리케이션 쪽에서 필요로 하는 환경변수 (배포 구성 자체는 범위 밖):
+- `DATABASE_URL` — 운영과 완전히 다른 DB를 가리켜야 함
+- `DEMO_CAMP_NAME=<운영자가 미리 정한 캠프 이름>` (예: `App Store Review Demo`) —
+  **캠프를 만들기 전에** 먼저 이 값을 정해서 배포한다. `.env.example`에 문서화 완료.
+- `ADMIN_BOOTSTRAP_USERNAME` / `ADMIN_BOOTSTRAP_PASSWORD` — 리뷰어에게 전달할 전용 관리자 계정
+- `TRACK_PIN_ENCRYPTION_KEY` — 운영과 다른 키
+
+서버가 뜨고 `BootstrapAdmin`으로 관리자 계정이 만들어지면, 그 계정으로 관리자 앱에 로그인해
+캠프 개설(이때 캠프 이름을 `DEMO_CAMP_NAME`과 **정확히 동일하게** 입력)→활성화→코너/트랙
+생성을 **수동으로 1회** 진행한다 — 이 시점에 재배포는 필요 없다, 다음 `/demo/device-
+registrations` 요청부터 바로 그 캠프가 조회된다.
+
+## Phase B: 프론트 — 같은 바이너리에서 운영/데모 backend 스위칭 (범위 밖)
+
+앱이 운영 API base URL과 review API base URL을 모두 갖고 있다가, 실행 중 스위칭하는 로직은
+`workflow/repo.md`의 "작업 범위 준수" 원칙에 따라 프론트엔드 작업이다. 이 계획서는 백엔드만
+다루므로, 이 부분은 별도 프론트 이슈로 분리해 전달이 필요하다는 점만 여기 기록해둔다.
+
+## 검증 체크리스트
+
+- [x] `sqlc generate` 실행 후 `internal/infrastructure/postgres/db` 생성물에 `GetCampByName`
+      반영 확인
+- [x] `internal/infrastructure/postgres`에 `mapCamp`(→`GetByName` 포함) 유닛 테스트 추가
+      (`camp_repo_test.go`, 이 저장소의 postgres 테스트는 실제 DB가 아니라 row→domain 매핑
+      함수를 직접 검증하는 방식이라 그 관례를 따름)
+- [x] `internal/usecase/device_trust_test.go`에 `RequestDemoRegistration` 케이스 추가:
+      `demoCampName=""` → `ErrCampNotFound`, 일치하는 캠프 있음 → `APPROVED` 저장 +
+      `CampID` 정확히 채워짐, 일치하는 캠프 없음 → `ErrCampNotFound`
+- [x] 기존 `RequestRegistration`/`Login` 등은 이번 변경으로 코드 자체가 손대지지 않았으므로
+      기존 테스트가 그대로 통과 — 회귀 없음 확인 (`go test ./...` 전체 통과)
+- [x] `go test ./...`, `gofmt -w . && go vet ./...` 통과
+- [x] `internal/infrastructure/web/router_test.go`에 라우팅 테스트 추가 — `Handlers.Demo ==
+      nil`일 때 `/demo/device-registrations`가 임의의 미등록 경로와 완전히 동일한 응답을
+      반환하는지, `Handlers.Demo != nil`일 때 라우트가 실제 등록되는지 확인
+- [x] `make swag`로 `api/swagger.yaml`/`api/swagger.json`/`api/docs.go` 재생성,
+      `/demo/device-registrations` 경로 포함 확인 (API 스키마 우선 원칙)
+- [ ] review 배포에서 실제로 `POST /demo/device-registrations` 호출 → 응답에 담긴
+      `deviceToken`으로 `GET /device-registrations/me`를 조회하면 즉시 `APPROVED`인지
+      curl/실기기로 확인 — **실제 review 배포가 있어야 가능, 이 세션 범위 밖**
+- [ ] review 배포에서 관리자 로그인 후 `GET /camps`가 (수동으로 만든) 데모 캠프 1개만
+      반환하는지 확인 — 위와 동일 사유로 범위 밖
+- [ ] `docker compose down` 후 volume을 유지한 채 재기동해도 수동으로 넣은 데모 캠프/코너/
+      트랙/관리자 계정 데이터가 그대로 남아있는지 확인 — 위와 동일 사유로 범위 밖
+- [ ] 트랙 PIN/관리자 계정을 App Store 심사 노트에 기재 — 실제 배포 이후 사용자가 진행
+
+## 백로그로 분리 (이번 계획에 포함하지 않음)
+
+- **캠프-스코프 관리자 RBAC** (GitHub Issue #236): `admins` 테이블에 캠프 접근범위 개념을
+  추가하고 `GET /camps` 등 캠프-스코프 조회/조작 API 전반에 소유권 체크를 추가하는 작업.
+  데모와 무관하게 존재하던 설계 공백이며, 여러 캠프/조직이 실제로 관리자 계정을 나눠 써야
+  하는 시점이 오면 반드시 필요하다.

--- a/backend/internal/infrastructure/postgres/camp_repo.go
+++ b/backend/internal/infrastructure/postgres/camp_repo.go
@@ -27,15 +27,9 @@ func (r *pgCampRepository) queries(ctx context.Context) *db.Queries {
 	return db.New(r.pool)
 }
 
-func (r *pgCampRepository) Get(ctx context.Context, id domain.CampID) (*domain.Camp, error) {
-	row, err := r.queries(ctx).GetCamp(ctx, string(id))
-	if err != nil {
-		if err == pgx.ErrNoRows {
-			return nil, nil
-		}
-		return nil, errs.Wrap(ctx, err)
-	}
-
+// mapCamp는 db.Camp row를 domain.Camp로 변환합니다. Get/GetByRegistrationCode/GetByName이
+// 공유합니다.
+func mapCamp(row db.Camp) *domain.Camp {
 	camp := domain.NewCampFromProps(domain.CampProps{
 		ID:                   domain.CampID(row.ID),
 		RegistrationCode:     row.RegistrationCode,
@@ -59,7 +53,18 @@ func (r *pgCampRepository) Get(ctx context.Context, id domain.CampID) (*domain.C
 		camp.SetEndedAt(domain.None[time.Time]())
 	}
 
-	return camp, nil
+	return camp
+}
+
+func (r *pgCampRepository) Get(ctx context.Context, id domain.CampID) (*domain.Camp, error) {
+	row, err := r.queries(ctx).GetCamp(ctx, string(id))
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, errs.Wrap(ctx, err)
+	}
+	return mapCamp(row), nil
 }
 
 func (r *pgCampRepository) GetByRegistrationCode(ctx context.Context, code string) (*domain.Camp, error) {
@@ -70,31 +75,19 @@ func (r *pgCampRepository) GetByRegistrationCode(ctx context.Context, code strin
 		}
 		return nil, errs.Wrap(ctx, err)
 	}
+	return mapCamp(row), nil
+}
 
-	camp := domain.NewCampFromProps(domain.CampProps{
-		ID:                   domain.CampID(row.ID),
-		RegistrationCode:     row.RegistrationCode,
-		Name:                 row.Name,
-		StartAt:              row.StartAt.Time,
-		EndAt:                row.EndAt.Time,
-		Status:               domain.CampStatus(row.Status),
-		BottleneckMinSamples: int(row.BottleneckMinSamples),
-		BottleneckRatioPct:   int(row.BottleneckRatioPct),
-	})
-
-	if row.ActivatedAt.Valid {
-		camp.SetActivatedAt(domain.Some(row.ActivatedAt.Time))
-	} else {
-		camp.SetActivatedAt(domain.None[time.Time]())
+// GetByName은 App Store 심사용 데모 캠프를 이름으로 조회하는 용도로만 쓰인다.
+func (r *pgCampRepository) GetByName(ctx context.Context, name string) (*domain.Camp, error) {
+	row, err := r.queries(ctx).GetCampByName(ctx, name)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, nil
+		}
+		return nil, errs.Wrap(ctx, err)
 	}
-
-	if row.EndedAt.Valid {
-		camp.SetEndedAt(domain.Some(row.EndedAt.Time))
-	} else {
-		camp.SetEndedAt(domain.None[time.Time]())
-	}
-
-	return camp, nil
+	return mapCamp(row), nil
 }
 
 func (r *pgCampRepository) Save(ctx context.Context, camp *domain.Camp) error {

--- a/backend/internal/infrastructure/postgres/camp_repo_test.go
+++ b/backend/internal/infrastructure/postgres/camp_repo_test.go
@@ -1,0 +1,60 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	"cornermon/backend/internal/domain"
+	"cornermon/backend/internal/infrastructure/postgres/db"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+func TestShouldMapNameAndStatusWhenMappingCampRow(t *testing.T) {
+	// Arrange - Get/GetByRegistrationCode/GetByName은 모두 이 mapCamp 헬퍼를 공유하므로,
+	// 헬퍼 하나만 검증하면 세 조회 경로 모두 동일하게 검증된다.
+	row := db.Camp{
+		ID:                   "camp-1",
+		Name:                 "App Store Review Demo",
+		RegistrationCode:     "REGCODE1",
+		StartAt:              pgtype.Timestamptz{Time: time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), Valid: true},
+		EndAt:                pgtype.Timestamptz{Time: time.Date(2026, 8, 2, 0, 0, 0, 0, time.UTC), Valid: true},
+		Status:               "ACTIVE",
+		BottleneckMinSamples: 3,
+		BottleneckRatioPct:   20,
+	}
+
+	// Act
+	got := mapCamp(row)
+
+	// Assert
+	if got.Name() != "App Store Review Demo" {
+		t.Errorf("expected Name 'App Store Review Demo', got %q", got.Name())
+	}
+	if got.Status() != domain.CampActive {
+		t.Errorf("expected Status ACTIVE, got %q", got.Status())
+	}
+	if _, ok := got.ActivatedAt().Value(); ok {
+		t.Errorf("expected ActivatedAt None when row.ActivatedAt is invalid, got Some")
+	}
+}
+
+func TestShouldMapActivatedAtWhenRowHasValidActivatedAt(t *testing.T) {
+	// Arrange
+	activatedAt := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	row := db.Camp{
+		ID:          "camp-1",
+		Name:        "캠프",
+		Status:      "ACTIVE",
+		ActivatedAt: pgtype.Timestamptz{Time: activatedAt, Valid: true},
+	}
+
+	// Act
+	got := mapCamp(row)
+
+	// Assert
+	value, ok := got.ActivatedAt().Value()
+	if !ok || !value.Equal(activatedAt) {
+		t.Errorf("expected ActivatedAt Some(%v), got ok=%v value=%v", activatedAt, ok, value)
+	}
+}

--- a/backend/internal/infrastructure/postgres/db/querier.go
+++ b/backend/internal/infrastructure/postgres/db/querier.go
@@ -22,6 +22,9 @@ type Querier interface {
 	GetBadge(ctx context.Context, id string) (Badge, error)
 	GetBadgeByQRPayload(ctx context.Context, qrPayload string) (Badge, error)
 	GetCamp(ctx context.Context, id string) (Camp, error)
+	// App Store 심사용 데모 캠프를 이름으로 조회하기 위한 전용 쿼리 (DEMO_CAMP_NAME).
+	// name은 UNIQUE 제약이 없으므로 여러 행이 일치할 수 있어 LIMIT 1로 첫 번째만 취한다.
+	GetCampByName(ctx context.Context, name string) (Camp, error)
 	GetCampByRegistrationCode(ctx context.Context, registrationCode string) (Camp, error)
 	GetCompletedVisitByGroupAndCorner(ctx context.Context, arg GetCompletedVisitByGroupAndCornerParams) (Visit, error)
 	GetCorner(ctx context.Context, id string) (Corner, error)

--- a/backend/internal/infrastructure/postgres/db/query.sql.go
+++ b/backend/internal/infrastructure/postgres/db/query.sql.go
@@ -184,6 +184,30 @@ func (q *Queries) GetCamp(ctx context.Context, id string) (Camp, error) {
 	return i, err
 }
 
+const getCampByName = `-- name: GetCampByName :one
+SELECT id, name, start_at, end_at, activated_at, ended_at, status, bottleneck_min_samples, bottleneck_ratio_pct, registration_code FROM camps WHERE name = $1 LIMIT 1
+`
+
+// App Store 심사용 데모 캠프를 이름으로 조회하기 위한 전용 쿼리 (DEMO_CAMP_NAME).
+// name은 UNIQUE 제약이 없으므로 여러 행이 일치할 수 있어 LIMIT 1로 첫 번째만 취한다.
+func (q *Queries) GetCampByName(ctx context.Context, name string) (Camp, error) {
+	row := q.db.QueryRow(ctx, getCampByName, name)
+	var i Camp
+	err := row.Scan(
+		&i.ID,
+		&i.Name,
+		&i.StartAt,
+		&i.EndAt,
+		&i.ActivatedAt,
+		&i.EndedAt,
+		&i.Status,
+		&i.BottleneckMinSamples,
+		&i.BottleneckRatioPct,
+		&i.RegistrationCode,
+	)
+	return i, err
+}
+
 const getCampByRegistrationCode = `-- name: GetCampByRegistrationCode :one
 SELECT id, name, start_at, end_at, activated_at, ended_at, status, bottleneck_min_samples, bottleneck_ratio_pct, registration_code FROM camps WHERE registration_code = $1
 `

--- a/backend/internal/infrastructure/web/demo_handler.go
+++ b/backend/internal/infrastructure/web/demo_handler.go
@@ -1,0 +1,55 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+type DemoHandler struct {
+	deviceTrust DeviceTrustUsecase
+}
+
+func NewDemoHandler(deviceTrust DeviceTrustUsecase) *DemoHandler {
+	return &DemoHandler{
+		deviceTrust: deviceTrust,
+	}
+}
+
+// DemoDeviceRegistrationRequest - 일반 DeviceRegistrationRequest와 달리 registrationCode가
+// 없다. 캠프는 서버가 배포 시 정해둔 이름(DEMO_CAMP_NAME)으로 이미 알고 있으므로 클라이언트가
+// 등록코드를 몰라도 된다.
+type DemoDeviceRegistrationRequest struct {
+	DeviceName  string `json:"deviceName"`
+	DeviceModel string `json:"deviceModel" example:"iPad Pro 11 2022"`
+	DisplayName string `json:"displayName" example:"1번 태블릿"`
+} // @name DemoDeviceRegistrationRequest
+
+// @Summary      App Store 심사용 데모 기기 등록
+// @Description  이 엔드포인트는 DEMO_CAMP_NAME 환경변수가 설정된 배포(App Store 리뷰 전용)에서만 존재한다. 등록과 동시에 즉시 승인 상태로 저장되므로 관리자 승인 대기가 없다. 운영 배포에는 이 라우트 자체가 등록되지 않는다.
+// @Tags         A. Auth & Device Trust
+// @Accept       json
+// @Produce      json
+// @Param        request body DemoDeviceRegistrationRequest true "등록 정보"
+// @Success      201 {object} DeviceRegistrationCreatedResponse
+// @Failure      404 {object} ErrorResponse "NOT_FOUND: 데모 모드가 비활성화되었거나 데모 캠프를 찾을 수 없음"
+// @Router       /demo/device-registrations [post]
+func (h *DemoHandler) RequestDemoRegistration(c echo.Context) error {
+	var req DemoDeviceRegistrationRequest
+	if err := c.Bind(&req); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, ErrorResponse{Code: CodeBadRequest, Message: "invalid request"}).SetInternal(err)
+	}
+
+	token, reg, err := h.deviceTrust.RequestDemoRegistration(c.Request().Context(), req.DeviceName, req.DeviceModel, req.DisplayName)
+	if err != nil {
+		// 일반 등록 엔드포인트와 동일한 에러 매핑을 재사용 — ErrCampNotFound가 404로
+		// 떨어지므로, 데모 캠프가 아직 없거나 데모 모드가 비활성화된 상태(demoCampName="")나
+		// 외부에서 보면 구분되지 않는다.
+		return deviceRegistrationHTTPError(err)
+	}
+
+	return c.JSON(http.StatusCreated, DeviceRegistrationCreatedResponse{
+		DeviceRegistrationResponse: mapDeviceRegistration(reg),
+		DeviceToken:                token,
+	})
+}

--- a/backend/internal/infrastructure/web/device_handler.go
+++ b/backend/internal/infrastructure/web/device_handler.go
@@ -16,6 +16,7 @@ import (
 type DeviceTrustUsecase interface {
 	GetMyRegistrationStatus(ctx context.Context, deviceToken string) (*usecase.DeviceRegistrationStatusView, error)
 	RequestRegistration(ctx context.Context, registrationCode string, deviceName, deviceModel, displayName string) (string, *domain.DeviceRegistration, error)
+	RequestDemoRegistration(ctx context.Context, deviceName, deviceModel, displayName string) (string, *domain.DeviceRegistration, error)
 	ApproveDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) (*domain.DeviceRegistration, error)
 	RejectDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) (*domain.DeviceRegistration, error)
 	RevokeDevice(ctx context.Context, regID domain.DeviceRegistrationID, actorAdminID domain.AdminID) (*domain.DeviceRegistration, error)

--- a/backend/internal/infrastructure/web/list_handlers_test.go
+++ b/backend/internal/infrastructure/web/list_handlers_test.go
@@ -39,6 +39,12 @@ func (s *listDeviceTrustStub) RequestRegistration(_ context.Context, registratio
 	}
 	return "token", s.requestedReg, nil
 }
+func (s *listDeviceTrustStub) RequestDemoRegistration(_ context.Context, _, _, _ string) (string, *domain.DeviceRegistration, error) {
+	if s.requestErr != nil {
+		return "", nil, s.requestErr
+	}
+	return "token", s.requestedReg, nil
+}
 func (s *listDeviceTrustStub) ApproveDevice(context.Context, domain.DeviceRegistrationID, domain.AdminID) (*domain.DeviceRegistration, error) {
 	return s.mutatedDevice, s.mutationErr
 }

--- a/backend/internal/infrastructure/web/report_handler_test.go
+++ b/backend/internal/infrastructure/web/report_handler_test.go
@@ -30,6 +30,15 @@ func (s *campRepositoryStub) GetByRegistrationCode(_ context.Context, code strin
 	return nil, nil
 }
 
+func (s *campRepositoryStub) GetByName(_ context.Context, name string) (*domain.Camp, error) {
+	for _, camp := range s.camps {
+		if camp.Name() == name {
+			return camp, nil
+		}
+	}
+	return nil, nil
+}
+
 func (s *campRepositoryStub) List(context.Context) ([]*domain.Camp, error) { return nil, nil }
 func (s *campRepositoryStub) Save(context.Context, *domain.Camp) error     { return nil }
 

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"net/http"
+
 	"github.com/labstack/echo/v4"
 )
 
@@ -183,4 +185,15 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 	if h.Event != nil {
 		track.GET("/events/track/:trackId", h.Event.TrackEvents)
 	}
+
+	// echo v4는 Group.Use()를 호출하면 그 그룹 전용 404 폴백을 그룹 자신의 prefix에 자동
+	// 등록하고, 그 폴백에도 그룹 미들웨어(AdminAuthMiddleware 등)를 그대로 씌운다. admin/
+	// track/message 그룹이 전부 v1과 같은 prefix("/api/v1")를 공유하는 구조라, 이 자동
+	// 등록이 서로 덮어써서 실제로 존재하지 않는 경로조차 401을 반환하게 된다 — 진짜 404여야
+	// 할 요청이 "인증되지 않음"으로 잘못 응답하는 기존 버그다. 가장 마지막에 v1 자신의
+	// prefix로 명시적인 404 핸들러를 등록해 이 자동 등록들을 덮어쓴다(라우팅 트리 노드당
+	// notFoundHandler는 마지막 등록이 이긴다) — 인증 미들웨어를 타지 않는 순수 404가 된다.
+	v1.RouteNotFound("/*", func(c echo.Context) error {
+		return echo.NewHTTPError(http.StatusNotFound, ErrorResponse{Code: CodeNotFound, Message: "not found"})
+	})
 }

--- a/backend/internal/infrastructure/web/router.go
+++ b/backend/internal/infrastructure/web/router.go
@@ -5,8 +5,12 @@ import (
 )
 
 type Handlers struct {
-	Auth            *AuthHandler
-	Device          *DeviceHandler
+	Auth   *AuthHandler
+	Device *DeviceHandler
+	// Demo는 App Store 심사용 데모 배포(DEMO_CAMP_NAME 환경변수가 설정된 경우)에서만
+	// non-nil이다. nil이면 /demo/device-registrations 라우트 자체가 등록되지 않아, 운영
+	// 배포에서는 이 엔드포인트가 echo의 표준 404로 "존재하지 않는 것처럼" 보인다.
+	Demo            *DemoHandler
 	Camp            *CampHandler
 	Corner          *CornerHandler
 	Track           *TrackHandler
@@ -39,6 +43,10 @@ func RegisterRoutes(e *echo.Echo, h *Handlers, adminAuth AuthAdminUsecase, track
 
 	v1.POST("/device-registrations", h.Device.RequestRegistration)
 	v1.GET("/device-registrations/me", h.Device.GetMyRegistrationStatus)
+
+	if h.Demo != nil {
+		v1.POST("/demo/device-registrations", h.Demo.RequestDemoRegistration)
+	}
 
 	admin := v1.Group("")
 	admin.Use(AdminAuthMiddleware(adminAuth))

--- a/backend/internal/infrastructure/web/router_test.go
+++ b/backend/internal/infrastructure/web/router_test.go
@@ -259,34 +259,24 @@ func TestDeviceRegistrationRoutesShouldBeScopedToCamp(t *testing.T) {
 }
 
 func TestDemoDeviceRegistrationRouteShouldOnlyExistWhenDemoHandlerIsSet(t *testing.T) {
-	t.Run("ShouldRespondIdenticallyToAnyUndefinedRouteWhenDemoHandlerIsNil", func(t *testing.T) {
+	t.Run("ShouldReturnPlain404WhenDemoHandlerIsNil", func(t *testing.T) {
 		// Arrange - 운영 배포와 동일한 상태(DEMO_CAMP_NAME 미설정 → Handlers.Demo == nil).
-		//
-		// echo v4는 같은 prefix("/api/v1")를 공유하는 여러 Group(v1 자신 + admin/track/
-		// message 서브그룹)이 있을 때, 그 prefix 아래의 미등록 경로 전부를 마지막에 등록된
-		// 서브그룹의 미들웨어(여기서는 AdminAuthMiddleware)로 흘려보낸다 — 그래서 진짜
-		// 존재하지 않는 라우트도 echo 표준 404가 아니라 401 "missing token"을 반환한다.
-		// 이건 이번 변경과 무관한 기존 라우터 동작이며, 오히려 우리 목적엔 더 잘 맞는다 —
-		// /demo/device-registrations를 두드려도 다른 아무 존재하지 않는 경로와 완전히
-		// 동일한 응답이 나와서 "이 경로가 특별히 존재하는지"에 대한 신호가 전혀 없다.
 		e := echo.New()
 		RegisterRoutes(e, &Handlers{Auth: &AuthHandler{}, Device: &DeviceHandler{}}, adminAuthForMessageRoutes{}, trackAuthForMessageRoutes{})
 
 		// Act
-		demoReq := httptest.NewRequest(http.MethodPost, "/api/v1/demo/device-registrations", strings.NewReader(`{}`))
-		demoReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-		demoRec := httptest.NewRecorder()
-		e.ServeHTTP(demoRec, demoReq)
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/demo/device-registrations", strings.NewReader(`{}`))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		rec := httptest.NewRecorder()
+		e.ServeHTTP(rec, req)
 
-		bogusReq := httptest.NewRequest(http.MethodPost, "/api/v1/totally-bogus-path-xyz", strings.NewReader(`{}`))
-		bogusReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
-		bogusRec := httptest.NewRecorder()
-		e.ServeHTTP(bogusRec, bogusReq)
-
-		// Assert
-		if demoRec.Code != bogusRec.Code || demoRec.Body.String() != bogusRec.Body.String() {
-			t.Fatalf("expected /demo/device-registrations to respond identically to an undefined route, got demo=%d %q bogus=%d %q",
-				demoRec.Code, demoRec.Body.String(), bogusRec.Code, bogusRec.Body.String())
+		// Assert - 도메인 에러를 4xx로 매핑한 결과도, 인증 미들웨어를 거쳐 나온 401도 아닌,
+		// 라우트 자체가 없어서 나오는 순수 404여야 한다.
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected status 404 when Demo handler is nil, got %d: %s", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), string(CodeNotFound)) {
+			t.Fatalf("expected body to contain %s, got %s", CodeNotFound, rec.Body.String())
 		}
 		for _, route := range e.Routes() {
 			if route.Path == "/api/v1/demo/device-registrations" {
@@ -313,4 +303,59 @@ func TestDemoDeviceRegistrationRouteShouldOnlyExistWhenDemoHandlerIsSet(t *testi
 			t.Fatal("expected /demo/device-registrations route to be registered when Demo handler is set")
 		}
 	})
+}
+
+// echo v4는 Group.Use()를 호출한 그룹마다 자기 prefix에 404 폴백을 자동 등록하고, 그
+// 폴백에도 그룹 미들웨어를 그대로 씌운다. admin/track/message 그룹이 v1과 같은 prefix를
+// 공유해서 이 자동 등록들이 서로 덮어쓰며, 고치기 전에는 진짜 존재하지 않는 경로조차
+// AdminAuthMiddleware를 타고 401을 반환했다 — 이 테스트는 그 회귀를 막는다.
+func TestUndefinedRouteShouldReturnPlain404RegardlessOfHowManyAuthGroupsShareThePrefix(t *testing.T) {
+	// Arrange - message 그룹까지 포함해 v1과 prefix를 공유하는 서브그룹을 최대한 채운다.
+	e := echo.New()
+	RegisterRoutes(e, &Handlers{
+		Auth:    &AuthHandler{},
+		Device:  &DeviceHandler{},
+		Message: NewMessageHandler(&messageUsecaseForHandler{}, nil, nil),
+	}, adminAuthForMessageRoutes{}, trackAuthForMessageRoutes{})
+
+	// Act
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/totally-bogus-path-xyz", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	// Assert
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected status 404 for a route that was never registered, got %d: %s", rec.Code, rec.Body.String())
+	}
+}
+
+// 위 404 수정이 실제 인증이 필요한 라우트의 인증 요구까지 없애버리지 않았는지 확인한다.
+func TestRealProtectedRoutesShouldStillRequireAuthAfter404Fix(t *testing.T) {
+	e := echo.New()
+	RegisterRoutes(e, &Handlers{
+		Auth:    &AuthHandler{},
+		Device:  &DeviceHandler{},
+		Message: NewMessageHandler(&messageUsecaseForHandler{}, nil, nil),
+	}, adminAuthForMessageRoutes{}, trackAuthForMessageRoutes{})
+
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{name: "admin route", method: http.MethodGet, path: "/api/v1/auth/track/sessions"},
+		{name: "track route", method: http.MethodPost, path: "/api/v1/auth/track/logout"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Act - 토큰 없이 호출
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			rec := httptest.NewRecorder()
+			e.ServeHTTP(rec, req)
+
+			// Assert - 여전히 401이어야 한다 (404로 바뀌면 안 됨 = 라우트는 실제로 존재)
+			if rec.Code != http.StatusUnauthorized {
+				t.Fatalf("expected status 401 for %s without token, got %d: %s", tc.path, rec.Code, rec.Body.String())
+			}
+		})
+	}
 }

--- a/backend/internal/infrastructure/web/router_test.go
+++ b/backend/internal/infrastructure/web/router_test.go
@@ -257,3 +257,60 @@ func TestDeviceRegistrationRoutesShouldBeScopedToCamp(t *testing.T) {
 		t.Fatal("expected legacy device registration route to be absent")
 	}
 }
+
+func TestDemoDeviceRegistrationRouteShouldOnlyExistWhenDemoHandlerIsSet(t *testing.T) {
+	t.Run("ShouldRespondIdenticallyToAnyUndefinedRouteWhenDemoHandlerIsNil", func(t *testing.T) {
+		// Arrange - 운영 배포와 동일한 상태(DEMO_CAMP_NAME 미설정 → Handlers.Demo == nil).
+		//
+		// echo v4는 같은 prefix("/api/v1")를 공유하는 여러 Group(v1 자신 + admin/track/
+		// message 서브그룹)이 있을 때, 그 prefix 아래의 미등록 경로 전부를 마지막에 등록된
+		// 서브그룹의 미들웨어(여기서는 AdminAuthMiddleware)로 흘려보낸다 — 그래서 진짜
+		// 존재하지 않는 라우트도 echo 표준 404가 아니라 401 "missing token"을 반환한다.
+		// 이건 이번 변경과 무관한 기존 라우터 동작이며, 오히려 우리 목적엔 더 잘 맞는다 —
+		// /demo/device-registrations를 두드려도 다른 아무 존재하지 않는 경로와 완전히
+		// 동일한 응답이 나와서 "이 경로가 특별히 존재하는지"에 대한 신호가 전혀 없다.
+		e := echo.New()
+		RegisterRoutes(e, &Handlers{Auth: &AuthHandler{}, Device: &DeviceHandler{}}, adminAuthForMessageRoutes{}, trackAuthForMessageRoutes{})
+
+		// Act
+		demoReq := httptest.NewRequest(http.MethodPost, "/api/v1/demo/device-registrations", strings.NewReader(`{}`))
+		demoReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		demoRec := httptest.NewRecorder()
+		e.ServeHTTP(demoRec, demoReq)
+
+		bogusReq := httptest.NewRequest(http.MethodPost, "/api/v1/totally-bogus-path-xyz", strings.NewReader(`{}`))
+		bogusReq.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		bogusRec := httptest.NewRecorder()
+		e.ServeHTTP(bogusRec, bogusReq)
+
+		// Assert
+		if demoRec.Code != bogusRec.Code || demoRec.Body.String() != bogusRec.Body.String() {
+			t.Fatalf("expected /demo/device-registrations to respond identically to an undefined route, got demo=%d %q bogus=%d %q",
+				demoRec.Code, demoRec.Body.String(), bogusRec.Code, bogusRec.Body.String())
+		}
+		for _, route := range e.Routes() {
+			if route.Path == "/api/v1/demo/device-registrations" {
+				t.Fatal("expected /demo/device-registrations route to be absent when Demo handler is nil")
+			}
+		}
+	})
+
+	t.Run("ShouldRegisterRouteWhenDemoHandlerIsSet", func(t *testing.T) {
+		// Arrange - review 배포와 동일한 상태(DEMO_CAMP_NAME 설정 → Handlers.Demo != nil).
+		e := echo.New()
+		RegisterRoutes(e, &Handlers{Auth: &AuthHandler{}, Device: &DeviceHandler{}, Demo: NewDemoHandler(&listDeviceTrustStub{})}, adminAuthForMessageRoutes{}, trackAuthForMessageRoutes{})
+
+		// Act
+		found := false
+		for _, route := range e.Routes() {
+			if route.Method == http.MethodPost && route.Path == "/api/v1/demo/device-registrations" {
+				found = true
+			}
+		}
+
+		// Assert
+		if !found {
+			t.Fatal("expected /demo/device-registrations route to be registered when Demo handler is set")
+		}
+	})
+}

--- a/backend/internal/usecase/device_trust.go
+++ b/backend/internal/usecase/device_trust.go
@@ -17,6 +17,13 @@ type DeviceTrustService struct {
 	broadcaster Broadcaster
 	tx          TxManager
 
+	// demoCampName은 App Store 심사용 데모 엔드포인트(RequestDemoRegistration) 전용이다.
+	// 운영 배포에서는 항상 빈 문자열 — 그 경우 RequestDemoRegistration은 항상 실패한다.
+	// 이 값이 비어 있지 않은 배포에서만 DemoHandler가 라우팅에 등록되므로(cmd/server/main.go),
+	// 이 필드가 빈 문자열인 채로 이 메서드가 외부에서 호출될 일 자체가 없다 — 아래 체크는
+	// 그럼에도 방어적으로 남겨둔 것이다.
+	demoCampName string
+
 	nowFn  func() time.Time
 	uuidFn func() string
 }
@@ -33,16 +40,18 @@ func NewDeviceTrustService(
 	auditLogs AuditLogRepository,
 	broadcaster Broadcaster,
 	tx TxManager,
+	demoCampName string,
 ) *DeviceTrustService {
 	return &DeviceTrustService{
-		camps:       camps,
-		devices:     devices,
-		admins:      admins,
-		auditLogs:   auditLogs,
-		broadcaster: broadcaster,
-		tx:          tx,
-		nowFn:       func() time.Time { return time.Now().UTC() },
-		uuidFn:      uuid.NewString,
+		camps:        camps,
+		devices:      devices,
+		admins:       admins,
+		auditLogs:    auditLogs,
+		broadcaster:  broadcaster,
+		tx:           tx,
+		demoCampName: demoCampName,
+		nowFn:        func() time.Time { return time.Now().UTC() },
+		uuidFn:       uuid.NewString,
 	}
 }
 
@@ -99,6 +108,74 @@ func (s *DeviceTrustService) RequestRegistration(
 
 	s.recordAuditLog(ctx, domain.Some(campID()), "anonymous", "anonymous", ActionDeviceRequest, string(reg.ID()), displayName, true, nil)
 	_ = s.broadcaster.Broadcast(ctx, campID(), EventDeviceRegistrationUpdated, CampScope())
+	return plainToken, reg, nil
+}
+
+// RequestDemoRegistration - App Store 심사용 데모 엔드포인트 전용. registrationCode 입력이
+// 없다 — 캠프를 demoCampName(배포 시 운영자가 미리 정한 캠프 이름)으로 식별한다. 등록과
+// 동시에 즉시 승인 상태로 저장하므로, 이 메서드를 거치는 흐름에는 관리자 승인 단계가 없다.
+// 기존 RequestRegistration/ApproveDevice는 이 메서드에서 전혀 호출되지 않는다 — 완전히
+// 별도 경로이므로 진행자가 쓰는 실제 등록 흐름은 이 코드의 존재로 영향받지 않는다.
+func (s *DeviceTrustService) RequestDemoRegistration(
+	ctx context.Context,
+	deviceName, deviceModel, displayName string,
+) (string, *domain.DeviceRegistration, error) {
+
+	if s.demoCampName == "" {
+		return "", nil, withErrorContext("device.request_demo_registration", "validate_demo_camp_name", domain.ErrCampNotFound, nil)
+	}
+
+	camp, err := s.camps.GetByName(ctx, s.demoCampName)
+	if err != nil {
+		return "", nil, withErrorContext("device.request_demo_registration", "repository.get_camp_by_name", err, nil)
+	}
+	if camp == nil {
+		return "", nil, withErrorContext("device.request_demo_registration", "find_demo_camp", domain.ErrCampNotFound, map[string]any{"camp_found": false})
+	}
+	campID := camp.ID()
+
+	plainToken, tokenHash, err := generateOpaqueToken()
+	if err != nil {
+		return "", nil, withErrorContext("device.request_demo_registration", "generate_token", err, nil)
+	}
+
+	now := s.nowFn()
+	regID := domain.DeviceRegistrationID(s.uuidFn())
+	reg := domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{
+		ID:                regID,
+		CampID:            campID,
+		DeviceName:        deviceName,
+		DeviceModel:       deviceModel,
+		DisplayName:       displayName,
+		Status:            domain.DevicePending,
+		TokenHash:         tokenHash,
+		FailedPinAttempts: 0,
+		LockedUntil:       domain.None[time.Time](),
+		ApprovedAt:        domain.None[time.Time](),
+		CreatedAt:         now,
+	})
+
+	// 아직 저장하지 않은 상태이므로, RequestRegistration→ApproveDevice처럼 두 번 저장할
+	// 필요 없이 메모리상에서 바로 승인 상태로 전이시킨 뒤 한 번만 저장한다.
+	if err := reg.Approve(now); err != nil {
+		return "", nil, withErrorContext("device.request_demo_registration", "domain.approve", err, map[string]any{"device_id": string(regID)})
+	}
+
+	err = s.tx.RunInTx(ctx, func(ctx context.Context) error {
+		if err := s.devices.Save(ctx, reg); err != nil {
+			return withErrorContext("device.request_demo_registration", "repository.save_device", err, map[string]any{"device_id": string(reg.ID())})
+		}
+		return nil
+	})
+
+	if err != nil {
+		s.recordAuditLog(ctx, domain.Some(campID), "system", "system:demo_auto_approve", ActionDeviceRequest, "", displayName, false, errorAuditMetadata(err, nil))
+		return "", nil, err
+	}
+
+	s.recordAuditLog(ctx, domain.Some(campID), "system", "system:demo_auto_approve", ActionDeviceRequest, string(reg.ID()), displayName, true, nil)
+	s.recordAuditLog(ctx, domain.Some(campID), "system", "system:demo_auto_approve", ActionDeviceApproved, string(reg.ID()), displayName, true, nil)
+	_ = s.broadcaster.Broadcast(ctx, campID, EventDeviceRegistrationUpdated, CampScope())
 	return plainToken, reg, nil
 }
 

--- a/backend/internal/usecase/device_trust_test.go
+++ b/backend/internal/usecase/device_trust_test.go
@@ -22,7 +22,7 @@ func TestDeviceTrustService_RequestRegistration(t *testing.T) {
 		broadcaster := &MockBroadcaster{}
 		tx := &MockTxManager{}
 
-		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx)
+		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx, "")
 		s.nowFn = func() time.Time { return now }
 		s.uuidFn = func() string { return "device-uuid" }
 
@@ -67,7 +67,7 @@ func TestDeviceTrustService_RequestRegistration(t *testing.T) {
 		broadcaster := &MockBroadcaster{}
 		tx := &MockTxManager{}
 
-		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx)
+		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx, "")
 
 		// Act
 		_, _, err := s.RequestRegistration(context.Background(), "UNKNOWN1", "iPad-1", "iPad Pro", "1번 태블릿")
@@ -89,7 +89,7 @@ func TestDeviceTrustService_RequestRegistration(t *testing.T) {
 		broadcaster := &MockBroadcaster{}
 		tx := &MockTxManager{}
 
-		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx)
+		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx, "")
 
 		// Act
 		_, registration, err := s.RequestRegistration(context.Background(), "REGCODE1", "iPad-1", "iPad Pro", "1번 태블릿")
@@ -100,6 +100,102 @@ func TestDeviceTrustService_RequestRegistration(t *testing.T) {
 		}
 		if registration == nil || registration.Status() != domain.DevicePending {
 			t.Fatalf("expected pending registration, got %+v", registration)
+		}
+	})
+}
+
+func TestDeviceTrustService_RequestDemoRegistration(t *testing.T) {
+	t.Run("ShouldReturnCampNotFoundWhenDemoCampNameIsEmpty", func(t *testing.T) {
+		// Arrange - demoCampName을 빈 문자열로 둔다(운영 기본값).
+		camps := NewMockCampRepository()
+		camp := domain.NewCampFromProps(domain.CampProps{ID: "camp-1", Name: "App Store Review Demo", RegistrationCode: "REGCODE1", Status: domain.CampActive})
+		camps.Save(context.Background(), camp)
+
+		devices := NewMockDeviceRegistrationRepository()
+		auditLogs := &MockAuditLogRepository{}
+		broadcaster := &MockBroadcaster{}
+		tx := &MockTxManager{}
+
+		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx, "")
+
+		// Act
+		_, _, err := s.RequestDemoRegistration(context.Background(), "iPad-1", "iPad Pro", "1번 태블릿")
+
+		// Assert
+		if !errors.Is(err, domain.ErrCampNotFound) {
+			t.Fatalf("expected ErrCampNotFound, got %v", err)
+		}
+	})
+
+	t.Run("ShouldReturnCampNotFoundWhenNoCampMatchesDemoCampName", func(t *testing.T) {
+		// Arrange - demoCampName은 설정되어 있지만 일치하는 캠프가 없다.
+		camps := NewMockCampRepository()
+		devices := NewMockDeviceRegistrationRepository()
+		auditLogs := &MockAuditLogRepository{}
+		broadcaster := &MockBroadcaster{}
+		tx := &MockTxManager{}
+
+		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx, "App Store Review Demo")
+
+		// Act
+		_, _, err := s.RequestDemoRegistration(context.Background(), "iPad-1", "iPad Pro", "1번 태블릿")
+
+		// Assert
+		if !errors.Is(err, domain.ErrCampNotFound) {
+			t.Fatalf("expected ErrCampNotFound, got %v", err)
+		}
+	})
+
+	t.Run("ShouldCreateApprovedRegistrationWhenDemoCampNameMatches", func(t *testing.T) {
+		// Arrange
+		now := time.Now()
+		camps := NewMockCampRepository()
+		camp := domain.NewCampFromProps(domain.CampProps{ID: "camp-1", Name: "App Store Review Demo", RegistrationCode: "REGCODE1", Status: domain.CampActive})
+		camps.Save(context.Background(), camp)
+
+		devices := NewMockDeviceRegistrationRepository()
+		auditLogs := &MockAuditLogRepository{}
+		broadcaster := &MockBroadcaster{}
+		tx := &MockTxManager{}
+
+		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx, "App Store Review Demo")
+		s.nowFn = func() time.Time { return now }
+		s.uuidFn = func() string { return "device-uuid" }
+
+		// Act
+		plainToken, reg, err := s.RequestDemoRegistration(context.Background(), "iPad-1", "iPad Pro 11 2022", "1번 태블릿")
+
+		// Assert
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if plainToken == "" {
+			t.Fatal("expected plain token, got empty")
+		}
+		if reg.CampID() != "camp-1" {
+			t.Errorf("expected campID resolved to 'camp-1', got '%s'", reg.CampID())
+		}
+		if reg.Status() != domain.DeviceApproved {
+			t.Errorf("expected status 'APPROVED', got %s", reg.Status())
+		}
+
+		persisted, _ := devices.Get(context.Background(), reg.ID())
+		if persisted == nil || persisted.Status() != domain.DeviceApproved {
+			t.Fatalf("expected persisted registration to be APPROVED, got %+v", persisted)
+		}
+
+		if len(broadcaster.Broadcasts) != 1 ||
+			broadcaster.Broadcasts[0].CampID != "camp-1" ||
+			broadcaster.Broadcasts[0].Event != EventDeviceRegistrationUpdated ||
+			broadcaster.Broadcasts[0].Scope != CampScope() {
+			t.Errorf("expected EventDeviceRegistrationUpdated broadcast, got %v", broadcaster.Broadcasts)
+		}
+
+		if len(auditLogs.Logs) != 2 {
+			t.Fatalf("expected 2 audit logs (request + auto-approve), got %d", len(auditLogs.Logs))
+		}
+		if auditLogs.Logs[0].Actor() != "system" || auditLogs.Logs[1].Actor() != "system" {
+			t.Errorf("expected both audit logs to have actor 'system', got %+v", auditLogs.Logs)
 		}
 	})
 }
@@ -134,7 +230,7 @@ func TestDeviceTrustService_ShouldReturnUpdatedRegistrationWhenDeviceStatusChang
 			admins := NewMockAdminRepository()
 			admins.Admins["admin-1"] = domain.NewAdminFromProps(domain.AdminProps{ID: "admin-1", Username: "김관리"})
 
-			s := NewDeviceTrustService(camps, devices, admins, auditLogs, broadcaster, tx)
+			s := NewDeviceTrustService(camps, devices, admins, auditLogs, broadcaster, tx, "")
 			s.nowFn = func() time.Time { return now }
 			s.uuidFn = func() string { return "audit-uuid" }
 
@@ -190,7 +286,7 @@ func TestDeviceTrustService_GetMyRegistrationStatus(t *testing.T) {
 		broadcaster := &MockBroadcaster{}
 		tx := &MockTxManager{}
 
-		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx)
+		s := NewDeviceTrustService(camps, devices, NewMockAdminRepository(), auditLogs, broadcaster, tx, "")
 		s.nowFn = func() time.Time { return now }
 		s.uuidFn = func() string { return "device-uuid" }
 

--- a/backend/internal/usecase/list_views_test.go
+++ b/backend/internal/usecase/list_views_test.go
@@ -16,7 +16,7 @@ func TestShouldListOnlyCurrentlyLockedApprovedDevicesWhenCampIsRequested(t *test
 	devices.Devices["expired"] = domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "expired", CampID: "camp-1", Status: domain.DeviceApproved, LockedUntil: domain.Some(now.Add(-time.Minute))})
 	devices.Devices["pending"] = domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "pending", CampID: "camp-1", Status: domain.DevicePending, LockedUntil: domain.Some(now.Add(time.Minute))})
 	devices.Devices["other-camp"] = domain.NewDeviceRegistrationFromProps(domain.DeviceRegistrationProps{ID: "other-camp", CampID: "camp-2", Status: domain.DeviceApproved, LockedUntil: domain.Some(now.Add(time.Minute))})
-	service := NewDeviceTrustService(NewMockCampRepository(), devices, NewMockAdminRepository(), &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{})
+	service := NewDeviceTrustService(NewMockCampRepository(), devices, NewMockAdminRepository(), &MockAuditLogRepository{}, &MockBroadcaster{}, &MockTxManager{}, "")
 	service.nowFn = func() time.Time { return now }
 
 	// Act

--- a/backend/internal/usecase/mock_test.go
+++ b/backend/internal/usecase/mock_test.go
@@ -41,6 +41,15 @@ func (r *MockCampRepository) GetByRegistrationCode(ctx context.Context, code str
 	return nil, nil
 }
 
+func (r *MockCampRepository) GetByName(ctx context.Context, name string) (*domain.Camp, error) {
+	for _, camp := range r.Camps {
+		if camp.Name() == name {
+			return camp, nil
+		}
+	}
+	return nil, nil
+}
+
 func (r *MockCampRepository) Save(ctx context.Context, camp *domain.Camp) error {
 	r.Camps[camp.ID()] = camp
 	return nil

--- a/backend/internal/usecase/port.go
+++ b/backend/internal/usecase/port.go
@@ -23,6 +23,9 @@ type TrackPINProtector interface {
 type CampRepository interface {
 	Get(ctx context.Context, id domain.CampID) (*domain.Camp, error)
 	GetByRegistrationCode(ctx context.Context, code string) (*domain.Camp, error)
+	// GetByName은 App Store 심사용 데모 캠프를 이름으로 조회하는 용도로만 쓰인다
+	// (DeviceTrustService.RequestDemoRegistration). name은 UNIQUE 제약이 없다.
+	GetByName(ctx context.Context, name string) (*domain.Camp, error)
 	List(ctx context.Context) ([]*domain.Camp, error)
 	Save(ctx context.Context, camp *domain.Camp) error
 }


### PR DESCRIPTION
## 변경 사항과 이유

App Store 심사용 데모 모드 백엔드 구현 (계획서: `backend/docs/artifacts/plan/20260820_앱스토어_심사용_데모환경_plan_.md`).

진행자 앱은 기기 등록 후 관리자 수동 승인이 있어야 PIN 로그인이 가능해, Apple 리뷰어가 관리자 접근 권한 없이는 앱을 끝까지 써볼 수 없었다. 이를 별도 review 배포(별도 DB)에서만 우회하는 데모 전용 엔드포인트로 해결한다 — **운영 배포 코드 경로는 단 한 줄도 바뀌지 않는다.**

1. `feat : 캠프 이름 기반 조회를 위한 CampRepository.GetByName 추가`
   - `db/query.sql`에 `GetCampByName` sqlc 쿼리 추가
   - `mapCamp` 헬퍼로 `Get`/`GetByRegistrationCode`/`GetByName` 매핑 로직 통합
2. `feat : DeviceTrustService.RequestDemoRegistration 추가`
   - 기존 `RequestRegistration`/`ApproveDevice` 상태머신은 전혀 건드리지 않는 완전히 별도 메서드
   - `demoCampName`(review 배포 전용 env var, 운영에서는 항상 빈 문자열)과 이름이 일치하는 캠프를 찾아 등록과 동시에 즉시 승인
3. `feat : /demo/device-registrations 엔드포인트 및 배선 추가`
   - `DEMO_CAMP_NAME` 환경변수가 설정된 배포에서만 존재하는 새 엔드포인트 (`Handlers.Demo`가 nil이면 라우트 자체가 등록되지 않음)
   - `make swag`로 `api/` 재생성 (API 스키마 우선 원칙)
4. `fix : /api/v1 밑 미등록 경로가 401을 반환하던 라우터 버그 수정`
   - 라우팅 테스트 작성 중 발견한, 이번 변경과 무관한 기존 버그. echo v4의 `Group.Use()`가 그룹 prefix에 자동 등록하는 404 폴백이 `admin`/`track`/`message`처럼 prefix를 공유하는 그룹들 사이에서 서로 덮어써서, `/api/v1` 밑 실제로 존재하지 않는 모든 경로가 404가 아니라 401을 반환하고 있었다. `v1.RouteNotFound("/*", ...)`로 명시적 404 핸들러를 등록해 수정.

## 종료 조건 증명

- `cd backend && go build ./... && go vet ./... && gofmt -l .` 전부 클린
- `go test ./...` 전체 통과 (신규: `RequestDemoRegistration` 3케이스, `mapCamp` 2케이스, 라우팅 404/등록 케이스, 404 버그 회귀 테스트 2건)
- `make swag` 재생성 결과에 `/demo/device-registrations` 경로 반영 확인
- 운영 배포 관련 기존 테스트 전부 회귀 없이 통과 (기존 상태머신 코드 미변경)

## 범위 밖 (별도 처리)

- 프론트엔드 API base URL 스위칭, review 배포 인프라 구성, 캠프-스코프 관리자 RBAC(Issue #236)은 계획서에 명시된 대로 이 PR 범위 밖.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
