### PR TITLE
chore : 인프라 부하 점검용 loadtest 하네스 + SSE 로깅 노이즈 수정

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,2 +1,7 @@
 ./.env
 ./bin
+
+# loadtest ops tool: compiled binary, run state, local config (has admin pw)
+/loadtest
+/loadtest-state.json
+cmd/loadtest/loadtest.yaml

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -3,5 +3,5 @@
 
 # loadtest ops tool: compiled binary, run state, local config (has admin pw)
 /loadtest
-/loadtest-state.json
+loadtest-state.json
 cmd/loadtest/loadtest.yaml

--- a/backend/cmd/loadtest/loadtest.example.yaml
+++ b/backend/cmd/loadtest/loadtest.example.yaml
@@ -1,0 +1,22 @@
+# loadtest 하네스 설정. `cp loadtest.example.yaml loadtest.yaml` 후 값 채우기.
+#   cd backend && go run ./cmd/loadtest -config cmd/loadtest/loadtest.yaml
+# 생략한 키는 아래 기본값이 적용된다. -phases 플래그로 phases만 일회성 오버라이드 가능.
+
+base: https://cornermon-api-demo.orca.pe.kr/api/v1
+adminId: admin
+adminPassword: ""            # 필수
+
+corners: 10                  # 코너 수
+tracksPerCorner: 1           # 코너당 트랙 수 (진행자 수 = corners * tracksPerCorner)
+groups: 25                   # 조 수 = 코너당 방문 용량. 장시간 소크면 늘릴 것
+admins: 3                    # 동시 관리자 클라이언트 (SSE + 폴링)
+
+visitEvery: 3m               # 트랙별 방문 start/end 주기
+chatEvery: 20s               # 트랙별 채팅 발신 주기
+adminPoll: 5s                # 관리자별 live-summary 폴링 주기
+duration: 30m                # 소크 지속 시간
+
+campName: ""                 # 비우면 loadtest-<unix>
+stateFile: loadtest-state.json
+
+phases: [bootstrap, soak, teardown]

--- a/backend/cmd/loadtest/loadtest.example.yaml
+++ b/backend/cmd/loadtest/loadtest.example.yaml
@@ -7,13 +7,16 @@ adminId: admin
 adminPassword: ""            # 필수
 
 corners: 10                  # 코너 수
-tracksPerCorner: 1           # 코너당 트랙 수 (진행자 수 = corners * tracksPerCorner)
-groups: 25                   # 조 수 = 코너당 방문 용량. 장시간 소크면 늘릴 것
+tracksPerCorner: 2           # 코너당 트랙 수 (진행자 수 = corners * tracksPerCorner)
+groups: 30                   # 조 수 = 코너당 방문 용량. 장시간 소크면 늘릴 것
 admins: 3                    # 동시 관리자 클라이언트 (SSE + 폴링)
 
-visitEvery: 3m               # 트랙별 방문 start/end 주기
-chatEvery: 20s               # 트랙별 채팅 발신 주기
+visitEvery: 5m               # 트랙별 방문 start/end 주기
+visitHoldFrac: 0.8            # 방문이 IN_PROGRESS로 남는 비율 (코너 BUSY 표시 확인용)
+chatEvery: 10s               # 트랙별 다이렉트 채팅 발신 주기
+readEvery: 45s               # 트랙별 채팅함 확인(읽음 처리) 주기
 adminPoll: 5s                # 관리자별 live-summary 폴링 주기
+broadcastEvery: 5m            # 공지 발송 주기 (admin 1명만 발송)
 duration: 30m                # 소크 지속 시간
 
 campName: ""                 # 비우면 loadtest-<unix>

--- a/backend/cmd/loadtest/main.go
+++ b/backend/cmd/loadtest/main.go
@@ -67,6 +67,18 @@ func (c config) I(key string, def int) int {
 	return n
 }
 
+func (c config) F(key string, def float64) float64 {
+	v, ok := c.raw[key]
+	if !ok || v == "" {
+		return def
+	}
+	n, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		log.Fatalf("config %s: %v", key, err)
+	}
+	return n
+}
+
 // config is the flat key/value config file. The format is a deliberately tiny
 // YAML subset — one `key: value` per line, `#` comments, `key: [a, b]` lists —
 // so no YAML dependency is needed for ~a dozen scalars.
@@ -81,8 +93,11 @@ type config struct {
 	Groups          int
 	Admins          int
 	VisitEvery      time.Duration
+	VisitHoldFrac   float64 // fraction of VisitEvery a visit stays IN_PROGRESS (corner reads BUSY)
 	ChatEvery       time.Duration
+	ReadEvery       time.Duration // per-track: how often a facilitator checks/reads messages
 	AdminPoll       time.Duration
+	BroadcastEvery  time.Duration // admin: how often to send a camp-wide announcement
 	Duration        time.Duration
 	CampName        string
 	StateFile       string
@@ -118,8 +133,11 @@ func loadConfig() config {
 	c.Groups = c.I("groups", 25)
 	c.Admins = c.I("admins", 3)
 	c.VisitEvery = c.D("visitEvery", 3*time.Minute)
+	c.VisitHoldFrac = c.F("visitHoldFrac", 0.8)
 	c.ChatEvery = c.D("chatEvery", 20*time.Second)
+	c.ReadEvery = c.D("readEvery", 45*time.Second)
 	c.AdminPoll = c.D("adminPoll", 5*time.Second)
+	c.BroadcastEvery = c.D("broadcastEvery", 5*time.Minute)
 	c.Duration = c.D("duration", 30*time.Minute)
 	c.StateFile = c.S("stateFile", "loadtest-state.json")
 
@@ -474,10 +492,11 @@ func soak(ctx context.Context, c config, st state) {
 		}()
 	}
 	for i := 0; i < c.Admins; i++ {
+		sendsBroadcasts := i == 0 // one admin announces; the rest just watch + poll
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			runAdmin(ctx, c, st)
+			runAdmin(ctx, c, st, sendsBroadcasts)
 		}()
 	}
 
@@ -505,8 +524,10 @@ func runTrack(ctx context.Context, c config, st state, t track, pool *visitPool)
 
 	visitT := time.NewTicker(jitter(c.VisitEvery))
 	chatT := time.NewTicker(jitter(c.ChatEvery))
+	readT := time.NewTicker(jitter(c.ReadEvery))
 	defer visitT.Stop()
 	defer chatT.Stop()
+	defer readT.Stop()
 
 	for {
 		select {
@@ -525,7 +546,15 @@ func runTrack(ctx context.Context, c config, st state, t track, pool *visitPool)
 			if err != nil {
 				continue
 			}
-			time.Sleep(2 * time.Second) // group is "in the corner" briefly
+			// Corner reads BUSY for this long — a hardcoded couple of seconds here
+			// made corners look permanently IDLE against any realistic visitEvery,
+			// so it's a share of the cycle instead (see visitHoldFrac).
+			hold := time.Duration(float64(c.VisitEvery) * c.VisitHoldFrac)
+			select {
+			case <-time.After(hold):
+			case <-ctx.Done():
+				return
+			}
 			timed("visit_end", func() error {
 				return call(ctx, "POST", c.Base+"/tracks/"+t.ID+"/visits/current/end", t.Token, nil, nil, nil)
 			})
@@ -534,15 +563,31 @@ func runTrack(ctx context.Context, c config, st state, t track, pool *visitPool)
 				return call(ctx, "POST", c.Base+"/tracks/"+t.ID+"/messages", t.Token,
 					map[string]string{"content": "loadtest " + time.Now().Format("15:04:05")}, nil, nil)
 			})
+		case <-readT.C:
+			// Facilitator opening the chat screen: lists messages with
+			// background=true, which also marks the admin's unread ones read.
+			timed("track_read", func() error {
+				return call(ctx, "GET", c.Base+"/tracks/"+t.ID+"/messages?background=true", t.Token, nil, nil, nil)
+			})
 		}
 	}
 }
 
-func runAdmin(ctx context.Context, c config, st state) {
+func runAdmin(ctx context.Context, c config, st state, sendsBroadcasts bool) {
 	go streamSSE(ctx, c.Base+"/camps/"+st.CampID+"/events/admin", st.AdminToken, "admin_sse")
 
 	poll := time.NewTicker(jitter(c.AdminPoll))
 	defer poll.Stop()
+
+	// Only one admin sends announcements; a nil channel in the select below
+	// just never fires for the rest.
+	var broadcastC <-chan time.Time
+	if sendsBroadcasts {
+		broadcast := time.NewTicker(jitter(c.BroadcastEvery))
+		defer broadcast.Stop()
+		broadcastC = broadcast.C
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -550,6 +595,11 @@ func runAdmin(ctx context.Context, c config, st state) {
 		case <-poll.C:
 			timed("admin_poll", func() error {
 				return call(ctx, "GET", c.Base+"/camps/"+st.CampID+"/reports/live-summary", st.AdminToken, nil, nil, nil)
+			})
+		case <-broadcastC:
+			timed("broadcast_send", func() error {
+				return call(ctx, "POST", c.Base+"/camps/"+st.CampID+"/messages/broadcast", st.AdminToken,
+					map[string]string{"content": "loadtest announcement " + time.Now().Format("15:04:05")}, nil, nil)
 			})
 		}
 	}

--- a/backend/cmd/loadtest/main.go
+++ b/backend/cmd/loadtest/main.go
@@ -463,14 +463,19 @@ func bootstrap(ctx context.Context, c config) (state, error) {
 // visitPool hands out (group, track-corner) pairs that haven't been used yet.
 // A group can visit each corner once; once a corner's groups are exhausted the
 // track's visit cycles are skipped (bump -groups if that starts early).
+//
+// A group also can't be at two corners at once — the server correctly rejects
+// that as ITINERARY_CONFLICT — so `busy` locks a group from take() until the
+// caller release()s it, covering the whole start→hold→end window.
 type visitPool struct {
 	mu   sync.Mutex
 	used map[string]map[string]bool // cornerID -> groupID -> done
+	busy map[string]bool            // groupID -> currently held by some track
 	all  []string
 }
 
 func newVisitPool(groups []string) *visitPool {
-	return &visitPool{used: map[string]map[string]bool{}, all: groups}
+	return &visitPool{used: map[string]map[string]bool{}, busy: map[string]bool{}, all: groups}
 }
 
 func (p *visitPool) take(cornerID string) (string, bool) {
@@ -482,12 +487,22 @@ func (p *visitPool) take(cornerID string) (string, bool) {
 		p.used[cornerID] = seen
 	}
 	for _, g := range rand.Perm(len(p.all)) {
-		if !seen[p.all[g]] {
-			seen[p.all[g]] = true
-			return p.all[g], true
+		gid := p.all[g]
+		if !seen[gid] && !p.busy[gid] {
+			seen[gid] = true
+			p.busy[gid] = true
+			return gid, true
 		}
 	}
 	return "", false
+}
+
+// release frees a group taken via take(), once its visit has ended (or failed
+// to start at all).
+func (p *visitPool) release(groupID string) {
+	p.mu.Lock()
+	delete(p.busy, groupID)
+	p.mu.Unlock()
 }
 
 func soak(ctx context.Context, c config, st state) {
@@ -555,6 +570,7 @@ func runTrack(ctx context.Context, c config, st state, t track, pool *visitPool)
 					map[string]string{"groupId": gid, "method": "MANUAL"}, nil, nil)
 			})
 			if err != nil {
+				pool.release(gid) // never actually started; free it back up
 				continue
 			}
 			// Corner reads BUSY for this long — a hardcoded couple of seconds here
@@ -564,11 +580,13 @@ func runTrack(ctx context.Context, c config, st state, t track, pool *visitPool)
 			select {
 			case <-time.After(hold):
 			case <-ctx.Done():
+				pool.release(gid)
 				return
 			}
 			timed("visit_end", func() error {
 				return call(ctx, "POST", c.Base+"/tracks/"+t.ID+"/visits/current/end", t.Token, nil, nil, nil)
 			})
+			pool.release(gid)
 		case <-chatT.C:
 			timed("chat_send", func() error {
 				return call(ctx, "POST", c.Base+"/tracks/"+t.ID+"/messages", t.Token,

--- a/backend/cmd/loadtest/main.go
+++ b/backend/cmd/loadtest/main.go
@@ -28,130 +28,87 @@ import (
 	"os"
 	"os/signal"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // ── config ──────────────────────────────────────────────────────────────────
 
-func (c config) D(key string, def time.Duration) time.Duration {
-	v, ok := c.raw[key]
-	if !ok || v == "" {
-		return def
-	}
-	d, err := time.ParseDuration(v)
+// Dur is a time.Duration that unmarshals from a YAML string like "3m" / "20s".
+type Dur time.Duration
+
+func (d Dur) D() time.Duration { return time.Duration(d) }
+
+func (d *Dur) UnmarshalYAML(n *yaml.Node) error {
+	v, err := time.ParseDuration(n.Value)
 	if err != nil {
-		log.Fatalf("config %s: %v", key, err)
+		return err
 	}
-	return d
+	*d = Dur(v)
+	return nil
 }
 
-func (c config) S(key, def string) string {
-	if v, ok := c.raw[key]; ok && v != "" {
-		return v
-	}
-	return def
-}
-
-func (c config) I(key string, def int) int {
-	v, ok := c.raw[key]
-	if !ok || v == "" {
-		return def
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil {
-		log.Fatalf("config %s: %v", key, err)
-	}
-	return n
-}
-
-func (c config) F(key string, def float64) float64 {
-	v, ok := c.raw[key]
-	if !ok || v == "" {
-		return def
-	}
-	n, err := strconv.ParseFloat(v, 64)
-	if err != nil {
-		log.Fatalf("config %s: %v", key, err)
-	}
-	return n
-}
-
-// config is the flat key/value config file. The format is a deliberately tiny
-// YAML subset — one `key: value` per line, `#` comments, `key: [a, b]` lists —
-// so no YAML dependency is needed for ~a dozen scalars.
 type config struct {
-	raw map[string]string
-
-	Base            string
-	AdminID         string
-	AdminPW         string
-	Corners         int
-	TracksPerCorner int
-	Groups          int
-	Admins          int
-	VisitEvery      time.Duration
-	VisitHoldFrac   float64 // fraction of VisitEvery a visit stays IN_PROGRESS (corner reads BUSY)
-	ChatEvery       time.Duration
-	ReadEvery       time.Duration // per-track: how often a facilitator checks/reads messages
-	AdminPoll       time.Duration
-	BroadcastEvery  time.Duration // admin: how often to send a camp-wide announcement
-	Duration        time.Duration
-	CampName        string
-	StateFile       string
-	Phases          []string
+	Base            string   `yaml:"base"`
+	AdminID         string   `yaml:"adminId"`
+	AdminPW         string   `yaml:"adminPassword"`
+	Corners         int      `yaml:"corners"`
+	TracksPerCorner int      `yaml:"tracksPerCorner"`
+	Groups          int      `yaml:"groups"`
+	Admins          int      `yaml:"admins"`
+	VisitEvery      Dur      `yaml:"visitEvery"`
+	VisitHoldFrac   float64  `yaml:"visitHoldFrac"` // fraction of VisitEvery a visit stays IN_PROGRESS (corner reads BUSY)
+	ChatEvery       Dur      `yaml:"chatEvery"`
+	ReadEvery       Dur      `yaml:"readEvery"` // per-track: how often a facilitator checks/reads messages
+	AdminPoll       Dur      `yaml:"adminPoll"`
+	BroadcastEvery  Dur      `yaml:"broadcastEvery"` // admin: how often to send a camp-wide announcement
+	Duration        Dur      `yaml:"duration"`
+	CampName        string   `yaml:"campName"`
+	StateFile       string   `yaml:"stateFile"`
+	Phases          []string `yaml:"phases"`
 }
 
+// loadConfig reads the YAML config (path from -config) on top of built-in
+// defaults, so the file only needs to set what differs. -phases overrides the
+// file's phase list for one-off runs.
 func loadConfig() config {
-	path := flag.String("config", "loadtest.yaml", "path to config file")
+	path := flag.String("config", "loadtest.yaml", "path to YAML config")
 	phasesOverride := flag.String("phases", "", "comma list overriding config phases (bootstrap,soak,teardown)")
 	flag.Parse()
 
+	c := config{
+		Base:            "http://localhost:8080/api/v1",
+		AdminID:         "admin",
+		StateFile:       "loadtest-state.json",
+		Corners:         10,
+		TracksPerCorner: 1,
+		Groups:          25,
+		Admins:          3,
+		VisitEvery:      Dur(3 * time.Minute),
+		VisitHoldFrac:   0.8,
+		ChatEvery:       Dur(20 * time.Second),
+		ReadEvery:       Dur(45 * time.Second),
+		AdminPoll:       Dur(5 * time.Second),
+		BroadcastEvery:  Dur(5 * time.Minute),
+		Duration:        Dur(30 * time.Minute),
+		Phases:          []string{"bootstrap", "soak", "teardown"},
+	}
 	b, err := os.ReadFile(*path)
 	if err != nil {
 		log.Fatalf("read config %s: %v", *path, err)
 	}
-	c := config{raw: map[string]string{}}
-	for _, line := range strings.Split(string(b), "\n") {
-		if i := strings.IndexByte(line, '#'); i >= 0 {
-			line = line[:i]
-		}
-		k, v, ok := strings.Cut(line, ":")
-		if !ok {
-			continue
-		}
-		c.raw[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"'`)
+	if err := yaml.Unmarshal(b, &c); err != nil {
+		log.Fatalf("parse config %s: %v", *path, err)
 	}
-
-	c.Base = c.S("base", "http://localhost:8080/api/v1")
-	c.AdminID = c.S("adminId", "admin")
-	c.AdminPW = c.S("adminPassword", "")
-	c.Corners = c.I("corners", 10)
-	c.TracksPerCorner = c.I("tracksPerCorner", 1)
-	c.Groups = c.I("groups", 25)
-	c.Admins = c.I("admins", 3)
-	c.VisitEvery = c.D("visitEvery", 3*time.Minute)
-	c.VisitHoldFrac = c.F("visitHoldFrac", 0.8)
-	c.ChatEvery = c.D("chatEvery", 20*time.Second)
-	c.ReadEvery = c.D("readEvery", 45*time.Second)
-	c.AdminPoll = c.D("adminPoll", 5*time.Second)
-	c.BroadcastEvery = c.D("broadcastEvery", 5*time.Minute)
-	c.Duration = c.D("duration", 30*time.Minute)
-	c.StateFile = c.S("stateFile", "loadtest-state.json")
-
-	phases := c.S("phases", "bootstrap, soak, teardown")
 	if *phasesOverride != "" {
-		phases = *phasesOverride
+		c.Phases = strings.Split(*phasesOverride, ",")
 	}
-	for _, p := range strings.Split(strings.Trim(phases, "[]"), ",") {
-		if p = strings.TrimSpace(p); p != "" {
-			c.Phases = append(c.Phases, p)
-		}
+	if c.CampName == "" {
+		c.CampName = fmt.Sprintf("loadtest-%d", time.Now().Unix())
 	}
-
-	c.CampName = c.S("campName", fmt.Sprintf("loadtest-%d", time.Now().Unix()))
 	return c
 }
 
@@ -198,20 +155,24 @@ func call(ctx context.Context, method, url, token string, body, out any, extra m
 	if err != nil {
 		return err
 	}
+
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
+
 	for k, v := range extra {
 		req.Header.Set(k, v)
 	}
+
 	resp, err := api.Do(req)
 	if err != nil {
 		return err
 	}
 	defer resp.Body.Close()
+
 	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if resp.StatusCode/100 != 2 {
 		return apiError{resp.StatusCode, string(raw)}
@@ -328,56 +289,151 @@ func printReport(elapsed time.Duration) {
 
 // ── bootstrap ───────────────────────────────────────────────────────────────
 
-func bootstrap(ctx context.Context, c config) (state, error) {
-	st := state{Base: c.Base}
+// adminCall is an already-authenticated request against c.Base as the admin.
+type adminCall func(method, path string, body, out any) error
 
+func adminLogin(ctx context.Context, c config) (string, error) {
 	var login struct {
 		AccessToken string `json:"accessToken"`
 	}
 	if err := call(ctx, "POST", c.Base+"/auth/admin/login", "",
 		map[string]string{"id": c.AdminID, "password": c.AdminPW}, &login, nil); err != nil {
-		return st, fmt.Errorf("admin login: %w", err)
+		return "", fmt.Errorf("admin login: %w", err)
 	}
-	st.AdminToken = login.AccessToken
-	adm := func(method, path string, body, out any) error {
-		return call(ctx, method, c.Base+path, st.AdminToken, body, out, nil)
-	}
+	return login.AccessToken, nil
+}
 
+func adminCaller(ctx context.Context, c config, token string) adminCall {
+	return func(method, path string, body, out any) error {
+		return call(ctx, method, c.Base+path, token, body, out, nil)
+	}
+}
+
+func createCamp(adm adminCall, name string) (id, regCode string, err error) {
 	var camp struct {
 		ID               string `json:"id"`
 		RegistrationCode string `json:"registrationCode"`
 	}
 	now := time.Now().UTC()
 	if err := adm("POST", "/camps", map[string]any{
-		"name":    c.CampName,
+		"name":    name,
 		"startAt": now.Add(-time.Hour).Format(time.RFC3339),
 		"endAt":   now.Add(7 * 24 * time.Hour).Format(time.RFC3339),
 	}, &camp); err != nil {
-		return st, fmt.Errorf("create camp: %w", err)
+		return "", "", fmt.Errorf("create camp: %w", err)
 	}
-	st.CampID, st.RegCode = camp.ID, camp.RegistrationCode
-	log.Printf("camp %s (%s) reg=%s", c.CampName, st.CampID, st.RegCode)
+	return camp.ID, camp.RegistrationCode, nil
+}
 
-	for i := 0; i < c.Corners; i++ {
+// createCornersAndTracks creates `corners` corners, each with `tracksPerCorner`
+// tracks, and returns every created track (without a facilitator token yet).
+func createCornersAndTracks(adm adminCall, campID string, corners, tracksPerCorner int) ([]track, error) {
+	var tracks []track
+	for i := 0; i < corners; i++ {
 		var corner struct {
 			ID string `json:"id"`
 		}
 		if err := adm("POST", "/corners", map[string]any{
-			"campId": st.CampID, "name": fmt.Sprintf("corner-%02d", i+1), "targetMinutes": 10,
+			"campId": campID, "name": fmt.Sprintf("corner-%02d", i+1), "targetMinutes": 10,
 		}, &corner); err != nil {
-			return st, fmt.Errorf("create corner %d: %w", i, err)
+			return nil, fmt.Errorf("create corner %d: %w", i, err)
 		}
 		var created []struct {
 			Track track `json:"track"`
 		}
 		if err := adm("POST", "/tracks", map[string]any{
-			"campId": st.CampID, "cornerId": corner.ID, "count": c.TracksPerCorner,
+			"campId": campID, "cornerId": corner.ID, "count": tracksPerCorner,
 		}, &created); err != nil {
-			return st, fmt.Errorf("create tracks for corner %d: %w", i, err)
+			return nil, fmt.Errorf("create tracks for corner %d: %w", i, err)
 		}
 		for _, t := range created {
-			st.Tracks = append(st.Tracks, track{ID: t.Track.ID, CornerID: corner.ID})
+			tracks = append(tracks, track{ID: t.Track.ID, CornerID: corner.ID})
 		}
+	}
+	return tracks, nil
+}
+
+// createGroups issues `n` badges and registers each into its own group,
+// returning the group IDs (visit capacity: one visit per group per corner).
+func createGroups(adm adminCall, campID string, n int) ([]string, error) {
+	var badges []struct {
+		ID string `json:"id"`
+	}
+	if err := adm("POST", "/badges/bulk-generate", map[string]any{"count": n}, &badges); err != nil {
+		return nil, fmt.Errorf("bulk-generate badges: %w", err)
+	}
+	groupIDs := make([]string, 0, len(badges))
+	for i, b := range badges {
+		var grp struct {
+			ID string `json:"id"`
+		}
+		if err := adm("POST", "/badges/"+b.ID+"/register", map[string]any{
+			"campId": campID, "groupName": fmt.Sprintf("group-%02d", i+1),
+		}, &grp); err != nil {
+			return nil, fmt.Errorf("register badge %d: %w", i, err)
+		}
+		groupIDs = append(groupIDs, grp.ID)
+	}
+	return groupIDs, nil
+}
+
+// provisionFacilitator registers, approves, and logs in one device for track
+// #i, returning the resulting track session token.
+func provisionFacilitator(ctx context.Context, c config, adm adminCall, campID, regCode string, t track, i int) (string, error) {
+	var dev struct {
+		ID          string `json:"id"`
+		DeviceToken string `json:"deviceToken"`
+	}
+	if err := call(ctx, "POST", c.Base+"/device-registrations", "", map[string]any{
+		"registrationCode": regCode,
+		"deviceName":       fmt.Sprintf("%s-dev-%03d", c.CampName, i),
+		"deviceModel":      "loadtest",
+		"displayName":      fmt.Sprintf("lt-%03d", i),
+		"role":             "FACILITATOR",
+	}, &dev, nil); err != nil {
+		return "", fmt.Errorf("register device %d: %w", i, err)
+	}
+	if err := adm("POST", "/camps/"+campID+"/device-registrations/"+dev.ID+"/approve", nil, nil); err != nil {
+		return "", fmt.Errorf("approve device %d: %w", i, err)
+	}
+	// PIN: /tracks/{id}/export returns {track:{id},pin}. Devices are approved in
+	// track order, but PINs aren't ordered — fetch this track's PIN explicitly.
+	var exp struct {
+		PIN string `json:"pin"`
+	}
+	if err := adm("GET", "/tracks/"+t.ID+"/export", nil, &exp); err != nil {
+		return "", fmt.Errorf("export track %d: %w", i, err)
+	}
+	var tl struct {
+		TrackToken string `json:"trackToken"`
+	}
+	if err := call(ctx, "POST", c.Base+"/auth/track/login", "",
+		map[string]string{"pin": exp.PIN}, &tl,
+		map[string]string{"X-Device-Token": dev.DeviceToken}); err != nil {
+		return "", fmt.Errorf("track login %d: %w", i, err)
+	}
+	return tl.TrackToken, nil
+}
+
+func bootstrap(ctx context.Context, c config) (state, error) {
+	st := state{Base: c.Base}
+
+	token, err := adminLogin(ctx, c)
+	if err != nil {
+		return st, err
+	}
+	st.AdminToken = token
+	adm := adminCaller(ctx, c, token)
+
+	st.CampID, st.RegCode, err = createCamp(adm, c.CampName)
+	if err != nil {
+		return st, err
+	}
+	log.Printf("camp %s (%s) reg=%s", c.CampName, st.CampID, st.RegCode)
+
+	st.Tracks, err = createCornersAndTracks(adm, st.CampID, c.Corners, c.TracksPerCorner)
+	if err != nil {
+		return st, err
 	}
 	log.Printf("%d corners, %d tracks", c.Corners, len(st.Tracks))
 
@@ -385,63 +441,18 @@ func bootstrap(ctx context.Context, c config) (state, error) {
 		return st, fmt.Errorf("start camp: %w", err)
 	}
 
-	var badges []struct {
-		ID string `json:"id"`
-	}
-	if err := adm("POST", "/badges/bulk-generate", map[string]any{"count": c.Groups}, &badges); err != nil {
-		return st, fmt.Errorf("bulk-generate badges: %w", err)
-	}
-	for i, b := range badges {
-		var grp struct {
-			ID string `json:"id"`
-		}
-		if err := adm("POST", "/badges/"+b.ID+"/register", map[string]any{
-			"campId": st.CampID, "groupName": fmt.Sprintf("group-%02d", i+1),
-		}, &grp); err != nil {
-			return st, fmt.Errorf("register badge %d: %w", i, err)
-		}
-		st.GroupIDs = append(st.GroupIDs, grp.ID)
+	st.GroupIDs, err = createGroups(adm, st.CampID, c.Groups)
+	if err != nil {
+		return st, err
 	}
 	log.Printf("%d groups", len(st.GroupIDs))
 
-	// One approved facilitator device per track, then track login for its PIN.
 	for i := range st.Tracks {
-		var dev struct {
-			ID          string `json:"id"`
-			DeviceToken string `json:"deviceToken"`
+		token, err := provisionFacilitator(ctx, c, adm, st.CampID, st.RegCode, st.Tracks[i], i)
+		if err != nil {
+			return st, err
 		}
-		if err := call(ctx, "POST", c.Base+"/device-registrations", "", map[string]any{
-			"registrationCode": st.RegCode,
-			"deviceName":       fmt.Sprintf("%s-dev-%03d", c.CampName, i),
-			"deviceModel":      "loadtest",
-			"displayName":      fmt.Sprintf("lt-%03d", i),
-			"role":             "FACILITATOR",
-		}, &dev, nil); err != nil {
-			return st, fmt.Errorf("register device %d: %w", i, err)
-		}
-		if err := adm("POST", "/camps/"+st.CampID+"/device-registrations/"+dev.ID+"/approve", nil, nil); err != nil {
-			return st, fmt.Errorf("approve device %d: %w", i, err)
-		}
-		var tl struct {
-			TrackToken string `json:"trackToken"`
-			Track      struct {
-				ID string `json:"id"`
-			} `json:"track"`
-		}
-		// PIN: /tracks/{id}/export returns {track:{id},pin}. Devices are approved in
-		// track order, but PINs aren't ordered — fetch this track's PIN explicitly.
-		var exp struct {
-			PIN string `json:"pin"`
-		}
-		if err := adm("GET", "/tracks/"+st.Tracks[i].ID+"/export", nil, &exp); err != nil {
-			return st, fmt.Errorf("export track %d: %w", i, err)
-		}
-		if err := call(ctx, "POST", c.Base+"/auth/track/login", "",
-			map[string]string{"pin": exp.PIN}, &tl,
-			map[string]string{"X-Device-Token": dev.DeviceToken}); err != nil {
-			return st, fmt.Errorf("track login %d: %w", i, err)
-		}
-		st.Tracks[i].Token = tl.TrackToken
+		st.Tracks[i].Token = token
 	}
 	log.Printf("%d facilitator devices approved + logged in", len(st.Tracks))
 	return st, nil
@@ -522,9 +533,9 @@ func soak(ctx context.Context, c config, st state) {
 func runTrack(ctx context.Context, c config, st state, t track, pool *visitPool) {
 	go streamSSE(ctx, c.Base+"/events/track/"+t.ID, t.Token, "track_sse")
 
-	visitT := time.NewTicker(jitter(c.VisitEvery))
-	chatT := time.NewTicker(jitter(c.ChatEvery))
-	readT := time.NewTicker(jitter(c.ReadEvery))
+	visitT := time.NewTicker(jitter(c.VisitEvery.D()))
+	chatT := time.NewTicker(jitter(c.ChatEvery.D()))
+	readT := time.NewTicker(jitter(c.ReadEvery.D()))
 	defer visitT.Stop()
 	defer chatT.Stop()
 	defer readT.Stop()
@@ -549,7 +560,7 @@ func runTrack(ctx context.Context, c config, st state, t track, pool *visitPool)
 			// Corner reads BUSY for this long — a hardcoded couple of seconds here
 			// made corners look permanently IDLE against any realistic visitEvery,
 			// so it's a share of the cycle instead (see visitHoldFrac).
-			hold := time.Duration(float64(c.VisitEvery) * c.VisitHoldFrac)
+			hold := time.Duration(float64(c.VisitEvery.D()) * c.VisitHoldFrac)
 			select {
 			case <-time.After(hold):
 			case <-ctx.Done():
@@ -576,14 +587,14 @@ func runTrack(ctx context.Context, c config, st state, t track, pool *visitPool)
 func runAdmin(ctx context.Context, c config, st state, sendsBroadcasts bool) {
 	go streamSSE(ctx, c.Base+"/camps/"+st.CampID+"/events/admin", st.AdminToken, "admin_sse")
 
-	poll := time.NewTicker(jitter(c.AdminPoll))
+	poll := time.NewTicker(jitter(c.AdminPoll.D()))
 	defer poll.Stop()
 
 	// Only one admin sends announcements; a nil channel in the select below
 	// just never fires for the rest.
 	var broadcastC <-chan time.Time
 	if sendsBroadcasts {
-		broadcast := time.NewTicker(jitter(c.BroadcastEvery))
+		broadcast := time.NewTicker(jitter(c.BroadcastEvery.D()))
 		defer broadcast.Stop()
 		broadcastC = broadcast.C
 	}
@@ -695,9 +706,9 @@ func main() {
 	}
 
 	if phases["soak"] {
-		soakCtx, cancel := context.WithTimeout(ctx, c.Duration)
+		soakCtx, cancel := context.WithTimeout(ctx, c.Duration.D())
 		defer cancel()
-		log.Printf("soak: %d tracks, %d admins, %s", len(st.Tracks), c.Admins, c.Duration)
+		log.Printf("soak: %d tracks, %d admins, %s", len(st.Tracks), c.Admins, c.Duration.D())
 		soak(soakCtx, c, st)
 	}
 

--- a/backend/cmd/loadtest/main.go
+++ b/backend/cmd/loadtest/main.go
@@ -1,0 +1,660 @@
+// Command loadtest drives a synthetic camp against a running server to check that
+// the infrastructure holds up: it bootstraps a camp (corners, tracks, groups,
+// approved facilitator devices), then runs a soak where each track holds an SSE
+// connection and periodically starts/ends visits and sends chat messages while
+// admins hold SSE connections and poll the live summary.
+//
+// Nothing here is camp-domain logic — it only speaks the public REST API — so it
+// lives as a throwaway ops tool, stdlib only.
+//
+//	cd backend
+//	cp cmd/loadtest/loadtest.example.yaml cmd/loadtest/loadtest.yaml   # fill in adminPassword
+//	go run ./cmd/loadtest -config cmd/loadtest/loadtest.yaml
+//
+// Re-run just the soak against an existing bootstrap with -phases soak (reads
+// stateFile). Tear the camp down afterwards with -phases teardown.
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ── config ──────────────────────────────────────────────────────────────────
+
+func (c config) D(key string, def time.Duration) time.Duration {
+	v, ok := c.raw[key]
+	if !ok || v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		log.Fatalf("config %s: %v", key, err)
+	}
+	return d
+}
+
+func (c config) S(key, def string) string {
+	if v, ok := c.raw[key]; ok && v != "" {
+		return v
+	}
+	return def
+}
+
+func (c config) I(key string, def int) int {
+	v, ok := c.raw[key]
+	if !ok || v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		log.Fatalf("config %s: %v", key, err)
+	}
+	return n
+}
+
+// config is the flat key/value config file. The format is a deliberately tiny
+// YAML subset — one `key: value` per line, `#` comments, `key: [a, b]` lists —
+// so no YAML dependency is needed for ~a dozen scalars.
+type config struct {
+	raw map[string]string
+
+	Base            string
+	AdminID         string
+	AdminPW         string
+	Corners         int
+	TracksPerCorner int
+	Groups          int
+	Admins          int
+	VisitEvery      time.Duration
+	ChatEvery       time.Duration
+	AdminPoll       time.Duration
+	Duration        time.Duration
+	CampName        string
+	StateFile       string
+	Phases          []string
+}
+
+func loadConfig() config {
+	path := flag.String("config", "loadtest.yaml", "path to config file")
+	phasesOverride := flag.String("phases", "", "comma list overriding config phases (bootstrap,soak,teardown)")
+	flag.Parse()
+
+	b, err := os.ReadFile(*path)
+	if err != nil {
+		log.Fatalf("read config %s: %v", *path, err)
+	}
+	c := config{raw: map[string]string{}}
+	for _, line := range strings.Split(string(b), "\n") {
+		if i := strings.IndexByte(line, '#'); i >= 0 {
+			line = line[:i]
+		}
+		k, v, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		c.raw[strings.TrimSpace(k)] = strings.Trim(strings.TrimSpace(v), `"'`)
+	}
+
+	c.Base = c.S("base", "http://localhost:8080/api/v1")
+	c.AdminID = c.S("adminId", "admin")
+	c.AdminPW = c.S("adminPassword", "")
+	c.Corners = c.I("corners", 10)
+	c.TracksPerCorner = c.I("tracksPerCorner", 1)
+	c.Groups = c.I("groups", 25)
+	c.Admins = c.I("admins", 3)
+	c.VisitEvery = c.D("visitEvery", 3*time.Minute)
+	c.ChatEvery = c.D("chatEvery", 20*time.Second)
+	c.AdminPoll = c.D("adminPoll", 5*time.Second)
+	c.Duration = c.D("duration", 30*time.Minute)
+	c.StateFile = c.S("stateFile", "loadtest-state.json")
+
+	phases := c.S("phases", "bootstrap, soak, teardown")
+	if *phasesOverride != "" {
+		phases = *phasesOverride
+	}
+	for _, p := range strings.Split(strings.Trim(phases, "[]"), ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			c.Phases = append(c.Phases, p)
+		}
+	}
+
+	c.CampName = c.S("campName", fmt.Sprintf("loadtest-%d", time.Now().Unix()))
+	return c
+}
+
+// ── state persisted between phases ──────────────────────────────────────────
+
+type state struct {
+	Base       string   `json:"base"`
+	AdminToken string   `json:"adminToken"`
+	CampID     string   `json:"campId"`
+	RegCode    string   `json:"registrationCode"`
+	GroupIDs   []string `json:"groupIds"`
+	Tracks     []track  `json:"tracks"`
+}
+
+type track struct {
+	ID       string `json:"id"`
+	CornerID string `json:"cornerId"`
+	Token    string `json:"token"`
+}
+
+// ── HTTP ────────────────────────────────────────────────────────────────────
+
+// api is the short-timeout client for ordinary requests. SSE uses its own
+// no-timeout client (see streamSSE).
+var api = &http.Client{Timeout: 15 * time.Second}
+
+type apiError struct {
+	status int
+	body   string
+}
+
+func (e apiError) Error() string { return fmt.Sprintf("http %d: %s", e.status, e.body) }
+
+// call sends a JSON request and unmarshals a 2xx JSON body into out (out may be nil).
+// token, when set, goes in Authorization: Bearer unless it looks like a device token
+// header is needed — callers pass deviceHdr for that.
+func call(ctx context.Context, method, url, token string, body, out any, extra map[string]string) error {
+	var rdr io.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		rdr = strings.NewReader(string(b))
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	for k, v := range extra {
+		req.Header.Set(k, v)
+	}
+	resp, err := api.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode/100 != 2 {
+		return apiError{resp.StatusCode, string(raw)}
+	}
+	if out != nil {
+		return json.Unmarshal(raw, out)
+	}
+	return nil
+}
+
+// ── metrics ─────────────────────────────────────────────────────────────────
+
+type metric struct {
+	mu    sync.Mutex
+	durs  []time.Duration
+	codes map[int]int
+	errs  int
+}
+
+func (m *metric) observe(d time.Duration, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.durs = append(m.durs, d)
+	if err != nil {
+		m.errs++
+		if ae, ok := err.(apiError); ok {
+			m.codes[ae.status]++
+		} else {
+			m.codes[0]++ // transport error
+		}
+		return
+	}
+	m.codes[200]++
+}
+
+func (m *metric) snapshot() (n int, p50, p95, p99 time.Duration, codes map[int]int, errs int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d := append([]time.Duration(nil), m.durs...)
+	sort.Slice(d, func(i, j int) bool { return d[i] < d[j] })
+	pick := func(p float64) time.Duration {
+		if len(d) == 0 {
+			return 0
+		}
+		return d[int(float64(len(d)-1)*p)]
+	}
+	cp := map[int]int{}
+	for k, v := range m.codes {
+		cp[k] = v
+	}
+	return len(d), pick(0.50), pick(0.95), pick(0.99), cp, m.errs
+}
+
+var (
+	metricsMu sync.Mutex
+	metrics   = map[string]*metric{}
+)
+
+func mget(label string) *metric {
+	metricsMu.Lock()
+	defer metricsMu.Unlock()
+	m := metrics[label]
+	if m == nil {
+		m = &metric{codes: map[int]int{}}
+		metrics[label] = m
+	}
+	return m
+}
+
+// timed runs fn, records its latency + outcome under label.
+func timed(label string, fn func() error) error {
+	start := time.Now()
+	err := fn()
+	mget(label).observe(time.Since(start), err)
+	return err
+}
+
+// SSE connection accounting.
+var (
+	sseMu          sync.Mutex
+	sseConnected   = map[string]int{} // label -> currently open
+	sseDisconnects = map[string]int{} // label -> total drops (excluding ctx cancel)
+	sseEvents      = map[string]int{} // label -> data: lines seen
+)
+
+func sseInc(label string, key map[string]int, d int) {
+	sseMu.Lock()
+	key[label] += d
+	sseMu.Unlock()
+}
+
+func printReport(elapsed time.Duration) {
+	fmt.Printf("\n─── loadtest report @ %s ───\n", elapsed.Round(time.Second))
+	labels := make([]string, 0, len(metrics))
+	metricsMu.Lock()
+	for l := range metrics {
+		labels = append(labels, l)
+	}
+	metricsMu.Unlock()
+	sort.Strings(labels)
+	for _, l := range labels {
+		n, p50, p95, p99, codes, errs := mget(l).snapshot()
+		fmt.Printf("%-16s n=%-5d p50=%-8v p95=%-8v p99=%-8v errs=%-3d codes=%v\n",
+			l, n, p50.Round(time.Millisecond), p95.Round(time.Millisecond), p99.Round(time.Millisecond), errs, codes)
+	}
+	sseMu.Lock()
+	defer sseMu.Unlock()
+	fmt.Println("SSE:")
+	for l := range sseEvents {
+		fmt.Printf("  %-16s open=%d disconnects=%d events=%d\n", l, sseConnected[l], sseDisconnects[l], sseEvents[l])
+	}
+	fmt.Println("(server-side: watch for 'SSE subscriber buffer full' WARN and pgx pool saturation)")
+}
+
+// ── bootstrap ───────────────────────────────────────────────────────────────
+
+func bootstrap(ctx context.Context, c config) (state, error) {
+	st := state{Base: c.Base}
+
+	var login struct {
+		AccessToken string `json:"accessToken"`
+	}
+	if err := call(ctx, "POST", c.Base+"/auth/admin/login", "",
+		map[string]string{"id": c.AdminID, "password": c.AdminPW}, &login, nil); err != nil {
+		return st, fmt.Errorf("admin login: %w", err)
+	}
+	st.AdminToken = login.AccessToken
+	adm := func(method, path string, body, out any) error {
+		return call(ctx, method, c.Base+path, st.AdminToken, body, out, nil)
+	}
+
+	var camp struct {
+		ID               string `json:"id"`
+		RegistrationCode string `json:"registrationCode"`
+	}
+	now := time.Now().UTC()
+	if err := adm("POST", "/camps", map[string]any{
+		"name":    c.CampName,
+		"startAt": now.Add(-time.Hour).Format(time.RFC3339),
+		"endAt":   now.Add(7 * 24 * time.Hour).Format(time.RFC3339),
+	}, &camp); err != nil {
+		return st, fmt.Errorf("create camp: %w", err)
+	}
+	st.CampID, st.RegCode = camp.ID, camp.RegistrationCode
+	log.Printf("camp %s (%s) reg=%s", c.CampName, st.CampID, st.RegCode)
+
+	for i := 0; i < c.Corners; i++ {
+		var corner struct {
+			ID string `json:"id"`
+		}
+		if err := adm("POST", "/corners", map[string]any{
+			"campId": st.CampID, "name": fmt.Sprintf("corner-%02d", i+1), "targetMinutes": 10,
+		}, &corner); err != nil {
+			return st, fmt.Errorf("create corner %d: %w", i, err)
+		}
+		var created []struct {
+			Track track `json:"track"`
+		}
+		if err := adm("POST", "/tracks", map[string]any{
+			"campId": st.CampID, "cornerId": corner.ID, "count": c.TracksPerCorner,
+		}, &created); err != nil {
+			return st, fmt.Errorf("create tracks for corner %d: %w", i, err)
+		}
+		for _, t := range created {
+			st.Tracks = append(st.Tracks, track{ID: t.Track.ID, CornerID: corner.ID})
+		}
+	}
+	log.Printf("%d corners, %d tracks", c.Corners, len(st.Tracks))
+
+	if err := adm("POST", "/camps/"+st.CampID+"/start", nil, nil); err != nil {
+		return st, fmt.Errorf("start camp: %w", err)
+	}
+
+	var badges []struct {
+		ID string `json:"id"`
+	}
+	if err := adm("POST", "/badges/bulk-generate", map[string]any{"count": c.Groups}, &badges); err != nil {
+		return st, fmt.Errorf("bulk-generate badges: %w", err)
+	}
+	for i, b := range badges {
+		var grp struct {
+			ID string `json:"id"`
+		}
+		if err := adm("POST", "/badges/"+b.ID+"/register", map[string]any{
+			"campId": st.CampID, "groupName": fmt.Sprintf("group-%02d", i+1),
+		}, &grp); err != nil {
+			return st, fmt.Errorf("register badge %d: %w", i, err)
+		}
+		st.GroupIDs = append(st.GroupIDs, grp.ID)
+	}
+	log.Printf("%d groups", len(st.GroupIDs))
+
+	// One approved facilitator device per track, then track login for its PIN.
+	for i := range st.Tracks {
+		var dev struct {
+			ID          string `json:"id"`
+			DeviceToken string `json:"deviceToken"`
+		}
+		if err := call(ctx, "POST", c.Base+"/device-registrations", "", map[string]any{
+			"registrationCode": st.RegCode,
+			"deviceName":       fmt.Sprintf("%s-dev-%03d", c.CampName, i),
+			"deviceModel":      "loadtest",
+			"displayName":      fmt.Sprintf("lt-%03d", i),
+			"role":             "FACILITATOR",
+		}, &dev, nil); err != nil {
+			return st, fmt.Errorf("register device %d: %w", i, err)
+		}
+		if err := adm("POST", "/camps/"+st.CampID+"/device-registrations/"+dev.ID+"/approve", nil, nil); err != nil {
+			return st, fmt.Errorf("approve device %d: %w", i, err)
+		}
+		var tl struct {
+			TrackToken string `json:"trackToken"`
+			Track      struct {
+				ID string `json:"id"`
+			} `json:"track"`
+		}
+		// PIN: /tracks/{id}/export returns {track:{id},pin}. Devices are approved in
+		// track order, but PINs aren't ordered — fetch this track's PIN explicitly.
+		var exp struct {
+			PIN string `json:"pin"`
+		}
+		if err := adm("GET", "/tracks/"+st.Tracks[i].ID+"/export", nil, &exp); err != nil {
+			return st, fmt.Errorf("export track %d: %w", i, err)
+		}
+		if err := call(ctx, "POST", c.Base+"/auth/track/login", "",
+			map[string]string{"pin": exp.PIN}, &tl,
+			map[string]string{"X-Device-Token": dev.DeviceToken}); err != nil {
+			return st, fmt.Errorf("track login %d: %w", i, err)
+		}
+		st.Tracks[i].Token = tl.TrackToken
+	}
+	log.Printf("%d facilitator devices approved + logged in", len(st.Tracks))
+	return st, nil
+}
+
+// ── soak ────────────────────────────────────────────────────────────────────
+
+// visitPool hands out (group, track-corner) pairs that haven't been used yet.
+// A group can visit each corner once; once a corner's groups are exhausted the
+// track's visit cycles are skipped (bump -groups if that starts early).
+type visitPool struct {
+	mu   sync.Mutex
+	used map[string]map[string]bool // cornerID -> groupID -> done
+	all  []string
+}
+
+func newVisitPool(groups []string) *visitPool {
+	return &visitPool{used: map[string]map[string]bool{}, all: groups}
+}
+
+func (p *visitPool) take(cornerID string) (string, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	seen := p.used[cornerID]
+	if seen == nil {
+		seen = map[string]bool{}
+		p.used[cornerID] = seen
+	}
+	for _, g := range rand.Perm(len(p.all)) {
+		if !seen[p.all[g]] {
+			seen[p.all[g]] = true
+			return p.all[g], true
+		}
+	}
+	return "", false
+}
+
+func soak(ctx context.Context, c config, st state) {
+	pool := newVisitPool(st.GroupIDs)
+	var wg sync.WaitGroup
+
+	for _, t := range st.Tracks {
+		t := t
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runTrack(ctx, c, st, t, pool)
+		}()
+	}
+	for i := 0; i < c.Admins; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			runAdmin(ctx, c, st)
+		}()
+	}
+
+	// Periodic progress report.
+	start := time.Now()
+	tick := time.NewTicker(30 * time.Second)
+	defer tick.Stop()
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-tick.C:
+				printReport(time.Since(start))
+			}
+		}
+	}()
+
+	wg.Wait()
+	printReport(time.Since(start))
+}
+
+func runTrack(ctx context.Context, c config, st state, t track, pool *visitPool) {
+	go streamSSE(ctx, c.Base+"/events/track/"+t.ID, t.Token, "track_sse")
+
+	visitT := time.NewTicker(jitter(c.VisitEvery))
+	chatT := time.NewTicker(jitter(c.ChatEvery))
+	defer visitT.Stop()
+	defer chatT.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-visitT.C:
+			gid, ok := pool.take(t.CornerID)
+			if !ok {
+				mget("visit_skip").observe(0, nil)
+				continue
+			}
+			err := timed("visit_start", func() error {
+				return call(ctx, "POST", c.Base+"/tracks/"+t.ID+"/visits/start", t.Token,
+					map[string]string{"groupId": gid, "method": "MANUAL"}, nil, nil)
+			})
+			if err != nil {
+				continue
+			}
+			time.Sleep(2 * time.Second) // group is "in the corner" briefly
+			timed("visit_end", func() error {
+				return call(ctx, "POST", c.Base+"/tracks/"+t.ID+"/visits/current/end", t.Token, nil, nil, nil)
+			})
+		case <-chatT.C:
+			timed("chat_send", func() error {
+				return call(ctx, "POST", c.Base+"/tracks/"+t.ID+"/messages", t.Token,
+					map[string]string{"content": "loadtest " + time.Now().Format("15:04:05")}, nil, nil)
+			})
+		}
+	}
+}
+
+func runAdmin(ctx context.Context, c config, st state) {
+	go streamSSE(ctx, c.Base+"/camps/"+st.CampID+"/events/admin", st.AdminToken, "admin_sse")
+
+	poll := time.NewTicker(jitter(c.AdminPoll))
+	defer poll.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-poll.C:
+			timed("admin_poll", func() error {
+				return call(ctx, "GET", c.Base+"/camps/"+st.CampID+"/reports/live-summary", st.AdminToken, nil, nil, nil)
+			})
+		}
+	}
+}
+
+// streamSSE holds one SSE connection open, counting events and reconnecting on
+// drop until ctx is cancelled. A drop that isn't ctx cancellation is what a
+// "buffer full, disconnecting" server-side eviction looks like from the client.
+func streamSSE(ctx context.Context, url, token, label string) {
+	client := &http.Client{} // no timeout: long-lived stream
+	for ctx.Err() == nil {
+		func() {
+			req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Accept", "text/event-stream")
+			resp, err := client.Do(req)
+			if err != nil {
+				sseInc(label, sseDisconnects, 1)
+				return
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != 200 {
+				sseInc(label, sseDisconnects, 1)
+				time.Sleep(time.Second)
+				return
+			}
+			sseInc(label, sseConnected, 1)
+			defer sseInc(label, sseConnected, -1)
+			sc := bufio.NewScanner(resp.Body)
+			sc.Buffer(make([]byte, 64*1024), 1<<20)
+			for sc.Scan() {
+				if strings.HasPrefix(sc.Text(), "data:") {
+					sseInc(label, sseEvents, 1)
+				}
+			}
+			if ctx.Err() == nil {
+				sseInc(label, sseDisconnects, 1)
+			}
+		}()
+		if ctx.Err() == nil {
+			time.Sleep(time.Second) // reconnect backoff
+		}
+	}
+}
+
+// jitter returns d ±20% so tickers don't align into thundering herds.
+func jitter(d time.Duration) time.Duration {
+	return d - d/5 + time.Duration(rand.Int63n(int64(2*d/5+1)))
+}
+
+// ── teardown ────────────────────────────────────────────────────────────────
+
+func teardown(ctx context.Context, st state) error {
+	return call(ctx, "POST", st.Base+"/camps/"+st.CampID+"/end", st.AdminToken, nil, nil, nil)
+}
+
+// ── main ────────────────────────────────────────────────────────────────────
+
+func main() {
+	log.SetFlags(log.Ltime)
+	c := loadConfig()
+	if c.AdminPW == "" {
+		log.Fatal("adminPassword missing in config")
+	}
+	phases := map[string]bool{}
+	for _, p := range c.Phases {
+		phases[strings.TrimSpace(p)] = true
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer stop()
+
+	var st state
+	if phases["bootstrap"] {
+		var err error
+		st, err = bootstrap(ctx, c)
+		if err != nil {
+			log.Fatalf("bootstrap: %v", err)
+		}
+		b, _ := json.MarshalIndent(st, "", "  ")
+		if err := os.WriteFile(c.StateFile, b, 0o644); err != nil {
+			log.Fatalf("write state: %v", err)
+		}
+		log.Printf("bootstrap done, state → %s", c.StateFile)
+	} else {
+		b, err := os.ReadFile(c.StateFile)
+		if err != nil {
+			log.Fatalf("read state (%s): %v", c.StateFile, err)
+		}
+		if err := json.Unmarshal(b, &st); err != nil {
+			log.Fatalf("parse state: %v", err)
+		}
+	}
+
+	if phases["soak"] {
+		soakCtx, cancel := context.WithTimeout(ctx, c.Duration)
+		defer cancel()
+		log.Printf("soak: %d tracks, %d admins, %s", len(st.Tracks), c.Admins, c.Duration)
+		soak(soakCtx, c, st)
+	}
+
+	if phases["teardown"] {
+		if err := teardown(context.Background(), st); err != nil {
+			log.Fatalf("teardown: %v", err)
+		}
+		log.Printf("camp %s ended", st.CampID)
+	}
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.15.4
 	golang.org/x/crypto v0.54.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -16,9 +17,11 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/labstack/gommon v0.5.0 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect
 	github.com/mattn/go-isatty v0.0.22 // indirect
+	github.com/rogpeppe/go-internal v1.16.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	golang.org/x/net v0.56.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -6,6 +6,7 @@ github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -43,6 +44,10 @@ github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/labstack/echo/v4 v4.15.4 h1:DL45vVYa+BWE+XuW+zZNd9H0YEdZ80UAWJGcTVW4EVs=
 github.com/labstack/echo/v4 v4.15.4/go.mod h1:CuMetKIRwsuO/qlAgMq+KTAalwGoB/h4tC+yPdrTj1g=
 github.com/labstack/gommon v0.5.0 h1:6VSQ2NOzsnEJ5W6+84E0RbcaDDmgB6NIAzWCczTEe6c=
@@ -68,6 +73,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rogpeppe/go-internal v1.16.0 h1:O9DK+vNMDVGLr2BeZqmpLeMjiMNkuXfcqntWbZV6S5g=
+github.com/rogpeppe/go-internal v1.16.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -98,6 +105,8 @@ golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.40.0 h1:Ub2Z6/xjgF1WrYQz2nuITOEegKFtiIy+rieRJ5lHZKs=
 golang.org/x/text v0.40.0/go.mod h1:hpnzDAfGV753zIKo+wk3u1bVKCGPbrnF7+7LBF/UHVY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/backend/internal/infrastructure/web/logger_middleware.go
+++ b/backend/internal/infrastructure/web/logger_middleware.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
 
 	"cornermon/backend/internal/errs"
@@ -55,13 +56,26 @@ func Logger() echo.MiddlewareFunc {
 			status := c.Response().Status
 			duration := time.Since(start)
 
+			// SSE 핸들러(setSSEHeaders)는 next(c)가 클라이언트 접속 종료까지 블로킹되므로,
+			// 이 duration은 응답 지연이 아니라 커넥션 유지 시간이다. duration_ms로 같이
+			// 찍으면 "느린 요청" 필터/알림이 SSE 커넥션마다 오탐한다. Content-Type으로
+			// 판별하는 이유: 경로 문자열(`/events/`)은 나중에 SSE 아닌 리소스가 같은
+			// 이름으로 생겨도 걸릴 수 있지만, Content-Type은 실제 SSE 핸들러만 세팅하는
+			// 응답의 실제 성격이라 안전하다.
+			msg := "Request completed"
+			durationField := slog.Float64("duration_ms", durationMs(duration))
+			if strings.HasPrefix(c.Response().Header().Get(echo.HeaderContentType), "text/event-stream") {
+				msg = "SSE connection closed"
+				durationField = slog.Float64("connection_duration_ms", durationMs(duration))
+			}
+
 			// 정상 처리 완료 시 INFO 레벨로 단 1회 로깅
 			// trace_id는 errs.SlogWrappedHandler가 ctx 기반으로 자동 1회 주입하므로 여기서는 찍지 않는다.
-			slog.InfoContext(ctx, "Request completed",
+			slog.InfoContext(ctx, msg,
 				slog.String("method", c.Request().Method),
 				slog.String("path", c.Request().URL.Path),
 				slog.Int("status", status),
-				slog.Float64("duration_ms", durationMs(duration)),
+				durationField,
 				slog.String("ip", c.RealIP()),
 				slog.String("user_agent", c.Request().UserAgent()),
 			)

--- a/backend/internal/infrastructure/web/logger_middleware_test.go
+++ b/backend/internal/infrastructure/web/logger_middleware_test.go
@@ -123,3 +123,39 @@ func TestLoggerShouldIncludeUserAgentAndDurationMsWhenRequestSucceeds(t *testing
 		t.Errorf("expected duration_ms to be a JSON number, got %v (%T)", parsed["duration_ms"], parsed["duration_ms"])
 	}
 }
+
+func TestLoggerShouldLogConnectionDurationMsWhenResponseIsSSE(t *testing.T) {
+	// arrange — SSE 핸들러는 next(c)가 클라이언트 접속 종료까지 블로킹되므로, 이 값을
+	// duration_ms로 찍으면 "느린 요청" 필터가 매 SSE 커넥션에 오탐한다(#분석 세션 참고).
+	// 경로 문자열이 아니라 실제 핸들러가 세팅하는 Content-Type으로 판별해야
+	// 나중에 "events"라는 이름의 SSE 아닌 리소스가 생겨도 오분류되지 않는다.
+	buf := withCapturedLogger(t)
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/camps/1/events/admin", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	next := func(c echo.Context) error {
+		c.Response().Header().Set(echo.HeaderContentType, "text/event-stream")
+		return c.NoContent(http.StatusOK)
+	}
+
+	// act
+	if err := web.Logger()(next)(c); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	// assert
+	var parsed map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("expected valid JSON log line, got error: %v, line: %s", err, buf.String())
+	}
+	if parsed["msg"] != "SSE connection closed" {
+		t.Errorf("expected msg 'SSE connection closed', got %v", parsed["msg"])
+	}
+	if _, ok := parsed["connection_duration_ms"].(float64); !ok {
+		t.Errorf("expected connection_duration_ms to be a JSON number, got %v (%T)", parsed["connection_duration_ms"], parsed["connection_duration_ms"])
+	}
+	if _, ok := parsed["duration_ms"]; ok {
+		t.Errorf("expected duration_ms to be absent for SSE responses, got %v", parsed["duration_ms"])
+	}
+}


### PR DESCRIPTION
## 변경 사항

### 1. loadtest 하네스 (`backend/cmd/loadtest/`) — 신규
공개 REST API만으로 동작하는 stdlib(+yaml.v3) ops 도구. 3단계:
- **bootstrap**: admin 로그인 → 캠프 생성 → 코너/트랙 → start → 배지/조 → 트랙별 기기 등록+승인+PIN 로그인 → 상태를 `loadtest-state.json`에 저장
- **soak**: 트랙별 goroutine(SSE 유지 + visit start/end + 다이렉트 채팅 + 채팅함 읽음), admin goroutine(SSE + live-summary 폴링 + 공지 발송 1명), 30초마다 리포트
- **teardown**: `POST /camps/:id/end`

규모/주기는 전부 YAML(`-config`), phase는 `-phases`로 일회성 오버라이드. 예시는 `loadtest.example.yaml`.

리포트: 요청종류별 n/p50/p95/p99/에러/HTTP코드 + SSE 연결수·끊김수·이벤트수.

### 2. SSE 커넥션 유지시간이 `duration_ms`로 잡히던 로깅 노이즈 수정 (`logger_middleware.go`)
`/events/*` 응답은 `next(c)`가 클라이언트 접속 종료까지 블로킹되므로 `duration_ms`에 연결 유지시간(수십 초~분)이 그대로 찍혀 "느린 요청" 필터/알림이 SSE마다 오탐함. 실제 SSE 핸들러가 세팅하는 응답 `Content-Type: text/event-stream`으로 판별(경로 문자열 아님 → 나중에 "events" 이름의 SSE 아닌 리소스가 생겨도 안전)해서, 해당 응답만 `"SSE connection closed"` + `connection_duration_ms` 필드로 분리.

> 이 커밋(3c4df5e)은 loadtest 도구와 무관한 프로덕션 미들웨어 수정이라 논리적으로 분리 가능 — 리뷰어가 원하면 별도 PR로 빼기 쉬움.

## 종료 조건 (검증)

- `go build ./... && go vet ./... && go test ./...` 전부 통과, `gofmt -l` 클린
- SSE 로깅 분기 테스트 추가 (`TestLoggerShouldLogConnectionDurationMsWhenResponseIsSSE`)
- 데모 서버(1vCPU, 4컨테이너 공유) 대상 **30분 소크, 30트랙 / 3admin** 실측:

```
─── loadtest report @ 30m0s ───
admin_poll       n=1138  p50=113ms  p95=167ms  p99=527ms  errs=0
broadcast_send   n=5     p50=104ms  p95=110ms  p99=110ms  errs=0
chat_send        n=1670  p50=99ms   p95=159ms  p99=711ms  errs=0
track_read       n=460   p50=102ms  p95=191ms  p99=592ms  errs=0
visit_end        n=105   p50=99ms   p95=202ms  p99=621ms  errs=0
visit_start      n=127   p50=100ms  p95=153ms  p99=284ms  errs=0
SSE: track_sse open=0 disconnects=0 events=18750 / admin_sse disconnects=0 events=7812
```

- **에러 0 / SSE 끊김 0 / `SSE subscriber buffer full` 로그 0 / 5xx 0**
- p99 400~700ms는 애플리케이션 병목이 아니라 데모 박스 스펙(물리 1vCPU에 prod/demo 4컨테이너 공유) 때문 — 읽기/쓰기 무관 엔드포인트가 동시에 같은 곡선으로 올라갔다 평평해지는 CPU 경합 패턴. 실서비스 규모(트랙 10)에선 이번 부하의 절반 이하.

🤖 Generated with [Claude Code](https://claude.com/claude-code)