### PR TITLE
fix : 배지 내보내기 크기 설정을 팝업 다이얼로그로 통합

### DIFF
--- a/frontend/lib/admin/features/badge_precreate/badge_precreate_screen.dart
+++ b/frontend/lib/admin/features/badge_precreate/badge_precreate_screen.dart
@@ -9,7 +9,7 @@ import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/app_dropdown.dart';
 import 'package:cornermon/shared/design_system/widgets/empty_state.dart';
 import 'package:cornermon/shared/design_system/widgets/app_tag.dart';
-import 'package:cornermon/shared/export/export_action_menu.dart';
+import 'package:cornermon/shared/export/export_action_menu.dart' show ExportAction;
 import 'package:cornermon/shared/export/export_file.dart';
 import 'package:material_ui/material_ui.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -156,9 +156,38 @@ class _BadgePrecreateScreenState extends ConsumerState<BadgePrecreateScreen> {
     }
   }
 
+  /// 스티커 내보내기 버튼 → 용지·QR 크기 선택 + 저장/공유를 한 다이얼로그에서 처리한다(#249 보완).
+  /// [setDialogState]로 다이얼로그 자신을 다시 그려야 드롭다운 변경이 반영된다.
+  Future<void> _openExportDialog() async {
+    final action = await showDialog<ExportAction>(
+      context: context,
+      builder: (dialogContext) => StatefulBuilder(
+        builder: (context, setDialogState) => AlertDialog(
+          title: const Text('스티커 내보내기'),
+          content: SingleChildScrollView(
+            child: _buildExportSettings(setDialogState),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () =>
+                  Navigator.pop(dialogContext, ExportAction.saveToDevice),
+              child: const Text('기기에 저장'),
+            ),
+            TextButton(
+              onPressed: () =>
+                  Navigator.pop(dialogContext, ExportAction.shareWithApp),
+              child: const Text('다른 앱으로 공유'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (action != null) await _export(action);
+  }
+
   /// 용지·QR 크기 설정 — 라벨 프린터 등 비표준 크기에 대응하기 위한 옵션(#249).
   /// [_format]에 따라 PDF(용지+QR mm) / 이미지(QR 해상도px) 중 필요한 컨트롤만 보여준다.
-  Widget _buildExportSettings() => Wrap(
+  Widget _buildExportSettings(StateSetter setState) => Wrap(
     spacing: AppSpacing.space3,
     runSpacing: AppSpacing.space2,
     crossAxisAlignment: WrapCrossAlignment.center,
@@ -328,16 +357,15 @@ class _BadgePrecreateScreenState extends ConsumerState<BadgePrecreateScreen> {
                           : null,
                       onPressed: _count == null || _busy ? null : _generate,
                     ),
-                    ExportActionButton(
+                    AppButton(
+                      variant: AppButtonVariant.secondary,
+                      size: AppButtonSize.compact,
                       icon: Icons.ios_share,
                       label: '스티커 내보내기',
-                      busy: _busy,
-                      onSelected: _export,
+                      onPressed: _busy ? null : _openExportDialog,
                     ),
                   ],
                 ),
-                const SizedBox(height: AppSpacing.space3),
-                _buildExportSettings(),
                 const SizedBox(height: AppSpacing.space5),
                 Text(
                   '미배정 $unassigned장 · 배정됨 ${items.length - unassigned}장',

--- a/frontend/lib/admin/features/badge_precreate/badge_precreate_screen.dart
+++ b/frontend/lib/admin/features/badge_precreate/badge_precreate_screen.dart
@@ -4,7 +4,9 @@ import 'package:cornermon/admin/session/selected_camp_provider.dart';
 import 'package:cornermon/shared/api/domain_aliases.dart' as api;
 import 'package:cornermon/shared/api/providers/badge_providers.dart';
 import 'package:cornermon/shared/api/providers/group_providers.dart';
+import 'package:cornermon/shared/design_system/tokens/colors.dart';
 import 'package:cornermon/shared/design_system/tokens/spacing.dart';
+import 'package:cornermon/shared/design_system/tokens/typography.dart';
 import 'package:cornermon/shared/design_system/widgets/app_button.dart';
 import 'package:cornermon/shared/design_system/widgets/app_dropdown.dart';
 import 'package:cornermon/shared/design_system/widgets/empty_state.dart';
@@ -163,9 +165,15 @@ class _BadgePrecreateScreenState extends ConsumerState<BadgePrecreateScreen> {
       context: context,
       builder: (dialogContext) => StatefulBuilder(
         builder: (context, setDialogState) => AlertDialog(
-          title: const Text('스티커 내보내기'),
-          content: SingleChildScrollView(
-            child: _buildExportSettings(setDialogState),
+          title: Text(
+            '스티커 내보내기',
+            style: AppTypography.bodyEmphasis.copyWith(fontSize: 18),
+          ),
+          content: SizedBox(
+            width: 320,
+            child: SingleChildScrollView(
+              child: _buildExportSettings(setDialogState),
+            ),
           ),
           actions: [
             TextButton(
@@ -187,116 +195,132 @@ class _BadgePrecreateScreenState extends ConsumerState<BadgePrecreateScreen> {
 
   /// 용지·QR 크기 설정 — 라벨 프린터 등 비표준 크기에 대응하기 위한 옵션(#249).
   /// [_format]에 따라 PDF(용지+QR mm) / 이미지(QR 해상도px) 중 필요한 컨트롤만 보여준다.
-  Widget _buildExportSettings(StateSetter setState) => Wrap(
-    spacing: AppSpacing.space3,
-    runSpacing: AppSpacing.space2,
-    crossAxisAlignment: WrapCrossAlignment.center,
+  /// 각 드롭다운은 무엇을 고르는 값인지 알 수 있도록 레이블을 위에 붙인 폼 형태로 배치한다.
+  Widget _buildExportSettings(StateSetter setState) => Column(
+    mainAxisSize: MainAxisSize.min,
+    crossAxisAlignment: CrossAxisAlignment.stretch,
     children: [
-      AppDropdown<BadgeExportFormat>(
-        value: _format,
-        items: const [
-          DropdownMenuItem(
-            value: BadgeExportFormat.pdfSheet,
-            child: Text('PDF 시트'),
-          ),
-          DropdownMenuItem(
-            value: BadgeExportFormat.images,
-            child: Text('개별 이미지'),
-          ),
-        ],
-        onChanged: (value) => setState(() => _format = value!),
-      ),
-      if (_format == BadgeExportFormat.pdfSheet) ...[
-        AppDropdown<PaperSizePreset>(
-          value: _paperPreset,
+      _LabeledField(
+        label: '형식',
+        child: AppDropdown<BadgeExportFormat>(
+          value: _format,
           items: const [
-            DropdownMenuItem(value: PaperSizePreset.a4, child: Text('A4')),
             DropdownMenuItem(
-              value: PaperSizePreset.letter,
-              child: Text('Letter'),
+              value: BadgeExportFormat.pdfSheet,
+              child: Text('PDF 시트'),
             ),
             DropdownMenuItem(
-              value: PaperSizePreset.custom,
-              child: Text('커스텀(mm)'),
+              value: BadgeExportFormat.images,
+              child: Text('개별 이미지'),
             ),
           ],
-          onChanged: (value) => setState(() => _paperPreset = value!),
+          onChanged: (value) => setState(() => _format = value!),
+        ),
+      ),
+      const SizedBox(height: AppSpacing.space3),
+      if (_format == BadgeExportFormat.pdfSheet) ...[
+        _LabeledField(
+          label: '용지',
+          child: AppDropdown<PaperSizePreset>(
+            value: _paperPreset,
+            items: const [
+              DropdownMenuItem(value: PaperSizePreset.a4, child: Text('A4')),
+              DropdownMenuItem(
+                value: PaperSizePreset.letter,
+                child: Text('Letter'),
+              ),
+              DropdownMenuItem(
+                value: PaperSizePreset.custom,
+                child: Text('커스텀(mm)'),
+              ),
+            ],
+            onChanged: (value) => setState(() => _paperPreset = value!),
+          ),
         ),
         if (_paperPreset == PaperSizePreset.custom) ...[
-          SizedBox(
-            width: 90,
-            child: TextField(
-              controller: _customWidthMm,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(labelText: '가로mm'),
-            ),
-          ),
-          SizedBox(
-            width: 90,
-            child: TextField(
-              controller: _customHeightMm,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(labelText: '세로mm'),
-            ),
+          const SizedBox(height: AppSpacing.space3),
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _customWidthMm,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: '가로mm'),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.space3),
+              Expanded(
+                child: TextField(
+                  controller: _customHeightMm,
+                  keyboardType: TextInputType.number,
+                  decoration: const InputDecoration(labelText: '세로mm'),
+                ),
+              ),
+            ],
           ),
         ],
-        AppDropdown<QrSizeMmPreset?>(
-          value: _qrSizeMmPreset,
-          items: const [
-            DropdownMenuItem(
-              value: QrSizeMmPreset.small,
-              child: Text('QR 작게(25mm)'),
-            ),
-            DropdownMenuItem(
-              value: QrSizeMmPreset.medium,
-              child: Text('QR 보통(35mm)'),
-            ),
-            DropdownMenuItem(
-              value: QrSizeMmPreset.large,
-              child: Text('QR 크게(45mm)'),
-            ),
-            DropdownMenuItem(value: null, child: Text('QR 커스텀(mm)')),
-          ],
-          onChanged: (value) => setState(() => _qrSizeMmPreset = value),
-        ),
-        if (_qrSizeMmPreset == null)
-          SizedBox(
-            width: 90,
-            child: TextField(
-              controller: _customQrSizeMm,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(labelText: 'QR mm'),
-            ),
+        const SizedBox(height: AppSpacing.space3),
+        _LabeledField(
+          label: 'QR 크기',
+          child: AppDropdown<QrSizeMmPreset?>(
+            value: _qrSizeMmPreset,
+            items: const [
+              DropdownMenuItem(
+                value: QrSizeMmPreset.small,
+                child: Text('QR 작게(25mm)'),
+              ),
+              DropdownMenuItem(
+                value: QrSizeMmPreset.medium,
+                child: Text('QR 보통(35mm)'),
+              ),
+              DropdownMenuItem(
+                value: QrSizeMmPreset.large,
+                child: Text('QR 크게(45mm)'),
+              ),
+              DropdownMenuItem(value: null, child: Text('QR 커스텀(mm)')),
+            ],
+            onChanged: (value) => setState(() => _qrSizeMmPreset = value),
           ),
+        ),
+        if (_qrSizeMmPreset == null) ...[
+          const SizedBox(height: AppSpacing.space3),
+          TextField(
+            controller: _customQrSizeMm,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(labelText: 'QR mm'),
+          ),
+        ],
       ] else ...[
-        AppDropdown<QrResolutionPreset?>(
-          value: _qrResolutionPreset,
-          items: const [
-            DropdownMenuItem(
-              value: QrResolutionPreset.small,
-              child: Text('해상도 작게(256px)'),
-            ),
-            DropdownMenuItem(
-              value: QrResolutionPreset.medium,
-              child: Text('해상도 보통(512px)'),
-            ),
-            DropdownMenuItem(
-              value: QrResolutionPreset.large,
-              child: Text('해상도 크게(1024px)'),
-            ),
-            DropdownMenuItem(value: null, child: Text('해상도 커스텀(px)')),
-          ],
-          onChanged: (value) => setState(() => _qrResolutionPreset = value),
-        ),
-        if (_qrResolutionPreset == null)
-          SizedBox(
-            width: 90,
-            child: TextField(
-              controller: _customQrResolutionPx,
-              keyboardType: TextInputType.number,
-              decoration: const InputDecoration(labelText: '해상도px'),
-            ),
+        _LabeledField(
+          label: '해상도',
+          child: AppDropdown<QrResolutionPreset?>(
+            value: _qrResolutionPreset,
+            items: const [
+              DropdownMenuItem(
+                value: QrResolutionPreset.small,
+                child: Text('해상도 작게(256px)'),
+              ),
+              DropdownMenuItem(
+                value: QrResolutionPreset.medium,
+                child: Text('해상도 보통(512px)'),
+              ),
+              DropdownMenuItem(
+                value: QrResolutionPreset.large,
+                child: Text('해상도 크게(1024px)'),
+              ),
+              DropdownMenuItem(value: null, child: Text('해상도 커스텀(px)')),
+            ],
+            onChanged: (value) => setState(() => _qrResolutionPreset = value),
           ),
+        ),
+        if (_qrResolutionPreset == null) ...[
+          const SizedBox(height: AppSpacing.space3),
+          TextField(
+            controller: _customQrResolutionPx,
+            keyboardType: TextInputType.number,
+            decoration: const InputDecoration(labelText: '해상도px'),
+          ),
+        ],
       ],
     ],
   );
@@ -437,6 +461,29 @@ class BadgeTable extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+/// 드롭다운이 무엇을 고르는 값인지 알 수 있게 레이블을 위에 붙이는 폼 필드.
+class _LabeledField extends StatelessWidget {
+  const _LabeledField({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final colors = isDark ? AppColors.dark : AppColors.light;
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: AppTypography.label.copyWith(color: colors.textSecondary)),
+        const SizedBox(height: AppSpacing.space1),
+        child,
+      ],
     );
   }
 }

--- a/frontend/lib/admin/features/badge_precreate/badge_sticker_pdf.dart
+++ b/frontend/lib/admin/features/badge_precreate/badge_sticker_pdf.dart
@@ -14,8 +14,6 @@ Future<Uint8List> buildBadgeStickerPdf(
   double qrSizeMm = 35,
 }) async {
   final qrSize = qrSizeMm * PdfPageFormat.mm;
-  final cellWidth = qrSize + _cellPadding;
-  final cellHeight = qrSize + _cellPadding + _textBlockHeight;
   final crossAxisCount = gridColumnsFor(pageFormat, qrSize);
   final document = pw.Document();
   document.addPage(
@@ -24,7 +22,7 @@ Future<Uint8List> buildBadgeStickerPdf(
       build: (_) => [
         pw.GridView(
           crossAxisCount: crossAxisCount,
-          childAspectRatio: cellWidth / cellHeight,
+          childAspectRatio: gridChildAspectRatioFor(qrSize),
           children: [
             for (final badge in badges)
               pw.Container(
@@ -74,3 +72,15 @@ int gridColumnsFor(PdfPageFormat pageFormat, double qrSize) =>
       1,
       20,
     );
+
+/// [qrSize](pt)짜리 QR + 아래 텍스트가 들어갈 셀의 childAspectRatio를 계산한다.
+///
+/// 주의: `pw.GridView`의 childAspectRatio는 width/height가 아니라
+/// `childMainAxis(높이) = childCrossAxis(너비) * childAspectRatio` 식으로 쓰인다
+/// (Flutter의 SliverGridDelegate와 반대 방향). height/width를 넣어야 하며,
+/// 반대로 넣으면 셀 높이가 실제보다 작게 잡혀 QR+텍스트가 셀 밖으로 넘친다.
+double gridChildAspectRatioFor(double qrSize) {
+  final cellWidth = qrSize + _cellPadding;
+  final cellHeight = qrSize + _cellPadding + _textBlockHeight;
+  return cellHeight / cellWidth;
+}

--- a/frontend/lib/admin/features/badge_precreate/badge_sticker_pdf.dart
+++ b/frontend/lib/admin/features/badge_precreate/badge_sticker_pdf.dart
@@ -14,14 +14,17 @@ Future<Uint8List> buildBadgeStickerPdf(
   double qrSizeMm = 35,
 }) async {
   final qrSize = qrSizeMm * PdfPageFormat.mm;
+  final cellWidth = qrSize + _cellPadding;
+  final cellHeight = qrSize + _cellPadding + _textBlockHeight;
+  final crossAxisCount = gridColumnsFor(pageFormat, qrSize);
   final document = pw.Document();
   document.addPage(
     pw.MultiPage(
       pageFormat: pageFormat,
       build: (_) => [
         pw.GridView(
-          crossAxisCount: 3,
-          childAspectRatio: 1.1,
+          crossAxisCount: crossAxisCount,
+          childAspectRatio: cellWidth / cellHeight,
           children: [
             for (final badge in badges)
               pw.Container(
@@ -57,3 +60,17 @@ Future<Uint8List> buildBadgeStickerPdf(
   );
   return document.save();
 }
+
+// 셀 하나가 감싸는 여백(마진 6*2 + 패딩 8*2).
+const _cellPadding = (6 + 8) * 2;
+// 셀 안 QR 아래 텍스트 2줄(shortId 12pt, qrPayload 7pt) + 사이 여백 높이.
+const _textBlockHeight = 8 + 12 + 2 + 7;
+
+/// [pageFormat] 인쇄 가능 폭에 [qrSize](pt)짜리 QR 셀이 몇 열 들어가는지 계산한다.
+/// QR을 줄였는데 열 개수가 그대로면 셀이 헐렁해 보이는 문제(#249 리뷰)를 막기
+/// 위해 crossAxisCount를 고정값이 아니라 QR 크기에서 역산한다.
+int gridColumnsFor(PdfPageFormat pageFormat, double qrSize) =>
+    (pageFormat.availableWidth / (qrSize + _cellPadding)).floor().clamp(
+      1,
+      20,
+    );

--- a/frontend/test/admin/features/badge_precreate/badge_precreate_screen_test.dart
+++ b/frontend/test/admin/features/badge_precreate/badge_precreate_screen_test.dart
@@ -98,10 +98,13 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
+
+    // act
+    await tester.tap(find.text('스티커 내보내기'));
+    await tester.pumpAndSettle();
     expect(find.text('A4'), findsOneWidget);
     expect(find.text('해상도 보통(512px)'), findsNothing);
 
-    // act
     await tester.tap(find.text('PDF 시트'));
     await tester.pumpAndSettle();
     await tester.tap(find.text('개별 이미지').last);

--- a/frontend/test/admin/features/badge_precreate/badge_precreate_screen_test.dart
+++ b/frontend/test/admin/features/badge_precreate/badge_precreate_screen_test.dart
@@ -115,6 +115,38 @@ void main() {
     expect(find.text('해상도 보통(512px)'), findsOneWidget);
   });
 
+  testWidgets(
+    'ShoudShowCustomPaperAndQrSizeFieldsWithoutLayoutErrorWhenCustomIsSelected',
+    (tester) async {
+      // arrange
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [badgeListProvider.overrideWith((ref) async => const [])],
+          child: const MaterialApp(home: BadgePrecreateScreen()),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('스티커 내보내기'));
+      await tester.pumpAndSettle();
+
+      // act
+      await tester.tap(find.text('A4'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('커스텀(mm)'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('QR 보통(35mm)'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('QR 커스텀(mm)').last);
+      await tester.pumpAndSettle();
+
+      // assert — 다이얼로그 고정폭이 없으면 Column stretch가 폭을 못 구해 레이아웃 오류가 난다.
+      expect(tester.takeException(), isNull);
+      expect(find.widgetWithText(TextField, '가로mm'), findsOneWidget);
+      expect(find.widgetWithText(TextField, '세로mm'), findsOneWidget);
+      expect(find.widgetWithText(TextField, 'QR mm'), findsOneWidget);
+    },
+  );
+
   testWidgets('ShoudRenderAssignedBadgeWithGroupNameWhenGroupExists', (
     tester,
   ) async {

--- a/frontend/test/admin/features/badge_precreate/badge_sticker_pdf_test.dart
+++ b/frontend/test/admin/features/badge_precreate/badge_sticker_pdf_test.dart
@@ -1,4 +1,5 @@
-import 'package:cornermon/admin/features/badge_precreate/badge_sticker_pdf.dart';
+import 'package:cornermon/admin/features/badge_precreate/badge_sticker_pdf.dart'
+    show buildBadgeStickerPdf, gridColumnsFor;
 import 'package:cornermon_api_gen/cornermon_api_gen.dart';
 import 'package:pdf/pdf.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -53,4 +54,21 @@ void main() {
     // assert
     expect(String.fromCharCodes(bytes.take(4)), '%PDF');
   });
+
+  test(
+    'ShoudIncreaseGridColumnsWhenQrSizeShrinksOnSamePage',
+    () {
+      // QR을 줄였는데 열 개수가 그대로면 셀이 헐렁해 보이는 리그레션(#249 리뷰)을 막는다.
+      // arrange
+      const wideQr = 35 * PdfPageFormat.mm;
+      const narrowQr = 15 * PdfPageFormat.mm;
+
+      // act
+      final columnsForWideQr = gridColumnsFor(PdfPageFormat.a4, wideQr);
+      final columnsForNarrowQr = gridColumnsFor(PdfPageFormat.a4, narrowQr);
+
+      // assert
+      expect(columnsForNarrowQr, greaterThan(columnsForWideQr));
+    },
+  );
 }

--- a/frontend/test/admin/features/badge_precreate/badge_sticker_pdf_test.dart
+++ b/frontend/test/admin/features/badge_precreate/badge_sticker_pdf_test.dart
@@ -1,5 +1,5 @@
 import 'package:cornermon/admin/features/badge_precreate/badge_sticker_pdf.dart'
-    show buildBadgeStickerPdf, gridColumnsFor;
+    show buildBadgeStickerPdf, gridChildAspectRatioFor, gridColumnsFor;
 import 'package:cornermon_api_gen/cornermon_api_gen.dart';
 import 'package:pdf/pdf.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -69,6 +69,24 @@ void main() {
 
       // assert
       expect(columnsForNarrowQr, greaterThan(columnsForWideQr));
+    },
+  );
+
+  test(
+    'ShoudReturnHeightOverWidthRatioNotInvertedForGridChildAspectRatio',
+    () {
+      // pw.GridView는 childAspectRatio를 height=width*ratio로 쓴다(Flutter
+      // SliverGridDelegate와 반대). width/height를 잘못 넣으면 셀 높이가 QR+텍스트보다
+      // 작게 잡혀 QR이 셀 밖으로 넘치는 리그레션이었다 — ratio가 1보다 커야
+      // (텍스트만큼 더 높아야) 한다는 걸 고정한다.
+      // arrange
+      const qrSize = 35 * PdfPageFormat.mm;
+
+      // act
+      final ratio = gridChildAspectRatioFor(qrSize);
+
+      // assert
+      expect(ratio, greaterThan(1));
     },
   );
 }


### PR DESCRIPTION
## 변경 사항
#249에서 추가한 용지·QR 크기 설정(PDF 시트 / 개별 이미지)이 화면에 항상 노출된 인라인 드롭다운이었고, 내보내기 버튼은 저장/공유만 고르는 별도 팝업 메뉴였다.

`스티커 내보내기` 버튼 클릭 시 크기 설정과 저장/공유 선택을 하나의 팝업 다이얼로그에서 처리하도록 바꾸고, 화면에 항상 떠 있던 인라인 컨트롤은 제거했다.

## 종료 조건
- `frontend/test/.../badge_precreate_screen_test.dart`: 내보내기 버튼 → 다이얼로그에서 PDF/이미지 형식 전환 시 옵션이 바뀌는지 검증하도록 수정
- `make docker-check` (analyze + test) 통과 — 350 tests passed

Issue: #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)