### PR TITLE
refactor : 조 현황 화면 GridView 전환 및 파일 분리

### DIFF
--- a/frontend/lib/admin/features/group_list/_group_status_card.dart
+++ b/frontend/lib/admin/features/group_list/_group_status_card.dart
@@ -1,0 +1,71 @@
+import 'package:cornermon/admin/entities/group_ext.dart';
+import 'package:cornermon/shared/api/domain_aliases.dart' as api;
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
+import 'package:cornermon/shared/design_system/widgets/app_tag.dart';
+import 'package:material_ui/material_ui.dart';
+
+class GroupStatusCard extends StatelessWidget {
+  const GroupStatusCard({super.key, required this.group, required this.onTap});
+
+  final api.Group group;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) => Card(
+    clipBehavior: Clip.antiAlias,
+    child: InkWell(
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.space4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    group.name ?? '이름 없는 조',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.title3.copyWith(
+                      color: Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                ),
+                AppTag(
+                  label: group.isFinished == true ? '완주' : '진행 중',
+                  tone: group.isFinished == true
+                      ? AppTagTone.success
+                      : AppTagTone.warning,
+                ),
+              ],
+            ),
+            const Spacer(),
+            Text(
+              '완료 코너',
+              style: AppTypography.caption.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: AppSpacing.space1),
+            Row(
+              children: [
+                Text(
+                  group.completedCountLabel,
+                  style: AppTypography.bodyEmphasis.copyWith(
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.space3),
+                Expanded(
+                  child: LinearProgressIndicator(value: group.completionRate),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/frontend/lib/admin/features/group_list/_register_group_actions.dart
+++ b/frontend/lib/admin/features/group_list/_register_group_actions.dart
@@ -1,0 +1,30 @@
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/providers/badge_providers.dart';
+import 'package:cornermon/shared/api/providers/group_providers.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+/// QR 프레임에서 배지 payload 문자열만 뽑아내는 순수 로직. 카메라/컨트롤러
+/// 라이프사이클(스캔 중지, dispose 레이스 등)은 다이얼로그(위젯) 쪽 책임.
+String? extractBadgePayload(BarcodeCapture capture) =>
+    capture.barcodes.firstOrNull?.rawValue;
+
+/// 조 등록 API를 호출하고 성공 시 목록을 invalidate한다. 성공 여부만 반환하고
+/// 에러 메시지 표시·다이얼로그 닫기 같은 뷰 반응은 호출부(다이얼로그)가 결정한다.
+Future<bool> registerGroup(
+  WidgetRef ref, {
+  required CampId campId,
+  required String payload,
+  required String name,
+}) async {
+  try {
+    await ref.read(
+      scanRegisterBadgeProvider(campId.value, payload, name).future,
+    );
+    ref.invalidate(groupListProvider(campId));
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/frontend/lib/admin/features/group_list/_register_group_dialog.dart
+++ b/frontend/lib/admin/features/group_list/_register_group_dialog.dart
@@ -2,16 +2,16 @@ import 'dart:async';
 
 import 'package:cornermon/shared/api/domain_aliases.dart' as api;
 import 'package:cornermon/shared/api/ids.dart';
-import 'package:cornermon/shared/api/providers/group_providers.dart';
 import 'package:cornermon/shared/api/providers/badge_providers.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/qr_scan_frame.dart';
-import 'package:collection/collection.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+
+import '_register_group_actions.dart';
 
 class RegisterGroupDialog extends ConsumerStatefulWidget {
   const RegisterGroupDialog({super.key, required this.campId});
@@ -44,7 +44,7 @@ class _RegisterGroupDialogState extends ConsumerState<RegisterGroupDialog> {
   // — 진행자 QrScanScreen과 동일한 패턴(qr_scan_screen.dart 참고).
   void _onDetect(BarcodeCapture capture) {
     if (_scanned) return;
-    final token = capture.barcodes.firstOrNull?.rawValue;
+    final token = extractBadgePayload(capture);
     if (token == null) return;
     unawaited(_scannerController.stop());
     setState(() {
@@ -56,27 +56,21 @@ class _RegisterGroupDialogState extends ConsumerState<RegisterGroupDialog> {
   Future<void> _submit() async {
     if (_name.text.trim().isEmpty || _payload.text.trim().isEmpty) return;
     setState(() => _busy = true);
-    try {
-      await ref.read(
-        scanRegisterBadgeProvider(
-          widget.campId.value,
-          _payload.text.trim(),
-          _name.text.trim(),
-        ).future,
+    final success = await registerGroup(
+      ref,
+      campId: widget.campId,
+      payload: _payload.text.trim(),
+      name: _name.text.trim(),
+    );
+    if (!mounted) return;
+    if (success) {
+      Navigator.pop(context);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('이미 등록된 배지이거나 등록할 수 없습니다')),
       );
-      ref.invalidate(groupListProvider(widget.campId));
-      if (mounted) {
-        Navigator.pop(context);
-      }
-    } catch (_) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('이미 등록된 배지이거나 등록할 수 없습니다')),
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _busy = false);
     }
+    setState(() => _busy = false);
   }
 
   @override

--- a/frontend/lib/admin/features/group_list/_register_group_dialog.dart
+++ b/frontend/lib/admin/features/group_list/_register_group_dialog.dart
@@ -1,0 +1,216 @@
+import 'dart:async';
+
+import 'package:cornermon/shared/api/domain_aliases.dart' as api;
+import 'package:cornermon/shared/api/ids.dart';
+import 'package:cornermon/shared/api/providers/group_providers.dart';
+import 'package:cornermon/shared/api/providers/badge_providers.dart';
+import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
+import 'package:cornermon/shared/design_system/widgets/app_button.dart';
+import 'package:cornermon/shared/design_system/widgets/qr_scan_frame.dart';
+import 'package:collection/collection.dart';
+import 'package:material_ui/material_ui.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+class RegisterGroupDialog extends ConsumerStatefulWidget {
+  const RegisterGroupDialog({super.key, required this.campId});
+  final CampId campId;
+  @override
+  ConsumerState<RegisterGroupDialog> createState() =>
+      _RegisterGroupDialogState();
+}
+
+class _RegisterGroupDialogState extends ConsumerState<RegisterGroupDialog> {
+  final _name = TextEditingController();
+  final _payload = TextEditingController();
+  final MobileScannerController _scannerController =
+      MobileScannerController();
+  int _tab = 0;
+  bool _busy = false;
+  bool _scanned = false;
+  @override
+  void dispose() {
+    _name.dispose();
+    _payload.dispose();
+    unawaited(_scannerController.dispose());
+    super.dispose();
+  }
+
+  // 카메라 프리뷰(MobileScanner) 위젯을 트리에서 통째로 스왑하면, 아직 처리 중인 네이티브
+  // 프레임 콜백이 이미 dispose된 카메라를 참조해 "Attempt to invoke virtual method ...
+  // on a null object reference"로 프로덕션에서 죽었다(mobile_scanner Android 플랫폼 뷰
+  // 언마운트 레이스). 위젯은 계속 마운트해 두고 controller.stop()으로만 카메라를 멈춘다
+  // — 진행자 QrScanScreen과 동일한 패턴(qr_scan_screen.dart 참고).
+  void _onDetect(BarcodeCapture capture) {
+    if (_scanned) return;
+    final token = capture.barcodes.firstOrNull?.rawValue;
+    if (token == null) return;
+    unawaited(_scannerController.stop());
+    setState(() {
+      _payload.text = token;
+      _scanned = true;
+    });
+  }
+
+  Future<void> _submit() async {
+    if (_name.text.trim().isEmpty || _payload.text.trim().isEmpty) return;
+    setState(() => _busy = true);
+    try {
+      await ref.read(
+        scanRegisterBadgeProvider(
+          widget.campId.value,
+          _payload.text.trim(),
+          _name.text.trim(),
+        ).future,
+      );
+      ref.invalidate(groupListProvider(widget.campId));
+      if (mounted) {
+        Navigator.pop(context);
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('이미 등록된 배지이거나 등록할 수 없습니다')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final badges = ref.watch(badgeListProvider);
+    return AlertDialog(
+      title: const Text('조 등록'),
+      content: SizedBox(
+        width: 460,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            SegmentedButton<int>(
+              segments: const [
+                ButtonSegment(value: 0, label: Text('카메라 QR')),
+                ButtonSegment(value: 1, label: Text('목록에서 선택')),
+                ButtonSegment(value: 2, label: Text('직접 입력')),
+              ],
+              selected: {_tab},
+              onSelectionChanged: (value) =>
+                  setState(() => _tab = value.single),
+            ),
+            const SizedBox(height: AppSpacing.space3),
+            if (_tab == 0)
+              SizedBox(
+                height: 220,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Stack(
+                    fit: StackFit.expand,
+                    alignment: Alignment.center,
+                    children: [
+                      ColoredBox(
+                        color: Colors.black,
+                        child: MobileScanner(
+                          controller: _scannerController,
+                          onDetect: _onDetect,
+                          errorBuilder: (context, error) => Center(
+                            child: Padding(
+                              padding: const EdgeInsets.all(
+                                AppSpacing.space4,
+                              ),
+                              child: Text(
+                                '카메라를 사용할 수 없습니다. 카메라 권한을 확인해주세요.',
+                                textAlign: TextAlign.center,
+                                style: AppTypography.body.copyWith(
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                      IgnorePointer(
+                        child: QrScanFrame(
+                          state: _scanned
+                              ? QrScanFrameState.success
+                              : QrScanFrameState.scanning,
+                          size: 160,
+                        ),
+                      ),
+                      if (_scanned)
+                        Positioned(
+                          bottom: 8,
+                          left: 8,
+                          right: 8,
+                          child: Text(
+                            'QR 인식 완료: ${_payload.text}',
+                            textAlign: TextAlign.center,
+                            style: AppTypography.caption.copyWith(
+                              color: Colors.white,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              )
+            else if (_tab == 1)
+              SizedBox(
+                height: 180,
+                child: badges.when(
+                  loading: () =>
+                      const Center(child: CircularProgressIndicator()),
+                  error: (_, _) => const Text('배지를 불러오지 못했습니다'),
+                  data: (items) => ListView(
+                    children: [
+                      for (final badge in items.where(
+                        (item) => item.status == api.BadgeStatus.UNASSIGNED,
+                      ))
+                        ListTile(
+                          title: Text(badge.shortId ?? badge.id ?? '-'),
+                          selected: _payload.text == badge.qrPayload,
+                          onTap: () => setState(
+                            () => _payload.text = badge.qrPayload ?? '',
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+              )
+            else
+              TextField(
+                controller: _payload,
+                onChanged: (_) => setState(() {}),
+                decoration: const InputDecoration(
+                  labelText: '배지 ID',
+                  hintText: 'QR 코드 아래 인쇄된 ID를 입력하세요',
+                ),
+              ),
+            if (_payload.text.isNotEmpty)
+              TextField(
+                controller: _name,
+                onChanged: (_) => setState(() {}),
+                decoration: const InputDecoration(labelText: '조 이름'),
+              ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _busy ? null : () => Navigator.pop(context),
+          child: const Text('취소'),
+        ),
+        AppButton(
+          variant: AppButtonVariant.primary,
+          size: AppButtonSize.compact,
+          label: '등록 확정',
+          onPressed:
+              _busy || _payload.text.trim().isEmpty || _name.text.trim().isEmpty
+              ? null
+              : _submit,
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/admin/features/group_list/group_list_screen.dart
+++ b/frontend/lib/admin/features/group_list/group_list_screen.dart
@@ -1,23 +1,17 @@
-import 'dart:async';
-
 import 'package:cornermon/admin/entities/group_ext.dart';
 import 'package:cornermon/admin/session/selected_camp_provider.dart';
-import 'package:cornermon/shared/api/domain_aliases.dart' as api;
-import 'package:cornermon/shared/api/ids.dart';
 import 'package:cornermon/shared/api/providers/group_providers.dart';
-import 'package:cornermon/shared/api/providers/badge_providers.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
 import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/app_dropdown.dart';
-import 'package:cornermon/shared/design_system/widgets/app_tag.dart';
 import 'package:cornermon/shared/design_system/widgets/pill_tab_bar.dart';
-import 'package:cornermon/shared/design_system/widgets/qr_scan_frame.dart';
-import 'package:collection/collection.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:mobile_scanner/mobile_scanner.dart';
+
+import '_group_status_card.dart';
+import '_register_group_dialog.dart';
 
 enum GroupStatusFilter { all, finished, partial }
 
@@ -151,7 +145,7 @@ class _GroupListScreenState extends ConsumerState<GroupListScreen> {
                       label: '조 등록',
                       onPressed: () => showDialog<void>(
                         context: context,
-                        builder: (_) => _RegisterGroupDialog(campId: campId),
+                        builder: (_) => RegisterGroupDialog(campId: campId),
                       ),
                     ),
                   ],
@@ -161,32 +155,21 @@ class _GroupListScreenState extends ConsumerState<GroupListScreen> {
                   child: RefreshIndicator(
                     onRefresh: () async =>
                         ref.refresh(groupListProvider(campId).future),
-                    child: LayoutBuilder(
-                      builder: (context, constraints) {
-                        final cardWidth = constraints.maxWidth < 300
-                            ? constraints.maxWidth
-                            : 300.0;
-                        return SingleChildScrollView(
-                          physics: const AlwaysScrollableScrollPhysics(),
-                          child: Align(
-                            alignment: Alignment.topLeft,
-                            child: Wrap(
-                              spacing: AppSpacing.space4,
-                              runSpacing: AppSpacing.space4,
-                              children: [
-                                for (final group in visible)
-                                  SizedBox(
-                                    width: cardWidth,
-                                    height: 144,
-                                    child: _GroupStatusCard(
-                                      group: group,
-                                      onTap: () =>
-                                          context.go('/groups/${group.id}'),
-                                    ),
-                                  ),
-                              ],
-                            ),
+                    child: GridView.builder(
+                      physics: const AlwaysScrollableScrollPhysics(),
+                      gridDelegate:
+                          const SliverGridDelegateWithMaxCrossAxisExtent(
+                            maxCrossAxisExtent: 300,
+                            mainAxisExtent: 144,
+                            crossAxisSpacing: AppSpacing.space4,
+                            mainAxisSpacing: AppSpacing.space4,
                           ),
+                      itemCount: visible.length,
+                      itemBuilder: (context, index) {
+                        final group = visible[index];
+                        return GroupStatusCard(
+                          group: group,
+                          onTap: () => context.go('/groups/${group.id}'),
                         );
                       },
                     ),
@@ -197,273 +180,6 @@ class _GroupListScreenState extends ConsumerState<GroupListScreen> {
           );
         },
       ),
-    );
-  }
-}
-
-class _GroupStatusCard extends StatelessWidget {
-  const _GroupStatusCard({required this.group, required this.onTap});
-
-  final api.Group group;
-  final VoidCallback onTap;
-
-  @override
-  Widget build(BuildContext context) => Card(
-    clipBehavior: Clip.antiAlias,
-    child: InkWell(
-      onTap: onTap,
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.space4),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Text(
-                    group.name ?? '이름 없는 조',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: AppTypography.title3.copyWith(
-                      color: Theme.of(context).colorScheme.onSurface,
-                    ),
-                  ),
-                ),
-                AppTag(
-                  label: group.isFinished == true ? '완주' : '진행 중',
-                  tone: group.isFinished == true
-                      ? AppTagTone.success
-                      : AppTagTone.warning,
-                ),
-              ],
-            ),
-            const Spacer(),
-            Text(
-              '완료 코너',
-              style: AppTypography.caption.copyWith(
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-            ),
-            const SizedBox(height: AppSpacing.space1),
-            Row(
-              children: [
-                Text(
-                  group.completedCountLabel,
-                  style: AppTypography.bodyEmphasis.copyWith(
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.space3),
-                Expanded(
-                  child: LinearProgressIndicator(value: group.completionRate),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    ),
-  );
-}
-
-class _RegisterGroupDialog extends ConsumerStatefulWidget {
-  const _RegisterGroupDialog({required this.campId});
-  final CampId campId;
-  @override
-  ConsumerState<_RegisterGroupDialog> createState() =>
-      _RegisterGroupDialogState();
-}
-
-class _RegisterGroupDialogState extends ConsumerState<_RegisterGroupDialog> {
-  final _name = TextEditingController();
-  final _payload = TextEditingController();
-  final MobileScannerController _scannerController =
-      MobileScannerController();
-  int _tab = 0;
-  bool _busy = false;
-  bool _scanned = false;
-  @override
-  void dispose() {
-    _name.dispose();
-    _payload.dispose();
-    unawaited(_scannerController.dispose());
-    super.dispose();
-  }
-
-  // 카메라 프리뷰(MobileScanner) 위젯을 트리에서 통째로 스왑하면, 아직 처리 중인 네이티브
-  // 프레임 콜백이 이미 dispose된 카메라를 참조해 "Attempt to invoke virtual method ...
-  // on a null object reference"로 프로덕션에서 죽었다(mobile_scanner Android 플랫폼 뷰
-  // 언마운트 레이스). 위젯은 계속 마운트해 두고 controller.stop()으로만 카메라를 멈춘다
-  // — 진행자 QrScanScreen과 동일한 패턴(qr_scan_screen.dart 참고).
-  void _onDetect(BarcodeCapture capture) {
-    if (_scanned) return;
-    final token = capture.barcodes.firstOrNull?.rawValue;
-    if (token == null) return;
-    unawaited(_scannerController.stop());
-    setState(() {
-      _payload.text = token;
-      _scanned = true;
-    });
-  }
-
-  Future<void> _submit() async {
-    if (_name.text.trim().isEmpty || _payload.text.trim().isEmpty) return;
-    setState(() => _busy = true);
-    try {
-      await ref.read(
-        scanRegisterBadgeProvider(
-          widget.campId.value,
-          _payload.text.trim(),
-          _name.text.trim(),
-        ).future,
-      );
-      ref.invalidate(groupListProvider(widget.campId));
-      if (mounted) {
-        Navigator.pop(context);
-      }
-    } catch (_) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('이미 등록된 배지이거나 등록할 수 없습니다')),
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _busy = false);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final badges = ref.watch(badgeListProvider);
-    return AlertDialog(
-      title: const Text('조 등록'),
-      content: SizedBox(
-        width: 460,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            SegmentedButton<int>(
-              segments: const [
-                ButtonSegment(value: 0, label: Text('카메라 QR')),
-                ButtonSegment(value: 1, label: Text('목록에서 선택')),
-                ButtonSegment(value: 2, label: Text('직접 입력')),
-              ],
-              selected: {_tab},
-              onSelectionChanged: (value) =>
-                  setState(() => _tab = value.single),
-            ),
-            const SizedBox(height: AppSpacing.space3),
-            if (_tab == 0)
-              SizedBox(
-                height: 220,
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(8),
-                  child: Stack(
-                    fit: StackFit.expand,
-                    alignment: Alignment.center,
-                    children: [
-                      ColoredBox(
-                        color: Colors.black,
-                        child: MobileScanner(
-                          controller: _scannerController,
-                          onDetect: _onDetect,
-                          errorBuilder: (context, error) => Center(
-                            child: Padding(
-                              padding: const EdgeInsets.all(
-                                AppSpacing.space4,
-                              ),
-                              child: Text(
-                                '카메라를 사용할 수 없습니다. 카메라 권한을 확인해주세요.',
-                                textAlign: TextAlign.center,
-                                style: AppTypography.body.copyWith(
-                                  color: Colors.white,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                      ),
-                      IgnorePointer(
-                        child: QrScanFrame(
-                          state: _scanned
-                              ? QrScanFrameState.success
-                              : QrScanFrameState.scanning,
-                          size: 160,
-                        ),
-                      ),
-                      if (_scanned)
-                        Positioned(
-                          bottom: 8,
-                          left: 8,
-                          right: 8,
-                          child: Text(
-                            'QR 인식 완료: ${_payload.text}',
-                            textAlign: TextAlign.center,
-                            style: AppTypography.caption.copyWith(
-                              color: Colors.white,
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-              )
-            else if (_tab == 1)
-              SizedBox(
-                height: 180,
-                child: badges.when(
-                  loading: () =>
-                      const Center(child: CircularProgressIndicator()),
-                  error: (_, _) => const Text('배지를 불러오지 못했습니다'),
-                  data: (items) => ListView(
-                    children: [
-                      for (final badge in items.where(
-                        (item) => item.status == api.BadgeStatus.UNASSIGNED,
-                      ))
-                        ListTile(
-                          title: Text(badge.shortId ?? badge.id ?? '-'),
-                          selected: _payload.text == badge.qrPayload,
-                          onTap: () => setState(
-                            () => _payload.text = badge.qrPayload ?? '',
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-              )
-            else
-              TextField(
-                controller: _payload,
-                onChanged: (_) => setState(() {}),
-                decoration: const InputDecoration(
-                  labelText: '배지 ID',
-                  hintText: 'QR 코드 아래 인쇄된 ID를 입력하세요',
-                ),
-              ),
-            if (_payload.text.isNotEmpty)
-              TextField(
-                controller: _name,
-                onChanged: (_) => setState(() {}),
-                decoration: const InputDecoration(labelText: '조 이름'),
-              ),
-          ],
-        ),
-      ),
-      actions: [
-        TextButton(
-          onPressed: _busy ? null : () => Navigator.pop(context),
-          child: const Text('취소'),
-        ),
-        AppButton(
-          variant: AppButtonVariant.primary,
-          size: AppButtonSize.compact,
-          label: '등록 확정',
-          onPressed:
-              _busy || _payload.text.trim().isEmpty || _name.text.trim().isEmpty
-              ? null
-              : _submit,
-        ),
-      ],
     );
   }
 }


### PR DESCRIPTION
## 변경 사항

1. **GridView 전환** — 카드 그리드 폭을 `LayoutBuilder`에서 손으로 계산(`Wrap` + 삼항 min)하던 코드를 `GridView.builder` + `SliverGridDelegateWithMaxCrossAxisExtent`로 교체. 플랫폼이 이미 제공하는 max-extent 그리드 레이아웃이라 직접 계산할 이유가 없음 (ponytail-audit 지적).
2. **파일 분리** — `group_list_screen.dart` 한 파일에 화면(`GroupListScreen`), 카드 위젯(`_GroupStatusCard`), 조 등록 다이얼로그(`_RegisterGroupDialog`, QR 스캔·배지 목록·직접 입력 3-tab, ~200줄)가 섞여 있던 걸 sibling feature(`dashboard/`)와 같은 컨벤션으로 위젯 파일 분리:
   - `_group_status_card.dart` (`GroupStatusCard`)
   - `_register_group_dialog.dart` (`RegisterGroupDialog`)

## 이유

- `group_list/` 폴더는 원래 파일 1개(`group_list_screen.dart`, 470줄)에 화면 렌더링·카드 표현·QR 등록 플로우까지 다 몰려 있었음. 반면 `dashboard/` 등 sibling feature는 이미 위젯을 `_xxx.dart` 파일로 분리해 두는 컨벤션을 쓰고 있어 불일치.
- 등록 다이얼로그는 스캐너 컨트롤러/배지 목록 조회/제출까지 갖춘 독립적인 하위 기능이라 화면 파일과 분리하는 게 자연스러움.

## 검증

- `make docker-build && make docker-check` (`flutter analyze && flutter test`) 통과 — 로그 마지막: `All tests passed!`
- 순수 리팩터링(로직/동작 변경 없음), 관련 기존 테스트 없음(신규 테스트 추가 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)