### PR TITLE
fix : PillTabBar 좌측 정렬 회귀 수정

### DIFF
--- a/frontend/lib/shared/design_system/widgets/pill_tab_bar.dart
+++ b/frontend/lib/shared/design_system/widgets/pill_tab_bar.dart
@@ -44,33 +44,40 @@ class _PillTabBarState extends State<PillTabBar> {
   }
 
   @override
-  Widget build(BuildContext context) => Padding(
-    padding: const EdgeInsets.symmetric(
-      horizontal: AppSpacing.space4,
-      vertical: AppSpacing.space2,
-    ),
-    // 탭 라벨 합이 화면 폭을 넘으면(스마트폰 폭 + 긴 라벨) Row가 그대로
-    // RenderFlex 오버플로를 냈다 — 가로 스크롤로 감싸 넘칠 때만 스크롤되게
-    // 한다(#241). 다 들어갈 땐 기존과 동일하게 내용 폭만큼만 차지한다.
-    // Scrollbar는 스크롤할 내용이 없으면(다 들어가는 폭) 스스로 아무것도 그리지
-    // 않으므로, 넘칠 때만 "더 있다"는 티가 나는 걸 조건 분기 없이 얻는다.
-    child: Scrollbar(
-      controller: _controller,
-      thumbVisibility: true,
-      child: SingleChildScrollView(
+  Widget build(BuildContext context) => Align(
+    // SingleChildScrollView는 내용 폭만큼만 차지해서(Row였던 이전과 달리
+    // 더는 자체적으로 폭을 채우지 않는다), crossAxisAlignment.center인
+    // 부모 Column 아래에서는 가운데로 밀려 보이는 회귀가 났다 — 항상
+    // 왼쪽에 붙도록 명시한다.
+    alignment: Alignment.centerLeft,
+    child: Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.space4,
+        vertical: AppSpacing.space2,
+      ),
+      // 탭 라벨 합이 화면 폭을 넘으면(스마트폰 폭 + 긴 라벨) Row가 그대로
+      // RenderFlex 오버플로를 냈다 — 가로 스크롤로 감싸 넘칠 때만 스크롤되게
+      // 한다(#241). 다 들어갈 땐 기존과 동일하게 내용 폭만큼만 차지한다.
+      // Scrollbar는 스크롤할 내용이 없으면(다 들어가는 폭) 스스로 아무것도 그리지
+      // 않으므로, 넘칠 때만 "더 있다"는 티가 나는 걸 조건 분기 없이 얻는다.
+      child: Scrollbar(
         controller: _controller,
-        scrollDirection: Axis.horizontal,
-        child: Row(
-          children: [
-            for (var i = 0; i < widget.tabs.length; i++) ...[
-              if (i > 0) const SizedBox(width: AppSpacing.space2),
-              _PillTabButton(
-                tab: widget.tabs[i],
-                selected: i == widget.selectedIndex,
-                onTap: () => widget.onSelected(i),
-              ),
+        thumbVisibility: true,
+        child: SingleChildScrollView(
+          controller: _controller,
+          scrollDirection: Axis.horizontal,
+          child: Row(
+            children: [
+              for (var i = 0; i < widget.tabs.length; i++) ...[
+                if (i > 0) const SizedBox(width: AppSpacing.space2),
+                _PillTabButton(
+                  tab: widget.tabs[i],
+                  selected: i == widget.selectedIndex,
+                  onTap: () => widget.onSelected(i),
+                ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     ),


### PR DESCRIPTION
## 변경 사항과 이유

#241(PR #? / commit dd8ab36)에서 탭 바 오버플로 방지를 위해 `PillTabBar` 내부 `Row`를 `Scrollbar`+`SingleChildScrollView`로 감쌌다. 기존 `Row(mainAxisSize.max)`는 부모 폭을 그대로 채워 자체 `mainAxisAlignment.start`로 왼쪽에 붙어 있었지만, `SingleChildScrollView`는 내용 폭만큼만 차지한다. 그 결과 `crossAxisAlignment`가 기본값(`center`)인 부모 `Column` 아래(기기 관리 화면 등)에서 탭 바가 화면 가운데로 밀려 보이는 비주얼 회귀가 발생했다.

같은 `PillTabBar`를 쓰는 모든 화면(기기 관리, 대시보드, 조 현황, 리포트, 메시지)이 같은 구조적 문제를 안고 있어, 개별 화면이 아니라 공유 위젯 자체를 `Align(alignment: Alignment.centerLeft)`로 감싸 부모의 `crossAxisAlignment`와 무관하게 항상 왼쪽에 붙도록 고정했다.

## 종료 조건 확인

- `make docker-check`로 전체 위젯 테스트(346개) 통과 확인
- 스크린샷으로 확인한 기기 관리 화면 회귀(탭 바 중앙 정렬) 원인이 `PillTabBar` 공통 위젯임을 git blame(dd8ab36)으로 특정 후 수정

🤖 Generated with [Claude Code](https://claude.com/claude-code)