### PR TITLE
fix : run-*-prod 타겟에서 --release 제거

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -32,10 +32,10 @@ run-facilitator:unlock-keychain
 	flutter run --dart-define-from-file=env/dev.json -t lib/main_facilitator.dart --flavor facilitator
 
 run-admin-prod:unlock-keychain
-	flutter run --release --dart-define-from-file=env/prod.json -t lib/main_admin.dart --flavor admin
+	flutter run --dart-define-from-file=env/prod.json -t lib/main_admin.dart --flavor admin
 
 run-facilitator-prod:unlock-keychain
-	flutter run --release --dart-define-from-file=env/prod.json -t lib/main_facilitator.dart --flavor facilitator
+	flutter run --dart-define-from-file=env/prod.json -t lib/main_facilitator.dart --flavor facilitator
 
 build-admin:unlock-keychain
 	flutter build ipa --release --dart-define-from-file=env/prod.json -t lib/main_admin.dart --flavor admin --build-number=$(BUILD_NUMBER)


### PR DESCRIPTION
--release 빌드는 서명이 필요해 개발용(미서명) 기기에서 못 돌린다. prod
dart-define 값으로 디버그 모드 실행해 실기기에서 운영/데모 환경 스위칭
(#238)을 검증할 수 있게 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)