### PR TITLE
fix : 방문 시작 시 타이머 즉시 시작되도록 수정

### DIFF
--- a/frontend/docs/artifacts/plan/done/20260825_visit_start_timer_delay_plan_.md
+++ b/frontend/docs/artifacts/plan/done/20260825_visit_start_timer_delay_plan_.md
@@ -1,0 +1,16 @@
+Issue: #239
+
+## 요구사항
+방문이 시작 처리된 순간 타이머가 바로 시작되지 않고 2~3초 후에 시작됨. 방문 시작 즉시 타이머가 시작되도록 수정.
+
+## 왜 이렇게 했는가
+`currentVisitProvider`는 `track_event_coordinator.dart`가 SSE `trackUpdated` 이벤트를 받아야만
+invalidate되어 재조회됐다. 방문 시작(`POST .../visits/start`)은 이미 성공 응답으로 최신
+`VisitSummary`(startedAt 포함) 정보를 갖고 있는데도, 정작 화면이 보는 `currentVisitProvider`는
+자기 자신이 보낸 요청의 브로드캐스트가 SSE로 돌아올 때까지 갱신되지 않아 그 왕복 시간(2~3초)만큼
+타이머 표시가 늦어졌다.
+
+기각한 대안: `startByQr`/`startManual`의 응답 데이터를 `currentVisitProvider` 캐시에 직접
+주입(optimistic set)하는 방법도 고려했으나, 이 provider는 codegen이 만든 단순 `FutureProvider`라
+외부에서 상태를 직접 쓰려면 `AsyncNotifier`로 구조를 바꿔야 해 변경 범위가 커진다. REST 응답을
+받은 시점에 `ref.invalidate`로 즉시 재조회를 트리거하는 쪽이 최소 변경으로 SSE 왕복을 제거한다.

--- a/frontend/lib/shared/api/providers/visit_providers.dart
+++ b/frontend/lib/shared/api/providers/visit_providers.dart
@@ -29,6 +29,9 @@ class VisitActions extends _$VisitActions {
     if (data == null) {
       throw Exception('방문 시작 응답이 올바르지 않습니다.');
     }
+    // trackUpdated SSE를 기다리면 브로드캐스트 왕복만큼(2~3초) 타이머 시작이 늦어진다
+    // (이슈 #239) — 이미 받은 응답으로 커스텀 이벤트 코디네이터보다 먼저 갱신한다.
+    ref.invalidate(currentVisitProvider(trackId));
     return data;
   }
 
@@ -47,6 +50,7 @@ class VisitActions extends _$VisitActions {
     if (data == null) {
       throw Exception('방문 시작 응답이 올바르지 않습니다.');
     }
+    ref.invalidate(currentVisitProvider(trackId));
     return data;
   }
 

--- a/frontend/test/shared/api/providers/visit_providers_test.dart
+++ b/frontend/test/shared/api/providers/visit_providers_test.dart
@@ -181,6 +181,26 @@ void main() {
     expect(fakeApi.capturedTrackId, 'track-1');
   });
 
+  test('ShouldRefreshCurrentVisitImmediatelyAfterStartByQr', () async {
+    // arrange — SSE trackUpdated 브로드캐스트를 기다리지 않고도 즉시 갱신되어야 한다(이슈 #239).
+    final visit = _buildVisitSummary();
+    final fakeApi = _FakeVisitScanFlowApi()..startVisitData = visit;
+    final container = ProviderContainer(
+      overrides: [visitScanFlowApiProvider.overrideWithValue(fakeApi)],
+    );
+    addTearDown(container.dispose);
+    await container.read(currentVisitProvider(trackId).future); // 최초 null 캐시
+    final notifier = container.read(visitActionsProvider(trackId).notifier);
+
+    // act
+    await notifier.startByQr('qr-token-abc');
+    fakeApi.currentVisitData = visit; // 시작 직후 서버에도 이미 반영된 상태
+    final result = await container.read(currentVisitProvider(trackId).future);
+
+    // assert
+    expect(result, same(visit));
+  });
+
   test('ShouldThrowWhenStartVisitReturnsNullData', () async {
     // arrange
     final fakeApi = _FakeVisitScanFlowApi(); // startVisitData 미설정 -> null


### PR DESCRIPTION
## 변경 사항과 이유

`currentVisitProvider`는 SSE `trackUpdated` 브로드캐스트를 받아야만 invalidate되어 재조회됐다.
방문 시작(`POST /tracks/{trackId}/visits/start`)은 응답으로 이미 최신 `VisitSummary`(startedAt 포함)를
받았음에도, 화면이 보는 `currentVisitProvider`는 자신이 유발한 이벤트가 SSE로 돌아올 때까지
갱신되지 않아 그 왕복 시간(2~3초)만큼 타이머 표시가 늦어졌다(#239).

`VisitActions.startByQr`/`startManual` 성공 직후 `currentVisitProvider`를 바로 invalidate해서
SSE 왕복을 기다리지 않고 재조회하도록 수정했다.

## 종료 조건 증명

- `visit_providers_test.dart`에 `ShouldRefreshCurrentVisitImmediatelyAfterStartByQr` 추가:
  start 성공 후 SSE 이벤트 없이도 `currentVisitProvider`가 최신 방문 정보를 반환함을 검증.
- `make docker-check`: 전체 333개 테스트 통과.

Closes #239