### PR TITLE
fix : 공지/DM 발신자 본인에게도 알림 소리·진동 오던 문제 수정

### DIFF
--- a/frontend/lib/admin/session/admin_event_coordinator.dart
+++ b/frontend/lib/admin/session/admin_event_coordinator.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'package:cornermon/shared/api/domain_aliases.dart';
@@ -74,9 +76,32 @@ class AdminEventCoordinator extends _$AdminEventCoordinator {
         ref.invalidate(selectedCampProvider);
         break;
       case SseEventEventEnum.messagesChanged:
-        ref.invalidate(broadcastMessageListProvider(campId));
-        ref.invalidate(trackMessageListProvider);
-        ref.read(noticeFeedbackProvider).notify();
+        {
+          // 발신자 구분 없는 이벤트라, 관리자 본인이 보낸 공지/DM의 반향으로 자기 알림음이
+          // 울리던 문제(#256)가 있었다. scope로 재조회 대상을 좁히고, REST 응답의
+          // senderRole로 상대(TRACK) 발신 여부를 걸러낸 뒤에만 notify한다.
+          final scope = event.scope;
+          if (scope?.kind == SseScopeKind.camp) {
+            ref.invalidate(broadcastMessageListProvider(campId));
+            unawaited(
+              _notifyIfFromTrack(
+                ref.read(broadcastMessageListProvider(campId).future),
+              ),
+            );
+          } else if (scope?.kind == SseScopeKind.track && scope?.trackId != null) {
+            final trackId = TrackId(scope!.trackId!);
+            // 열린 스레드(background: true, ChatThreadPane)와 목록 미리보기
+            // (background: false, trackDirectSummariesProvider)는 서로 다른 family
+            // 인스턴스라 둘 다 무효화해야 한다.
+            ref.invalidate(trackMessageListProvider(trackId, background: true));
+            ref.invalidate(trackMessageListProvider(trackId, background: false));
+            unawaited(
+              _notifyIfFromTrack(
+                ref.read(trackMessageListProvider(trackId, background: true).future),
+              ),
+            );
+          }
+        }
         break;
       case SseEventEventEnum.trackDeleted:
         ref.invalidate(trackListProvider(campId));
@@ -103,6 +128,15 @@ class AdminEventCoordinator extends _$AdminEventCoordinator {
         break;
       default:
         break;
+    }
+  }
+
+  /// 방금 재조회한 목록의 최신 항목이 트랙(상대) 발신일 때만 알림음을 울린다.
+  /// [_handle]의 messagesChanged 분기 주석(#256) 참고.
+  Future<void> _notifyIfFromTrack(Future<List<Message>> messages) async {
+    final list = await messages;
+    if (list.isNotEmpty && list.last.senderRole == MessageSenderRoleEnum.TRACK) {
+      ref.read(noticeFeedbackProvider).notify();
     }
   }
 

--- a/frontend/lib/facilitator/realtime/track_event_coordinator.dart
+++ b/frontend/lib/facilitator/realtime/track_event_coordinator.dart
@@ -76,7 +76,13 @@ class TrackEventCoordinator extends _$TrackEventCoordinator {
         } else if (isThisTrack) {
           ref.invalidate(trackMessageListProvider(trackId, background: true));
           ref.invalidate(unreadDirectMessageCountProvider(trackId));
-          ref.read(noticeFeedbackProvider).notify();
+          unawaited(
+            _notifyIfFromAdmin(
+              ref.read(
+                trackMessageListProvider(trackId, background: true).future,
+              ),
+            ),
+          );
         }
         break;
       case SseEventEventEnum.trackDeleted:
@@ -103,6 +109,16 @@ class TrackEventCoordinator extends _$TrackEventCoordinator {
         break;
       default:
         break; // groups_updated/lockout_alert 등 관리자 전용 알림은 진행자 화면과 무관
+    }
+  }
+
+  /// 방금 재조회한 트랙 메시지 목록의 최신 항목이 관리자 발신일 때만 알림음을 울린다.
+  /// messagesChanged는 발신자 구분 없는 이벤트라, 본인(TRACK)이 보낸 메시지의 반향으로
+  /// 자기 알림음이 울리던 문제(#256)를 REST 응답의 senderRole로 걸러낸다.
+  Future<void> _notifyIfFromAdmin(Future<List<Message>> messages) async {
+    final list = await messages;
+    if (list.isNotEmpty && list.last.senderRole == MessageSenderRoleEnum.ADMIN) {
+      ref.read(noticeFeedbackProvider).notify();
     }
   }
 

--- a/frontend/test/admin/session/admin_event_coordinator_test.dart
+++ b/frontend/test/admin/session/admin_event_coordinator_test.dart
@@ -33,6 +33,10 @@ void main() {
   late int broadcastListBuildCount;
   late int threadMessageListBuildCount;
   late int previewMessageListBuildCount;
+  // 이슈 #256: notify 여부가 목록 마지막 항목의 senderRole에 좌우되므로, 테스트별로
+  // 반환값을 바꿔 끼울 수 있어야 한다.
+  late List<Message> broadcastListResult;
+  late List<Message> threadMessageListResult;
 
   // 스트림 이벤트 전달 → AsyncValue 갱신 → ref.listen 콜백 → invalidate/rebuild가
   // 모두 마이크로태스크를 거쳐 일어나므로, 한 틱을 흘려보내야 결과를 관찰할 수 있다.
@@ -53,6 +57,8 @@ void main() {
     broadcastListBuildCount = 0;
     threadMessageListBuildCount = 0;
     previewMessageListBuildCount = 0;
+    broadcastListResult = <Message>[];
+    threadMessageListResult = <Message>[];
 
     container = ProviderContainer(
       overrides: [
@@ -60,12 +66,12 @@ void main() {
         noticeFeedbackProvider.overrideWithValue(fakeNoticeFeedback),
         broadcastMessageListProvider(campId).overrideWith((ref) async {
           broadcastListBuildCount++;
-          return <Message>[];
+          return broadcastListResult;
         }),
         // ChatThreadPane이 실제로 watch하는 것과 동일한 인자(trackId, background: true).
         trackMessageListProvider(trackId, background: true).overrideWith((ref) async {
           threadMessageListBuildCount++;
-          return <Message>[];
+          return threadMessageListResult;
         }),
         // trackDirectSummariesProvider가 내부적으로 조합하는 소스들.
         trackListProvider(campId).overrideWith(
@@ -164,16 +170,16 @@ void main() {
   );
 
   test(
-    'ShouldInvalidateBroadcastListWhenMessagesChangedArrives',
+    'ShouldInvalidateBroadcastListWhenMessagesChangedScopeIsCamp',
     () async {
-      // arrange
+      // arrange — 공지는 camp scope로 온다(이슈 #256: track scope 이벤트는 무관한
+      // 목록이므로 더 이상 함께 무효화하지 않는다).
       await container.read(broadcastMessageListProvider(campId).future);
       final baseline = broadcastListBuildCount;
       final event = SseEvent(
         (b) => b
           ..event = SseEventEventEnum.messagesChanged
-          ..scope.kind = SseScopeKind.track
-          ..scope.trackId = trackId.value,
+          ..scope.kind = SseScopeKind.camp,
       );
 
       // act
@@ -186,9 +192,19 @@ void main() {
   );
 
   test(
-    'ShouldTriggerNoticeFeedbackWhenMessagesChangedArrives',
+    'ShouldTriggerNoticeFeedbackWhenMessagesChangedScopeIsOwnTrackAndSenderIsTrack',
     () async {
-      // arrange
+      // arrange — 이슈 #218: 트랙이 보낸 다이렉트 메시지는 피드백 대상이다.
+      threadMessageListResult = [
+        Message(
+          (b) => b
+            ..id = 'dm-1'
+            ..channelType = MessageChannelType.DIRECT
+            ..senderRole = MessageSenderRoleEnum.TRACK
+            ..content = '진행자 발신'
+            ..sentAt = DateTime.utc(2026, 8, 26),
+        ),
+      ];
       final event = SseEvent(
         (b) => b
           ..event = SseEventEventEnum.messagesChanged
@@ -199,8 +215,66 @@ void main() {
       // act
       await pushAndSettle(event);
 
-      // assert — 이슈 #218: 공지/메시지 수신 시 소리+진동 피드백을 준다.
+      // assert
       expect(fakeNoticeFeedback.notifyCalls, 1);
+    },
+  );
+
+  test(
+    'ShouldNotTriggerNoticeFeedbackWhenMessagesChangedScopeIsOwnTrackAndSenderIsSelf',
+    () async {
+      // arrange — 이슈 #256: 관리자 본인이 보낸 DM의 반향으로는 알림음이 울리면 안 된다.
+      threadMessageListResult = [
+        Message(
+          (b) => b
+            ..id = 'dm-1'
+            ..channelType = MessageChannelType.DIRECT
+            ..senderRole = MessageSenderRoleEnum.ADMIN
+            ..content = '관리자 발신'
+            ..sentAt = DateTime.utc(2026, 8, 26),
+        ),
+      ];
+      final event = SseEvent(
+        (b) => b
+          ..event = SseEventEventEnum.messagesChanged
+          ..scope.kind = SseScopeKind.track
+          ..scope.trackId = trackId.value,
+      );
+
+      // act
+      await pushAndSettle(event);
+
+      // assert
+      expect(fakeNoticeFeedback.notifyCalls, 0);
+    },
+  );
+
+  test(
+    'ShouldNotTriggerNoticeFeedbackWhenMessagesChangedScopeIsCampAndSenderIsSelf',
+    () async {
+      // arrange — 이슈 #256: 관리자 본인이 보낸 공지의 반향으로는 알림음이 울리면 안 된다.
+      // (공지는 관리자만 보낼 수 있어 senderRole은 항상 ADMIN이다.)
+      broadcastListResult = [
+        Message(
+          (b) => b
+            ..id = 'broadcast-1'
+            ..channelType = MessageChannelType.BROADCAST
+            ..senderRole = MessageSenderRoleEnum.ADMIN
+            ..content = '공지'
+            ..sentAt = DateTime.utc(2026, 8, 26),
+        ),
+      ];
+      final event = SseEvent(
+        (b) => b
+          ..event = SseEventEventEnum.messagesChanged
+          ..scope.kind = SseScopeKind.camp,
+      );
+
+      // act
+      await pushAndSettle(event);
+
+      // assert
+      expect(fakeNoticeFeedback.notifyCalls, 0);
     },
   );
 }

--- a/frontend/test/facilitator/features/track_event_coordinator_test.dart
+++ b/frontend/test/facilitator/features/track_event_coordinator_test.dart
@@ -76,6 +76,9 @@ void main() {
   late int trackMessageListBuildCount;
   late int unreadDirectCountBuildCount;
   late int trackCornerBuildCount;
+  // 이슈 #256: notify 여부가 목록 마지막 항목의 senderRole에 좌우되므로, 테스트별로
+  // 반환값을 바꿔 끼울 수 있어야 한다.
+  late List<Message> trackMessageListResult;
 
   // 스트림 이벤트 전달 → AsyncValue 갱신 → ref.listen 콜백 → invalidate/rebuild가
   // 모두 마이크로태스크를 거쳐 일어나므로, 한 틱을 흘려보내야 결과를 관찰할 수 있다.
@@ -100,6 +103,7 @@ void main() {
     trackMessageListBuildCount = 0;
     unreadDirectCountBuildCount = 0;
     trackCornerBuildCount = 0;
+    trackMessageListResult = <Message>[];
 
     container = ProviderContainer(
       overrides: [
@@ -121,7 +125,7 @@ void main() {
         ),
         trackMessageListProvider(trackId, background: true).overrideWith((ref) {
           trackMessageListBuildCount++;
-          return <Message>[];
+          return trackMessageListResult;
         }),
         unreadDirectMessageCountProvider(trackId).overrideWith((ref) async {
           unreadDirectCountBuildCount++;
@@ -359,9 +363,19 @@ void main() {
   );
 
   test(
-    'ShouldTriggerNoticeFeedbackWhenMessagesChangedScopeIsOwnTrack',
+    'ShouldTriggerNoticeFeedbackWhenMessagesChangedScopeIsOwnTrackAndSenderIsAdmin',
     () async {
-      // arrange — 이슈 #218: 자기 트랙 앞 다이렉트 메시지도 피드백 대상이다.
+      // arrange — 이슈 #218: 관리자가 보낸 다이렉트 메시지는 피드백 대상이다.
+      trackMessageListResult = [
+        Message(
+          (b) => b
+            ..id = 'dm-1'
+            ..channelType = MessageChannelType.DIRECT
+            ..senderRole = MessageSenderRoleEnum.ADMIN
+            ..content = '관리자 답장'
+            ..sentAt = DateTime.utc(2026, 8, 26),
+        ),
+      ];
       final event = SseEvent(
         (b) => b
           ..event = SseEventEventEnum.messagesChanged
@@ -374,6 +388,36 @@ void main() {
 
       // assert
       expect(fakeNoticeFeedback.notifyCalls, 1);
+    },
+  );
+
+  test(
+    'ShouldNotTriggerNoticeFeedbackWhenMessagesChangedScopeIsOwnTrackAndSenderIsSelf',
+    () async {
+      // arrange — 이슈 #256: 본인(TRACK)이 보낸 다이렉트 메시지의 반향으로는
+      // 알림음이 울리면 안 된다.
+      trackMessageListResult = [
+        Message(
+          (b) => b
+            ..id = 'dm-1'
+            ..channelType = MessageChannelType.DIRECT
+            ..senderRole = MessageSenderRoleEnum.TRACK
+            ..content = '진행자 발신'
+            ..sentAt = DateTime.utc(2026, 8, 26),
+        ),
+      ];
+      final event = SseEvent(
+        (b) => b
+          ..event = SseEventEventEnum.messagesChanged
+          ..scope.kind = SseScopeKind.track
+          ..scope.trackId = trackId.value,
+      );
+
+      // act
+      await pushAndSettle(event);
+
+      // assert
+      expect(fakeNoticeFeedback.notifyCalls, 0);
     },
   );
 


### PR DESCRIPTION
## 요약
`messagesChanged` SSE 이벤트는 발신자 구분 없는 best-effort 알림이라, 코디네이터가 발신자 여부를 확인하지 않고 무조건 `noticeFeedbackProvider.notify()`를 호출했다. 그 결과 본인이 보낸 공지/DM에도 알림 소리·진동이 울렸다.

이슈 본문은 백엔드가 발신자 식별자를 SSE payload에 실어주는 방향을 제안했지만, REST 응답(`MessageResponse.senderRole`)에 이미 발신자 구분이 있어 **백엔드 변경 없이 프론트에서만 해결**했다.

## 변경 사항
- `frontend/lib/facilitator/realtime/track_event_coordinator.dart`: DM 분기에서 재조회한 목록의 최신 메시지가 `senderRole == ADMIN`일 때만 `notify()`.
- `frontend/lib/admin/session/admin_event_coordinator.dart`: `messagesChanged`를 `scope.kind`(camp/track)로 분기해 필요한 목록만 재조회하고, 최신 메시지가 `senderRole == TRACK`일 때만 `notify()`. (기존엔 scope 무관하게 broadcast/track 목록을 항상 둘 다 무효화하던 낭비도 함께 정리됨.)

## 검증
- `make docker-check` (flutter analyze + flutter test) 통과 — 350 tests all passed.
- 자기 발신 시 알림 억제, 상대 발신 시 알림 유지 케이스를 각각 admin/facilitator 코디네이터 테스트에 추가.

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)